### PR TITLE
fix(extensions): implement Add Alias for commands

### DIFF
--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -45,6 +45,7 @@ export interface AppSettings {
   hasSeenWhisperOnboarding: boolean;
   ai: AISettings;
   commandMetadata?: Record<string, { subtitle?: string }>;
+  commandAliases?: Record<string, string>;
   debugMode: boolean;
 }
 
@@ -145,6 +146,7 @@ export function loadSettings(): AppSettings {
         parsed.hasSeenWhisperOnboarding ?? false,
       ai: { ...DEFAULT_AI_SETTINGS, ...parsed.ai },
       commandMetadata: parsed.commandMetadata ?? {},
+      commandAliases: parsed.commandAliases ?? {},
       debugMode: parsed.debugMode ?? DEFAULT_SETTINGS.debugMode,
     };
   } catch {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -103,6 +103,7 @@ const App: React.FC = () => {
     hideMenuBarExtension,
     upsertMenuBarExtension,
   } = useMenuBarExtensions();
+  const [commandAliases, setCommandAliases] = useState<Record<string, string>>({});
   const [selectedTextSnapshot, setSelectedTextSnapshot] = useState('');
   const [memoryFeedback, setMemoryFeedback] = useState<MemoryFeedback>(null);
   const [memoryActionLoading, setMemoryActionLoading] = useState(false);
@@ -195,6 +196,7 @@ const App: React.FC = () => {
       const shortcutStatus = await window.electron.getGlobalShortcutStatus();
       setPinnedCommands(settings.pinnedCommands || []);
       setRecentCommands(settings.recentCommands || []);
+      setCommandAliases(settings.commandAliases || {});
       setLauncherShortcut(settings.globalShortcut || 'Alt+Space');
       const speakToggleHotkey = settings.commandHotkeys?.['system-supercmd-whisper-speak-toggle'] || 'Fn';
       setWhisperSpeakToggleLabel(formatShortcutLabel(speakToggleHotkey));
@@ -717,8 +719,8 @@ const App: React.FC = () => {
   const calcOffset = calcResult ? 1 : 0;
   const contextualCommands = commands;
   const filteredCommands = useMemo(
-    () => filterCommands(contextualCommands, searchQuery),
-    [contextualCommands, searchQuery]
+    () => filterCommands(contextualCommands, searchQuery, commandAliases),
+    [contextualCommands, searchQuery, commandAliases]
   );
 
   // When calculator is showing but no commands match, show unfiltered list below

--- a/src/renderer/src/utils/command-helpers.tsx
+++ b/src/renderer/src/utils/command-helpers.tsx
@@ -39,7 +39,7 @@ export type ReadVoiceOption = {
 /**
  * Filter and sort commands based on search query
  */
-export function filterCommands(commands: CommandInfo[], query: string): CommandInfo[] {
+export function filterCommands(commands: CommandInfo[], query: string, aliases?: Record<string, string>): CommandInfo[] {
   if (!query.trim()) {
     return commands;
   }
@@ -51,20 +51,33 @@ export function filterCommands(commands: CommandInfo[], query: string): CommandI
       const lowerTitle = cmd.title.toLowerCase();
       const lowerSubtitle = String(cmd.subtitle || '').toLowerCase();
       const keywords = cmd.keywords?.map((k) => k.toLowerCase()) || [];
+      const alias = (aliases?.[cmd.id] || '').toLowerCase();
 
       let score = 0;
 
-      // Exact match
-      if (lowerTitle === lowerQuery) {
+      // Alias exact match — highest priority (user explicitly set this shorthand)
+      if (alias && alias === lowerQuery) {
+        score = 250;
+      }
+      // Exact title match
+      else if (lowerTitle === lowerQuery) {
         score = 200;
       }
       // Title starts with query
       else if (lowerTitle.startsWith(lowerQuery)) {
         score = 100;
       }
+      // Alias starts with query
+      else if (alias && alias.startsWith(lowerQuery)) {
+        score = 90;
+      }
       // Title includes query
       else if (lowerTitle.includes(lowerQuery)) {
         score = 75;
+      }
+      // Alias includes query
+      else if (alias && alias.includes(lowerQuery)) {
+        score = 60;
       }
       // Keywords start with query
       else if (keywords.some((k) => k.startsWith(lowerQuery))) {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -153,6 +153,7 @@ export interface AppSettings {
   hasSeenWhisperOnboarding: boolean;
   ai: AISettings;
   commandMetadata?: Record<string, { subtitle?: string }>;
+  commandAliases?: Record<string, string>;
   debugMode: boolean;
 }
 


### PR DESCRIPTION
Closes #35

Clicking **Add Alias** in the Extensions settings now opens an inline input. Type a short alias, press Enter (or click away) to save. Clear the field and save to remove it.

Aliases are persisted in `settings.commandAliases` and wired into the launcher search — an exact alias match ranks higher than any title match.