### PR TITLE
fix: debug mode checkbox not selectable in Advanced settings

### DIFF
--- a/src/renderer/src/settings/AdvancedTab.tsx
+++ b/src/renderer/src/settings/AdvancedTab.tsx
@@ -202,10 +202,9 @@ const AdvancedTab: React.FC = () => {
           <label className="inline-flex items-center gap-2.5 text-[13px] text-white/85 cursor-pointer">
             <input
               type="checkbox"
-              checked={settings?.developerMode ?? false}
-              onChange={async (e) => {
-                await window.electron.updateSettings({ developerMode: e.target.checked });
-                setSettings((prev) => (prev ? { ...prev, developerMode: e.target.checked } : null));
+              checked={settings?.debugMode ?? false}
+              onChange={(e) => {
+                void applySettingsPatch({ debugMode: e.target.checked });
               }}
               className="settings-checkbox"
             />


### PR DESCRIPTION
Fixes #211

**Root cause:** Two bugs in `AdvancedTab.tsx`:
1. `window.electron.updateSettings` was called but this method doesn't exist on the Electron bridge — should be `saveSettings`
2. Property name `developerMode` was used instead of `debugMode` (the actual field in `AppSettings`)

**Fix:** Use the existing `applySettingsPatch` helper with the correct property name.

Generated with [Claude Code](https://claude.ai/code)