### PR TITLE
fix: Whisper hold-to-talk fails to stop with Delete/Arrow/F-key hotkeys

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5403,6 +5403,11 @@ function parseHoldShortcutConfig(shortcut: string): {
     n: 45, m: 46, '.': 47, '`': 50,
     period: 47, comma: 43, slash: 44, semicolon: 41, quote: 39,
     tab: 48, space: 49, return: 36, enter: 36, escape: 53, fn: 63, function: 63,
+    backspace: 51, delete: 117, forwarddelete: 117,
+    up: 126, down: 125, left: 123, right: 124,
+    home: 115, end: 119, pageup: 116, pagedown: 121,
+    f1: 122, f2: 120, f3: 99, f4: 118, f5: 96, f6: 97, f7: 98, f8: 100,
+    f9: 101, f10: 109, f11: 103, f12: 111,
   };
   const keyCode = map[keyToken];
   if (!Number.isFinite(keyCode)) return null;


### PR DESCRIPTION
Fix Whisper recording never stopping when Delete, Backspace, arrow keys, or F-keys are used as the Whisper hotkey.

## Problem
`parseHoldShortcutConfig` in `src/main/main.ts` has a hardcoded key→macOS HID key-code map used to spawn the native hold-watcher process. This map was missing Delete, Backspace, arrow keys, F-keys, and navigation keys. When any of those keys were used (e.g. Control+Delete), the lookup returned `undefined`, causing `startWhisperHoldWatcher` to bail early. Recording started via globalShortcut but the hold-watcher was never spawned, so key-up was never detected and recording never stopped.

## Fix
Adds macOS HID key codes for backspace (51), delete/forward-delete (117), arrow keys, home/end/pageup/pagedown, and F1–F12. Change is purely additive.

Closes #201

Generated with [Claude Code](https://claude.ai/code)