### PR TITLE
Security: Add SHA-256 integrity check for whisper.cpp framework download

### DIFF
--- a/scripts/build-whispercpp.mjs
+++ b/scripts/build-whispercpp.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { createHash } from 'crypto';
 import path from 'path';
 import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
@@ -12,6 +13,10 @@ const repoRoot = path.resolve(__dirname, '..');
 
 const whisperVersion = 'v1.8.3';
 const frameworkUrl = `https://github.com/ggml-org/whisper.cpp/releases/download/${whisperVersion}/whisper-${whisperVersion}-xcframework.zip`;
+// SHA-256 of the xcframework zip. The whisper.cpp project does not publish
+// checksums with their releases, so this was computed from the v1.8.3 asset
+// and pinned here. Update this when bumping whisperVersion.
+const frameworkSha256 = 'a970006f256c8e689bc79e73f7fa7ddb8c1ed2703ad43ee48eb545b5bb6de6af';
 
 const distNativeDir = path.join(repoRoot, 'dist', 'native');
 const runtimeDir = path.join(distNativeDir, 'whisper-runtime');
@@ -39,6 +44,19 @@ function prepareFramework() {
 
   console.log(`[whisper.cpp] Downloading macOS framework (${whisperVersion})`);
   run('curl', ['-L', frameworkUrl, '-o', archivePath]);
+
+  const fileBuffer = readFileSync(archivePath);
+  const actualHash = createHash('sha256').update(fileBuffer).digest('hex');
+  if (actualHash !== frameworkSha256) {
+    throw new Error(
+      `[whisper.cpp] Integrity check failed!\n` +
+      `  Expected SHA-256: ${frameworkSha256}\n` +
+      `  Actual SHA-256:   ${actualHash}\n` +
+      `  The downloaded file does not match the pinned hash. ` +
+      `This could indicate a corrupted download or a compromised release asset.`
+    );
+  }
+  console.log('[whisper.cpp] Integrity check passed (SHA-256)');
 
   console.log('[whisper.cpp] Extracting framework');
   run('unzip', ['-q', '-o', archivePath, '-d', extractDir]);


### PR DESCRIPTION
## Summary

- Add SHA-256 verification to `scripts/build-whispercpp.mjs` after downloading the pre-compiled `whisper.framework` from GitHub releases
- The build now fails with a clear error if the downloaded ZIP doesn't match the pinned hash
- The whisper.cpp project does not publish checksums with their releases, so the hash was independently computed and pinned

## What changed

In `scripts/build-whispercpp.mjs`:
- Import `readFileSync` and `createHash`
- Pin the expected SHA-256 hash for `whisper-v1.8.3-xcframework.zip`
- After `curl` download, read the file, compute SHA-256, and compare against the pinned hash
- Fail the build with a descriptive error if there's a mismatch

## Test plan

- [x] Verified the build passes with the correct download (hash matches)
- [ ] Verify that modifying the pinned hash causes a build failure
- [ ] Verify `npm run build:native` still completes successfully end-to-end

Closes #192