### PR TITLE
Boost recently used commands in search results

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1359,8 +1359,8 @@ const App: React.FC = () => {
   const calcOffset = calcResult ? 1 : 0;
   const contextualCommands = commands;
   const filteredCommands = useMemo(
-    () => filterCommands(contextualCommands, searchQuery, commandAliases),
-    [contextualCommands, searchQuery, commandAliases]
+    () => filterCommands(contextualCommands, searchQuery, commandAliases, recentCommands),
+    [contextualCommands, searchQuery, commandAliases, recentCommands]
   );
 
   // When calculator is showing but no commands match, show unfiltered list below

--- a/src/renderer/src/utils/command-helpers.tsx
+++ b/src/renderer/src/utils/command-helpers.tsx
@@ -180,7 +180,8 @@ function bestTermScore(term: string, candidates: SearchCandidate[]): number {
 export function filterCommands(
   commands: CommandInfo[],
   query: string,
-  aliasLookup: Record<string, string> = {}
+  aliasLookup: Record<string, string> = {},
+  recentCommands: string[] = []
 ): CommandInfo[] {
   const normalizedQuery = normalizeSearchText(query);
   if (!normalizedQuery) {
@@ -188,6 +189,8 @@ export function filterCommands(
   }
 
   const queryTerms = tokenizeSearchText(normalizedQuery);
+
+  const recencyRankMap = new Map(recentCommands.map((id, index) => [id, index]));
 
   const scored = commands
     .map((cmd) => {
@@ -255,10 +258,16 @@ export function filterCommands(
       // Favor concise titles when scores are close.
       score += Math.max(0, 12 - Math.max(0, title.length - normalizedQuery.length));
 
-      return { cmd, score, title, hasExactAliasMatch };
+      // Boost recently used commands (Alfred-style). Most recent gets +80, decays quickly.
+      const recencyRank = recencyRankMap.get(cmd.id) ?? Number.MAX_SAFE_INTEGER;
+      if (recencyRank !== Number.MAX_SAFE_INTEGER) {
+        score += Math.round(80 / (1 + recencyRank));
+      }
+
+      return { cmd, score, title, hasExactAliasMatch, recencyRank };
     })
     .filter(
-      (entry): entry is { cmd: CommandInfo; score: number; title: string; hasExactAliasMatch: boolean } =>
+      (entry): entry is { cmd: CommandInfo; score: number; title: string; hasExactAliasMatch: boolean; recencyRank: number } =>
         Boolean(entry) && entry.score > 0
     )
     .sort((a, b) => {
@@ -266,6 +275,10 @@ export function filterCommands(
         return Number(b.hasExactAliasMatch) - Number(a.hasExactAliasMatch);
       }
       if (b.score !== a.score) return b.score - a.score;
+      // When scores are equal, prefer the most recently used command (Alfred-style)
+      const recencyA = a.recencyRank;
+      const recencyB = b.recencyRank;
+      if (recencyA !== recencyB) return recencyA - recencyB;
       return a.title.localeCompare(b.title);
     });
 


### PR DESCRIPTION
## Summary
- Adds an Alfred-style recency boost to search scoring: recently launched commands rank higher when search scores are close
- Uses the existing `recentCommands` tracking (already persisted to settings) — no new state or storage needed
- Most recently used command gets +80 points, decaying quickly (`80 / (1 + rank)`), so it nudges results without overriding genuinely better matches
- Also uses recency as a secondary tiebreaker when scores are exactly equal

**Example:** Searching "chrome" after launching Google Chrome now puts it above Chrome Remote Desktop, even though the latter has a prefix match advantage.

## Test plan
- [ ] Launch a command (e.g. Google Chrome), then search for a term that matches multiple commands — the just-launched one should appear higher
- [ ] Verify that exact title/alias matches still rank above recency-boosted results
- [ ] Verify the "Recent" section on the home screen is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)