### PR TITLE
fix: keep launcher on current desktop when opening via hotkey

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5991,10 +5991,22 @@ async function showWindow(options?: { systemCommandId?: string }): Promise<void>
     });
   }
 
+  // Avoid force-activating the whole app for normal launcher opens on macOS.
+  // When the window is already visible on every Space, app.focus({ steal: true })
+  // can make Mission Control jump back to the app's "home" desktop instead of
+  // presenting the launcher in the user's current Space.
+  if (launcherMode === 'onboarding') {
+    try { app.focus({ steal: true }); } catch {}
+  }
   try {
-    app.focus({ steal: true });
-  } catch {}
-  mainWindow.show();
+    if (!mainWindow.isVisible() && typeof (mainWindow as any).showInactive === 'function') {
+      (mainWindow as any).showInactive();
+    } else {
+      mainWindow.show();
+    }
+  } catch {
+    mainWindow.show();
+  }
   mainWindow.focus();
   mainWindow.moveTop();
   isVisible = true;
@@ -6004,7 +6016,11 @@ async function showWindow(options?: { systemCommandId?: string }): Promise<void>
     if (!mainWindow || mainWindow.isDestroyed()) return;
     if (mainWindow.isVisible()) return;
     try {
-      mainWindow.show();
+      if (typeof (mainWindow as any).showInactive === 'function') {
+        (mainWindow as any).showInactive();
+      } else {
+        mainWindow.show();
+      }
       mainWindow.focus();
       mainWindow.moveTop();
       isVisible = true;


### PR DESCRIPTION
## Summary
- stop force-activating SuperCmd during normal launcher hotkey opens on macOS
- use inactive window showing for the launcher so it stays on the current desktop instead of jumping back to Desktop 1
- keep the stronger activation behavior for onboarding, where it is still needed for permission/setup flows

## Why
Pressing the launcher hotkey could switch macOS back to Desktop 1 because the launcher window is visible on all workspaces and the show path always called `app.focus({ steal: true })`. Spotlight and Raycast do not force that desktop jump.

## Compatibility Impact
- preserves existing onboarding focus-stealing behavior
- changes only the normal launcher open path in `src/main/main.ts`
- does not modify Raycast API shims or extension runtime behavior

## Testing
- npm run build
- npm start
- verified locally on macOS by opening SuperCmd with `Command+Space` from a desktop other than Desktop 1 and confirming it stayed on the current desktop
