### PR TITLE
Security: Renderer page lacks a strict Content Security Policy (CSP)

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <script>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'nonce-supercmd-csp'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+    />
+    <script nonce="supercmd-csp">
       (function () {
         var themeMediaQuery = '(prefers-color-scheme: dark)';
         var prefersDarkFromSystem = !!(


### PR DESCRIPTION
## Summary

Security: Renderer page lacks a strict Content Security Policy (CSP)

## Problem

**Severity**: `High` | **File**: `src/renderer/index.html:L1`

The renderer HTML does not define a Content-Security-Policy. In an Electron app, missing CSP significantly increases the impact of any XSS/injection bug, potentially enabling arbitrary script execution in the renderer and abuse of preload-exposed IPC APIs.

## Solution

Add a restrictive CSP (prefer HTTP header; meta as fallback), remove unsafe-inline where possible, and move inline scripts to external files with nonces/hashes. Example baseline: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'.

## Changes

- `src/renderer/index.html` (modified)