### PR TITLE
fix: resolve 3-key combo hotkey recording with Option/Alt modifier

### DIFF
--- a/src/renderer/src/settings/HotkeyRecorder.tsx
+++ b/src/renderer/src/settings/HotkeyRecorder.tsx
@@ -111,9 +111,9 @@ function keyEventToAccelerator(e: KeyboardLikeEvent): string | null {
   };
 
   const mappedKey =
+    mapCodeToAcceleratorToken(e.code as string) ||
     keyMap[key] ||
-    (key.length === 1 ? key.toUpperCase() : null) ||
-    mapCodeToAcceleratorToken(e.code) ||
+    (key.length === 1 && key !== ' ' && key !== '\u00A0' ? key.toUpperCase() : null) ||
     key;
 
   const allowWithoutModifier = /^F\d{1,2}$/i.test(mappedKey) || mappedKey === 'CapsLock' || mappedKey === 'Fn';
@@ -158,9 +158,9 @@ function mapKeyToAcceleratorToken(key: string): string | null {
 }
 
 function mapKeyboardEventToAcceleratorToken(e: KeyboardLikeEvent): string | null {
-  const byKey = mapKeyToAcceleratorToken(e.key);
-  if (byKey) return byKey;
-  return mapCodeToAcceleratorToken(e.code);
+  const byCode = mapCodeToAcceleratorToken(e.code as string);
+  if (byCode) return byCode;
+  return mapKeyToAcceleratorToken(e.key);
 }
 
 function formatShortcut(shortcut: string): string {


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where 3-key hotkey combinations involving the `Option` (`Alt`) modifier sequence (e.g. `Option + Command + Space`) failed to record and register properly in the settings window.

### Why is this necessary?
When pressing the `Option` key on macOS, the DOM fundamentally alters the character of the associated key sequence on `KeyboardEvent.key` (for example, generating a non-breaking space `\u00A0` instead of a literal `' '` for the Space key). Because [HotkeyRecorder](cci:1://file:///Users/roman/dev/SuperCmd/src/renderer/src/settings/HotkeyRecorder.tsx:169:0-386:2) relied heavily on mapping `e.key`, the resulting string combinations bypassed valid Electron accelerator representations.

### How was it fixed?
Updated the [HotkeyRecorder.tsx](cci:7://file:///Users/roman/dev/SuperCmd/src/renderer/src/settings/HotkeyRecorder.tsx:0:0-0:0) logic to strictly prioritize extracting tokens from the underlying physical `e.code` over the logical `e.key`. The mapping logic will now correctly identify the base key string (like `Space` or map physical keys) irrespective of whether an `Option` modifier translates its typable character in the DOM.

### Testing Notes
- Navigate to the hotkey settings and click to record a new shortcut.
- Press standard 2-key and single key shortcuts (e.g.,`Cmd + Space`).
- Press a 3-key sequence involving `Option` (e.g., `Option + Cmd + Space` or `Option + Shift + H`). 
- Verify the recorder successfully reads, renders, and persists the hotkey properly.
