### PR TITLE
fix: keep macOS launcher on the current Space

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ SuperCmd is an Electron + React launcher that focuses on Raycast extension compa
 - **Memory-aware AI** support (Supermemory integration)
 - AI integrations (Ollama / OpenAI / Anthropic / ElevenLabs for speech)
 - Native macOS helpers (hotkeys, color picker, speech, snippet expansion)
+- macOS launcher panel behavior that stays on the active Space for normal hotkey opens
 
 ## Tech Stack
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1320,11 +1320,25 @@ function setLauncherOverlayTopmost(enabled: boolean): void {
   try {
     mainWindow.setAlwaysOnTop(Boolean(enabled));
   } catch {}
+  const launcherShouldSpanAllWorkspaces =
+    Boolean(enabled) &&
+    (
+      process.platform !== 'darwin' ||
+      launcherMode === 'onboarding'
+    );
   try {
-    if (enabled) {
-      mainWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+    if (launcherShouldSpanAllWorkspaces) {
+      mainWindow.setVisibleOnAllWorkspaces(true, {
+        visibleOnFullScreen: true,
+        skipTransformProcessType: process.platform === 'darwin',
+      });
     } else {
-      mainWindow.setVisibleOnAllWorkspaces(false);
+      // Avoid the dock/process-type transform for the launcher panel so
+      // Mission Control keeps it on the active Space.
+      mainWindow.setVisibleOnAllWorkspaces(false, {
+        visibleOnFullScreen: true,
+        skipTransformProcessType: process.platform === 'darwin',
+      } as any);
     }
   } catch {}
 }
@@ -5097,6 +5111,7 @@ function createWindow(): void {
   const primaryDisplay = screen.getPrimaryDisplay();
   const { width: screenWidth, height: screenHeight } =
     primaryDisplay.workAreaSize;
+  const useDarwinLauncherPanel = process.platform === 'darwin';
 
   mainWindow = new BrowserWindow({
     width: DEFAULT_WINDOW_WIDTH,
@@ -5112,6 +5127,14 @@ function createWindow(): void {
     vibrancy: false,
     transparent: true,
     backgroundColor: '#00000000',
+    ...(useDarwinLauncherPanel
+      ? {
+          // Use AppKit's panel-backed window on macOS for launcher semantics.
+          type: 'panel' as const,
+          hiddenInMissionControl: true,
+          fullscreenable: false,
+        }
+      : {}),
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
@@ -5282,7 +5305,7 @@ function createWindow(): void {
     mainWindow.setWindowButtonVisibility(false);
   }
 
-  mainWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  setLauncherOverlayTopmost(true);
 
   // NOTE: Do NOT call app.dock.hide() here. Hiding the dock before the window
   // is loaded and shown prevents macOS from granting the app foreground status,
@@ -5828,10 +5851,13 @@ function setLauncherMode(mode: LauncherMode): void {
       }
       if (mode === 'onboarding') {
         mainWindow.setAlwaysOnTop(false);
-        mainWindow.setVisibleOnAllWorkspaces(false);
+        mainWindow.setVisibleOnAllWorkspaces(false, {
+          visibleOnFullScreen: true,
+          skipTransformProcessType: process.platform === 'darwin',
+        } as any);
       } else {
         mainWindow.setAlwaysOnTop(true);
-        mainWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+        setLauncherOverlayTopmost(true);
       }
     } catch {}
     const onboardingTintChanged = (prevMode === 'onboarding') !== (mode === 'onboarding');
@@ -5949,6 +5975,7 @@ function captureFrontmostAppContext(): void {
 async function showWindow(options?: { systemCommandId?: string }): Promise<void> {
   if (!mainWindow) return;
   setLauncherOverlayTopmost(true);
+  const shouldActivateLauncherWindow = process.platform !== 'darwin' || launcherMode === 'onboarding';
   let selectionSnapshotPromise: Promise<string> | null = null;
 
   // Capture the frontmost app BEFORE showing our window.
@@ -5991,11 +6018,18 @@ async function showWindow(options?: { systemCommandId?: string }): Promise<void>
     });
   }
 
-  try {
-    app.focus({ steal: true });
-  } catch {}
+  if (shouldActivateLauncherWindow) {
+    try {
+      app.focus({ steal: true });
+    } catch {}
+  }
   mainWindow.show();
-  mainWindow.focus();
+  if (shouldActivateLauncherWindow) {
+    mainWindow.focus();
+  } else {
+    try { (mainWindow as any).focusOnWebView?.(); } catch {}
+    try { mainWindow.webContents.focus(); } catch {}
+  }
   mainWindow.moveTop();
   isVisible = true;
 
@@ -6005,7 +6039,12 @@ async function showWindow(options?: { systemCommandId?: string }): Promise<void>
     if (mainWindow.isVisible()) return;
     try {
       mainWindow.show();
-      mainWindow.focus();
+      if (shouldActivateLauncherWindow) {
+        mainWindow.focus();
+      } else {
+        try { (mainWindow as any).focusOnWebView?.(); } catch {}
+        try { mainWindow.webContents.focus(); } catch {}
+      }
       mainWindow.moveTop();
       isVisible = true;
     } catch {}


### PR DESCRIPTION
## What changed

This changes the macOS launcher window model so normal hotkey opens use a panel-backed launcher window instead of the previous activation-heavy BrowserWindow behavior.

Key changes:
- Create the launcher as a macOS `panel` window
- Avoid forcing the launcher onto all Spaces during normal use
- Stop explicitly activating/focusing the app for normal macOS launcher opens
- Keep onboarding on the old activation path so permission/setup flows still come to the front
- Add a short README note for the macOS launcher behavior

## Why

The previous `BrowserWindow` show/focus changes were not enough to fix the Spaces bug. The launcher could still switch to the wrong desktop when opened by hotkey after Space changes.

This PR takes the narrower native-window-model approach available in Electron on macOS, which matches the successful fix path better than the abandoned `showWindow()` focus patch series.

## Compatibility impact

- macOS launcher behavior changes for normal hotkey opens: it now stays on the active Space instead of behaving like an all-Spaces overlay.
- Onboarding behavior is preserved so permission dialogs and setup still work.

## How I tested

- `npm run build`
- `npm run dev`
- Manual macOS repro from the bug report:

  1. Have Desktop 1 and Desktop 2 open, currently on Desktop 2
  2. Launch SuperCmd
  3. Open Desktop 3, then close Desktop 3
  4. Go to Desktop 1 and open SuperCmd via hotkey
  5. Confirm it stays on Desktop 1 instead of switching to Desktop 2
