### PR TITLE
Fix inline AI prompt deleting content before selection and duplicate streaming

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7761,11 +7761,13 @@ async function replaceTextDirectly(previousText: string, nextText: string): Prom
 
   try {
     if (prev.length > 0) {
+      // The original selection is still active in the target app, so a single
+      // backspace (or simply typing) replaces the entire selection.  Sending
+      // prev.length backspaces is wrong: the first one deletes the whole
+      // selection and every subsequent one eats a character *before* it.
       const script = `
         tell application "System Events"
-          repeat ${prev.length} times
-            key code 51
-          end repeat
+          key code 51
         end tell
       `;
       await execFileAsync('osascript', ['-e', script]);
@@ -7790,11 +7792,11 @@ async function replaceTextViaBackspaceAndPaste(previousText: string, nextText: s
 
   try {
     if (prev.length > 0) {
+      // Single backspace to clear the active selection — see replaceTextDirectly
+      // for rationale.
       const script = `
         tell application "System Events"
-          repeat ${prev.length} times
-            key code 51
-          end repeat
+          key code 51
         end tell
       `;
       await execFileAsync('osascript', ['-e', script]);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -823,13 +823,19 @@ contextBridge.exposeInMainWorld('electron', {
     return () => { ipcRenderer.removeListener('whisper-native-chunk', listener); };
   },
   onAIStreamChunk: (callback: (data: { requestId: string; chunk: string }) => void) => {
-    ipcRenderer.on('ai-stream-chunk', (_event: any, data: any) => callback(data));
+    const listener = (_event: any, data: any) => callback(data);
+    ipcRenderer.on('ai-stream-chunk', listener);
+    return () => { ipcRenderer.removeListener('ai-stream-chunk', listener); };
   },
   onAIStreamDone: (callback: (data: { requestId: string }) => void) => {
-    ipcRenderer.on('ai-stream-done', (_event: any, data: any) => callback(data));
+    const listener = (_event: any, data: any) => callback(data);
+    ipcRenderer.on('ai-stream-done', listener);
+    return () => { ipcRenderer.removeListener('ai-stream-done', listener); };
   },
   onAIStreamError: (callback: (data: { requestId: string; error: string }) => void) => {
-    ipcRenderer.on('ai-stream-error', (_event: any, data: any) => callback(data));
+    const listener = (_event: any, data: any) => callback(data);
+    ipcRenderer.on('ai-stream-error', listener);
+    return () => { ipcRenderer.removeListener('ai-stream-error', listener); };
   },
 
   // ─── Ollama Model Management ────────────────────────────────────

--- a/src/renderer/src/PromptApp.tsx
+++ b/src/renderer/src/PromptApp.tsx
@@ -208,9 +208,15 @@ const PromptApp: React.FC = () => {
       setStatus('error');
       setErrorText(data.error || 'Failed to process this prompt.');
     };
-    window.electron.onAIStreamChunk(handleChunk);
-    window.electron.onAIStreamDone(handleDone);
-    window.electron.onAIStreamError(handleError);
+    const removeChunk = window.electron.onAIStreamChunk(handleChunk);
+    const removeDone = window.electron.onAIStreamDone(handleDone);
+    const removeError = window.electron.onAIStreamError(handleError);
+
+    return () => {
+      removeChunk?.();
+      removeDone?.();
+      removeError?.();
+    };
   }, [applyResult]);
 
   return (

--- a/src/renderer/src/hooks/useAiChat.ts
+++ b/src/renderer/src/hooks/useAiChat.ts
@@ -72,9 +72,15 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
       }
     };
 
-    window.electron.onAIStreamChunk(handleChunk);
-    window.electron.onAIStreamDone(handleDone);
-    window.electron.onAIStreamError(handleError);
+    const removeChunk = window.electron.onAIStreamChunk(handleChunk);
+    const removeDone = window.electron.onAIStreamDone(handleDone);
+    const removeError = window.electron.onAIStreamError(handleError);
+
+    return () => {
+      removeChunk?.();
+      removeDone?.();
+      removeError?.();
+    };
   }, []);
 
   // ── Auto-scroll AI response ─────────────────────────────────────

--- a/src/renderer/src/hooks/useCursorPrompt.ts
+++ b/src/renderer/src/hooks/useCursorPrompt.ts
@@ -107,9 +107,15 @@ export function useCursorPrompt({
       }
     };
 
-    window.electron.onAIStreamChunk(handleChunk);
-    window.electron.onAIStreamDone(handleDone);
-    window.electron.onAIStreamError(handleError);
+    const removeChunk = window.electron.onAIStreamChunk(handleChunk);
+    const removeDone = window.electron.onAIStreamDone(handleDone);
+    const removeError = window.electron.onAIStreamError(handleError);
+
+    return () => {
+      removeChunk?.();
+      removeDone?.();
+      removeError?.();
+    };
   }, [applyCursorPromptResultToEditor]);
 
   // ── Focus cursor prompt input when shown ────────────────────────

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -757,9 +757,9 @@ export interface ElectronAPI {
   aiAsk: (requestId: string, prompt: string, options?: { model?: string; creativity?: number; systemPrompt?: string }) => Promise<void>;
   aiCancel: (requestId: string) => Promise<void>;
   aiIsAvailable: () => Promise<boolean>;
-  onAIStreamChunk: (callback: (data: { requestId: string; chunk: string }) => void) => void;
-  onAIStreamDone: (callback: (data: { requestId: string }) => void) => void;
-  onAIStreamError: (callback: (data: { requestId: string; error: string }) => void) => void;
+  onAIStreamChunk: (callback: (data: { requestId: string; chunk: string }) => void) => (() => void);
+  onAIStreamDone: (callback: (data: { requestId: string }) => void) => (() => void);
+  onAIStreamError: (callback: (data: { requestId: string; error: string }) => void) => (() => void);
   whisperRefineTranscript: (
     transcript: string
   ) => Promise<{ correctedText: string; source: 'ai' | 'heuristic' | 'raw' }>;


### PR DESCRIPTION
- Fix 1: Inline AI prompt deleting content before selection — When applying a inline AI prompt result, the code sent prev.length backspaces to clear the selected text. But since the selection was still active, the first backspace already deleted the entire selection, and every subsequent one ate a character before it. Fixed by sending a single backspace in both replaceTextDirectly and replaceTextViaBackspaceAndPaste.

- Fix 2: AI streaming output duplicating every word (which is found when testing fix 1) — AI stream event listeners (onAIStreamChunk/Done/Error) were registered in useEffect hooks without cleanup functions, causing listeners to stack on re-renders. Each chunk was processed multiple times, doubling every word in the output. Fixed by returning removal functions from the preload bridge and calling them in useEffect teardown across useCursorPrompt, useAiChat, and PromptApp.