### PR TITLE
feat: UI Scale setting in Advanced tab

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -614,6 +614,10 @@ contextBridge.exposeInMainWorld('electron', {
     ipcRenderer.on('ollama-pull-error', (_event: any, data: any) => callback(data));
   },
 
+  // ─── Display ─────────────────────────────────────────────────────
+  updateUiScale: (scale: number): Promise<void> =>
+    ipcRenderer.invoke('update-ui-scale', scale),
+
   // ─── WindowManagement ────────────────────────────────────────────
   getActiveWindow: (): Promise<any> =>
     ipcRenderer.invoke('window-management-get-active-window'),

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -65,6 +65,7 @@ export interface AppSettings {
   commandMetadata?: Record<string, { subtitle?: string }>;
   debugMode: boolean;
   hyperKey: HyperKeySettings;
+  uiScale: number;
 }
 
 const DEFAULT_AI_SETTINGS: AISettings = {
@@ -114,6 +115,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     triggerKey: 'caps_lock',
     preserveOriginal: true,
   },
+  uiScale: 1.0,
 };
 
 let settingsCache: AppSettings | null = null;
@@ -184,6 +186,9 @@ export function loadSettings(): AppSettings {
       commandMetadata: parsed.commandMetadata ?? {},
       debugMode: parsed.debugMode ?? DEFAULT_SETTINGS.debugMode,
       hyperKey: { ...DEFAULT_SETTINGS.hyperKey, ...(parsed.hyperKey ?? {}) },
+      uiScale: typeof parsed.uiScale === 'number' && parsed.uiScale > 0
+        ? parsed.uiScale
+        : DEFAULT_SETTINGS.uiScale,
     };
   } catch {
     settingsCache = { ...DEFAULT_SETTINGS };

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -182,6 +182,7 @@ export interface AppSettings {
   commandMetadata?: Record<string, { subtitle?: string }>;
   debugMode: boolean;
   hyperKey: HyperKeySettings;
+  uiScale: number;
 }
 
 export interface CatalogEntry {
@@ -305,6 +306,7 @@ export interface ElectronAPI {
   updateHyperKeySettings: (settings: HyperKeySettings) => Promise<{ success: boolean }>;
   getHyperKeyStatus: () => Promise<{ running: boolean; error?: string }>;
   onHyperKeyStatus: (callback: (payload: { running: boolean; error?: string }) => void) => (() => void);
+  updateUiScale: (scale: number) => Promise<void>;
   getAllCommands: () => Promise<CommandInfo[]>;
   updateGlobalShortcut: (shortcut: string) => Promise<boolean>;
   setOpenAtLogin: (enabled: boolean) => Promise<boolean>;


### PR DESCRIPTION
## Summary

Closes #36

> **Note:** This PR targets `feat/hyper-key` (not `main`) since it builds on the Advanced tab introduced there. Once Hyper Key (#57) merges, this can be re-targeted to `main`.

Users running macOS "More Space" display mode often find SuperCmd's text too small compared to Raycast. This adds a **Display** section to Settings → Advanced with a UI scale picker.

Since SuperCmd is Electron/Chromium, `webContents.setZoomFactor()` scales everything uniformly — text, icons, borders, spacing — exactly like the browser zoom but persisted across restarts.

## Changes

| File | Change |
|------|--------|
| `src/main/settings-store.ts` | New `uiScale: number` field (default `1.0`) |
| `src/main/main.ts` | `update-ui-scale` IPC handler; zoom applied at `createWindow`, `openSettingsWindow`, `openExtensionStoreWindow` |
| `src/main/preload.ts` | `updateUiScale(scale)` bridge |
| `src/renderer/types/electron.d.ts` | `uiScale` on `AppSettings`; `updateUiScale` on `ElectronAPI` |
| `src/renderer/src/settings/AdvancedTab.tsx` | Display section with segmented scale picker added below Hyper Key |

## Scale options

80% · 90% · **100% (default)** · 110% · 125% · 150%

Changes apply instantly to all open windows and persist to `settings.json`.

## Test plan

- [ ] Settings → Advanced — "Display" section visible below Hyper Key
- [ ] Click 125% — launcher and settings window both scale up immediately, "Applied" flash shown
- [ ] Close and reopen SuperCmd — 125% zoom persists
- [ ] Click 100% — returns to normal
- [ ] No visual regressions at 100%