### PR TITLE
feat: also grab XPC-type packages to show in search results

### DIFF
--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -620,7 +620,9 @@ async function discoverApplications(): Promise<CommandInfo[]> {
         if (info) {
           const packageType = String(info.CFBundlePackageType || '').trim();
           const isFinder = appPath === finderPath;
-          if (packageType && packageType !== 'APPL' && !isFinder) return null;
+          const isAllowedType =
+            !packageType || packageType === 'APPL' || packageType === 'XPC!';
+          if (!isAllowedType && !isFinder) return null;
           if (info.LSUIElement === true) return null;
           if (info.NSUIElement === true) return null;
           if (info.LSBackgroundOnly === true) return null;


### PR DESCRIPTION
## Summary

Broaden app discovery to include XPC-based bundles (e.g., Apple’s Passwords), while still excluding LSUIElement/NSUIElement/LSBackgroundOnly agents.

<img width="1772" height="1124" alt="image" src="https://github.com/user-attachments/assets/ec57168e-325b-4e3d-ab77-83c0b2fcbfc4" />

## Details

- [commands.ts:](https://github.com/SuperCmdLabs/SuperCmd/blob/main/src/main/commands.ts) allow CFBundlePackageType APPL, empty, or XPC!; continue filtering background agents. This surfaces Passwords.app and similar UI-bearing XPC bundles.

Closes #55 