### PR TITLE
Added auto-close setting for whisper bar and fixed warmup banner

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -367,6 +367,7 @@ const App: React.FC = () => {
   const [onboardingRequiresShortcutFix, setOnboardingRequiresShortcutFix] = useState(false);
   const [onboardingHotkeyPresses, setOnboardingHotkeyPresses] = useState(0);
   const [launcherShortcut, setLauncherShortcut] = useState('Alt+Space');
+  const [whisperAutoClose, setWhisperAutoClose] = useState(true);
   const [showActions, setShowActions] = useState(false);
   const [actionsCommand, setActionsCommand] = useState<CommandInfo | null>(null);
   const [contextMenu, setContextMenu] = useState<{
@@ -536,6 +537,7 @@ const App: React.FC = () => {
       setWhisperSpeakToggleLabel(formatShortcutLabel(speakToggleHotkey));
       setConfiguredEdgeTtsVoice(String(settings.ai?.edgeTtsVoice || 'en-US-EricNeural'));
       setConfiguredTtsModel(String(settings.ai?.textToSpeechModel || 'edge-tts'));
+      setWhisperAutoClose(settings.ai?.whisperAutoClose !== false);
       setLauncherBackgroundImagePath(String(settings.launcherBackgroundImagePath || ''));
       setLauncherBackgroundImageEverywhere(Boolean(settings.launcherBackgroundImageEverywhere));
       setLauncherBackgroundImageBlurPercent(
@@ -2834,6 +2836,7 @@ const App: React.FC = () => {
               ? t('whisper.coachmark.holdToTalk', { shortcut: whisperSpeakToggleLabel })
               : undefined
           }
+          autoClose={whisperAutoClose}
           onClose={() => {
             whisperSessionRef.current = false;
             setShowWhisper(false);

--- a/src/renderer/src/SuperCmdWhisper.tsx
+++ b/src/renderer/src/SuperCmdWhisper.tsx
@@ -9,6 +9,7 @@ interface SuperCmdWhisperProps {
   onboardingCaptureMode?: boolean;
   onOnboardingTranscriptAppend?: (text: string) => void;
   coachmarkText?: string;
+  autoClose?: boolean;
 }
 
 type WhisperState = 'idle' | 'listening' | 'processing' | 'error';
@@ -250,6 +251,7 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
   onboardingCaptureMode = false,
   onOnboardingTranscriptAppend,
   coachmarkText,
+  autoClose = true,
 }) => {
   const { t } = useI18n();
   const idleStatus = t('whisper.status.idle');
@@ -1319,10 +1321,14 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
               ? window.electron.qwen3Warmup
               : window.electron.parakeetWarmup;
             parakeetWarmingUpRef.current = true;
-            setParakeetWarmingUp(true);
-            setState('listening');
-            setStatusText(t('whisper.status.loadingModels'));
-            console.log(`[Whisper][${sttModelRef.current}] Warming up server (first use)...`);
+            // Only show the "loading models" banner if warmup takes a while.
+            // When the server is already warm the IPC roundtrip is <10ms.
+            const bannerTimer = window.setTimeout(() => {
+              setParakeetWarmingUp(true);
+              setState('listening');
+              setStatusText(t('whisper.status.loadingModels'));
+            }, 200);
+            console.log(`[Whisper][${sttModelRef.current}] Warming up server...`);
             let warmupOk = false;
             try {
               const result = await warmupFn();
@@ -1335,6 +1341,7 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
             } catch (err) {
               console.warn(`[Whisper][${sttModelRef.current}] Warmup failed:`, err);
             }
+            window.clearTimeout(bannerTimer);
             // Always clear the warming banner once the warmup call returns.
             parakeetWarmingUpRef.current = false;
             setParakeetWarmingUp(false);
@@ -1576,7 +1583,7 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
       if (!PUSH_TO_TALK_MODE) return;
       pushToTalkArmedRef.current = false;
       if (whisperStateRef.current === 'listening') {
-        void finalizeAndClose(false);
+        void finalizeAndClose(autoClose);
       }
     });
     const disposeWhisperStart = window.electron.onWhisperStartListening(() => {
@@ -1592,7 +1599,7 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
       const currentState = whisperStateRef.current;
       if (currentState === 'listening' || currentState === 'processing') {
         pushToTalkArmedRef.current = false;
-        void finalizeAndClose(false);
+        void finalizeAndClose(autoClose);
       } else {
         pushToTalkArmedRef.current = false;
         void startListening();
@@ -1606,7 +1613,7 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
       disposeWhisperStart();
       disposeWhisperToggle();
     };
-  }, [finalizeAndClose, portalTarget, startListening]);
+  }, [finalizeAndClose, portalTarget, startListening, autoClose]);
 
   useEffect(() => {
     return () => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -357,6 +357,10 @@
           "fnHintBefore": "Use",
           "fnHintAfter": "to restore the default hold-to-talk key."
         },
+        "autoClose": {
+          "title": "Auto-Close After Dictation",
+          "description": "Automatically close the whisper bar when dictation finishes."
+        },
         "smoothOutput": {
           "title": "Smooth Output",
           "description": "Clean up filler words and self-corrections."

--- a/src/renderer/src/settings/AITab.tsx
+++ b/src/renderer/src/settings/AITab.tsx
@@ -1553,6 +1553,18 @@ const AITab: React.FC = () => {
 
               <div className="flex items-center justify-between gap-3">
                 <div>
+                  <h3 className="text-[0.8125rem] font-semibold text-[var(--text-primary)]">{t('settings.ai.whisper.autoClose.title')}</h3>
+                  <p className="text-[0.75rem] text-[var(--text-muted)] mt-0.5 leading-snug">{t('settings.ai.whisper.autoClose.description')}</p>
+                </div>
+                <SectionToggle
+                  enabled={ai.whisperAutoClose !== false}
+                  onToggle={() => updateAI({ whisperAutoClose: ai.whisperAutoClose === false })}
+                  label={t('settings.ai.whisper.autoClose.title')}
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-3">
+                <div>
                   <h3 className="text-[0.8125rem] font-semibold text-[var(--text-primary)]">{t('settings.ai.whisper.smoothOutput.title')}</h3>
                   <p className="text-[0.75rem] text-[var(--text-muted)] mt-0.5 leading-snug">{t('settings.ai.whisper.smoothOutput.description')}</p>
                 </div>

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -175,6 +175,7 @@ export interface AISettings {
   enabled: boolean;
   llmEnabled: boolean;
   whisperEnabled: boolean;
+  whisperAutoClose: boolean;
   readEnabled: boolean;
   openaiCompatibleBaseUrl: string;
   openaiCompatibleApiKey: string;


### PR DESCRIPTION
## Summary
- Adds an **Auto-Close After Dictation** toggle in Settings > AI > Whisper (on by default)
  - When enabled, the whisper bar automatically closes after dictation finishes instead of lingering idle on screen
  - When disabled, preserves the existing behavior (bar stays open for back-to-back dictation)
- Fixes the **warmup banner flashing** on every dictation start — the "Loading models..." banner now only appears if warmup actually takes >200ms, so it's invisible when the server is already warm

## Changes
- `electron.d.ts` — added `whisperAutoClose` to `AISettings`
- `en.json` — added i18n strings for the new toggle
- `AITab.tsx` — added the toggle UI in the Whisper settings panel
- `App.tsx` — loads and passes the `whisperAutoClose` setting to `SuperCmdWhisper`
- `SuperCmdWhisper.tsx` — respects `autoClose` prop in push-to-talk and toggle flows; delays warmup banner with a 200ms timer

## Test plan
- [ ] Enable auto-close (default) → dictate → bar should close after text is typed
- [ ] Disable auto-close → dictate → bar should stay open in idle state
- [ ] With server already warm: no "Loading models..." flash on dictation start
- [ ] Cold start (first dictation after app launch): "Loading models..." banner should appear after ~200ms if warmup is still in progress
- [ ] Toggle persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)