### PR TITLE
fix: devtool hotkey registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:native": "mkdir -p dist/native && swiftc -O -o dist/native/color-picker src/native/color-picker.swift -framework AppKit && swiftc -O -o dist/native/snippet-expander src/native/snippet-expander.swift -framework AppKit && swiftc -O -o dist/native/hotkey-hold-monitor src/native/hotkey-hold-monitor.swift -framework CoreGraphics -framework AppKit -framework Carbon && swiftc -O -o dist/native/speech-recognizer src/native/speech-recognizer.swift -framework Speech -framework AVFoundation && swiftc -O -o dist/native/microphone-access src/native/microphone-access.swift -framework AVFoundation && swiftc -O -o dist/native/input-monitoring-request src/native/input-monitoring-request.swift -framework CoreGraphics",
     "postinstall": "electron-builder install-app-deps",
     "start": "electron .",
-    "package": "npm run build && electron-builder"
+    "package": "cross-env NODE_ENV=production npm run build && electron-builder"
   },
   "license": "ISC",
   "devDependencies": {


### PR DESCRIPTION
## Summary
This PR updates the devtool hotkey behavior, only showing it if the app is running in development mode

It addresses #80 but instead of checking focus it will check for `NODE_ENV` env to determine whether to register the hotkey, this reduces code complexity + I don't think there is a need to view devtool in production mode