### PR TITLE
feat: add ElevenLabs v3 TTS support

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1289,6 +1289,9 @@ function resolveElevenLabsTtsConfig(selectedModel: string): { modelId: string; v
   if (modelId === 'turbo_v2_5' || modelId === 'turbo-v2-5') {
     modelId = 'eleven_turbo_v2_5';
   }
+  if (modelId === 'v3') {
+    modelId = 'eleven_v3';
+  }
   if (!modelId) {
     modelId = 'eleven_multilingual_v2';
   }

--- a/src/renderer/src/settings/AITab.tsx
+++ b/src/renderer/src/settings/AITab.tsx
@@ -68,6 +68,7 @@ const SPEAK_TTS_OPTIONS = [
   { id: 'elevenlabs-multilingual-v2', label: 'ElevenLabs Multilingual v2' },
   { id: 'elevenlabs-flash-v2-5', label: 'ElevenLabs Flash v2.5' },
   { id: 'elevenlabs-turbo-v2-5', label: 'ElevenLabs Turbo v2.5' },
+  { id: 'elevenlabs-v3', label: 'ElevenLabs v3 (Alpha)' },
 ];
 
 type EdgeVoiceGender = 'female' | 'male';


### PR DESCRIPTION
## Summary

Add support for ElevenLabs v3 (Alpha) text-to-speech model.

<img width="1518" height="970" alt="image" src="https://github.com/user-attachments/assets/a62598a9-a575-46ef-b484-141c0cfca599" />

## Changes

- Added `elevenlabs-v3` option to TTS model selection in Settings → AI → SuperCmd Read
- Updated model resolution logic to map `v3` → `eleven_v3` for API calls

## Features

- New ElevenLabs v3 model with enhanced expressiveness and emotional control
- Works with existing voice ID selection system
- Uses same ElevenLabs API endpoint and authentication
- Supports all existing ElevenLabs voices

Closes #3