### PR TITLE
fix: Fn key hotkey support (#27)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1975,6 +1975,10 @@ function startFnSpeakToggleWatcher(): void {
       try {
         const payload = JSON.parse(trimmed);
         if (payload?.pressed) {
+          // Don't fire while the settings window is focused — the user is
+          // likely recording a hotkey in HotkeyRecorder and the Fn keydown
+          // should not open whisper or trigger any command.
+          if (settingsWindow && !settingsWindow.isDestroyed() && settingsWindow.isFocused()) continue;
           const now = Date.now();
           if (now - fnSpeakToggleLastPressedAt < 180) continue;
           fnSpeakToggleLastPressedAt = now;


### PR DESCRIPTION
## Summary

Closes #27

- **F-keys (F1–F24) now bindable as hotkeys** — any command can use bare `F1`–`F24` accelerators; `Fn+F5` on Apple keyboards naturally sends `F5` which is now accepted
- **Fn key no longer fires whisper while recording** — the Fn hold-watcher skips command dispatch when the Settings window is focused, so typing into a HotkeyRecorder can't accidentally open whisper
- **Fn can be rebound or replaced** — HotkeyRecorder now debounces the `Fn` keydown (400 ms window): if a follow-up key arrives (e.g. `F5`), that key is recorded instead; if nothing follows, `Fn` itself is saved — giving users a chance to type their intended combo

## Changes

| File | Change |
|------|--------|
| `src/renderer/src/settings/HotkeyRecorder.tsx` | Debounce Fn key; show `Fn…` while waiting; clean up on Escape/blur |
| `src/main/main.ts` | Skip Fn watcher dispatch when `settingsWindow.isFocused()`; generalize Fn hotkey to any command (not only whisper) |

## Test plan

- [ ] Open Settings → Extensions, click a command's hotkey field, press `Fn+F5` → records `F5`
- [ ] Click hotkey field, press `F3` alone → records `F3`
- [ ] With whisper bound to `Fn`: open Settings → AI tab → click Start/Stop Speaking recorder → press `Fn` → whisper does **not** open
- [ ] In recorder, press `Fn` → shows `Fn…` → wait 400 ms → saves `Fn`
- [ ] In recorder, press `Fn` then quickly `F5` → saves `F5`
- [ ] In recorder, press `Fn` then `Escape` → cancels cleanly
- [ ] After remapping whisper to `F3` → pressing `F3` triggers whisper; `Fn` alone opens macOS emoji picker (expected OS default)