### PR TITLE
feat: persist launcher position + drag on all views + reset command

### DIFF
--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -55,6 +55,10 @@ const EMPTY_TRASH_ICON_DATA_URL = svgToBase64DataUrl(
   '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none"><defs><linearGradient id="etBg" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse"><stop stop-color="#6ee7b7" stop-opacity="0.7"/><stop offset="1" stop-color="#047857" stop-opacity="0.82"/></linearGradient></defs><rect x="8" y="8" width="48" height="48" rx="15" fill="url(#etBg)"/><g transform="translate(18,18) scale(1.167)" stroke="rgba(255,255,255,0.92)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></g></svg>'
 );
 
+const RESET_POSITION_ICON_DATA_URL = svgToBase64DataUrl(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none"><defs><linearGradient id="rpBg" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse"><stop stop-color="#7dd3fc" stop-opacity="0.7"/><stop offset="1" stop-color="#0369a1" stop-opacity="0.82"/></linearGradient></defs><rect x="8" y="8" width="48" height="48" rx="15" fill="url(#rpBg)"/><g transform="translate(18,18) scale(1.167)" stroke="rgba(255,255,255,0.92)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 9 2 12 5 15"/><polyline points="9 5 12 2 15 5"/><polyline points="15 19 12 22 9 19"/><polyline points="19 9 22 12 19 15"/><line x1="2" y1="12" x2="22" y2="12"/><line x1="12" y1="2" x2="12" y2="22"/></g></svg>'
+);
+
 export interface CommandInfo {
   id: string;
   title: string;
@@ -1230,6 +1234,7 @@ async function discoverAndBuildCommands(): Promise<CommandInfo[]> {
       id: 'system-reset-launcher-position',
       title: 'Reset Launcher Position',
       keywords: ['reset', 'position', 'center', 'move', 'launcher', 'window', 'default'],
+      iconDataUrl: RESET_POSITION_ICON_DATA_URL,
       category: 'system',
     },
     {

--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -1227,6 +1227,12 @@ async function discoverAndBuildCommands(): Promise<CommandInfo[]> {
       category: 'system',
     },
     {
+      id: 'system-reset-launcher-position',
+      title: 'Reset Launcher Position',
+      keywords: ['reset', 'position', 'center', 'move', 'launcher', 'window', 'default'],
+      category: 'system',
+    },
+    {
       id: 'system-open-settings',
       title: 'SuperCmd Settings',
       keywords: ['settings', 'preferences', 'config', 'configuration', 'supercmd'],

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -15,7 +15,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { fork, type ChildProcess } from 'child_process';
 import { getAvailableCommands, executeCommand, invalidateCache } from './commands';
-import { loadSettings, saveSettings, setOAuthToken, getOAuthToken, removeOAuthToken } from './settings-store';
+import { loadSettings, saveSettings, setOAuthToken, getOAuthToken, removeOAuthToken, loadWindowState, saveWindowState, clearWindowState } from './settings-store';
 import type { AppSettings } from './settings-store';
 import { streamAI, isAIAvailable, transcribeAudio } from './ai-provider';
 import { addMemory, buildMemoryContextSystemPrompt } from './memory';
@@ -6815,6 +6815,15 @@ function createWindow(): void {
     }
   });
 
+  // Persist the window position whenever it is moved in default mode so we
+  // can restore it on the next open.
+  mainWindow.on('moved', () => {
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    if (launcherMode !== 'default') return;
+    const [x, y] = mainWindow.getPosition();
+    saveWindowState({ x, y });
+  });
+
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
@@ -7276,6 +7285,22 @@ function applyLauncherBounds(mode: LauncherMode): void {
   } = currentDisplay.workArea;
   const size = getLauncherSize(mode);
   const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+  // In default mode, restore the last saved position if it falls within any display.
+  if (mode === 'default') {
+    const saved = loadWindowState();
+    if (saved) {
+      const savedCenter = { x: saved.x + Math.floor(size.width / 2), y: saved.y + Math.floor(size.height / 2) };
+      const nearestDisplay = screen.getDisplayNearestPoint(savedCenter);
+      const wa = nearestDisplay.workArea;
+      // Clamp to keep the window fully on-screen.
+      const clampedX = clamp(saved.x, wa.x, wa.x + wa.width - size.width);
+      const clampedY = clamp(saved.y, wa.y, wa.y + wa.height - size.height);
+      mainWindow.setBounds({ x: clampedX, y: clampedY, width: size.width, height: size.height });
+      return;
+    }
+  }
+
   const promptFallbackX = displayX + Math.floor((displayWidth - size.width) / 2);
   const promptFallbackY = displayY + Math.floor(displayHeight * 0.32);
   const windowX = mode === 'speak'
@@ -8465,6 +8490,15 @@ async function runCommandById(commandId: string, source: 'launcher' | 'hotkey' |
     if (source === 'launcher') {
       setTimeout(() => hideWindow(), 50);
     }
+    return true;
+  }
+
+  if (commandId === 'system-reset-launcher-position') {
+    clearWindowState();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      applyLauncherBounds('default');
+    }
+    if (source === 'launcher') hideWindow();
     return true;
   }
 
@@ -10959,6 +10993,13 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('close-prompt-window', () => {
     hidePromptWindow();
+  });
+
+  ipcMain.handle('reset-launcher-position', () => {
+    clearWindowState();
+    if (mainWindow && !mainWindow.isDestroyed() && isVisible && launcherMode === 'default') {
+      applyLauncherBounds('default');
+    }
   });
 
   ipcMain.handle('set-launcher-mode', (_event: any, mode: LauncherMode) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -30,6 +30,7 @@ contextBridge.exposeInMainWorld('electron', {
   executeCommandFromWidget: (commandId: string): Promise<boolean> =>
     ipcRenderer.invoke('execute-command-from-widget', commandId),
   hideWindow: (): Promise<void> => ipcRenderer.invoke('hide-window'),
+  resetLauncherPosition: (): Promise<void> => ipcRenderer.invoke('reset-launcher-position'),
   openDevTools: (): Promise<boolean> => ipcRenderer.invoke('open-devtools'),
   closePromptWindow: (): Promise<void> => ipcRenderer.invoke('close-prompt-window'),
   setLauncherMode: (mode: 'default' | 'onboarding' | 'whisper' | 'speak' | 'prompt'): Promise<void> =>

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -465,3 +465,59 @@ export function removeOAuthToken(provider: string): void {
   delete tokens[provider];
   saveOAuthTokens(tokens);
 }
+
+// ─── Window State Store ───────────────────────────────────────────
+// Stores the last known position of the launcher window so it can be
+// restored on the next open. Kept separate from AppSettings because
+// it updates on every move and should never be part of user-facing
+// settings sync.
+
+export interface LauncherWindowState {
+  /** Last saved X position of the launcher window. */
+  x: number;
+  /** Last saved Y position of the launcher window. */
+  y: number;
+}
+
+let windowStateCache: LauncherWindowState | null | undefined = undefined; // undefined = not loaded yet
+
+function getWindowStatePath(): string {
+  return path.join(app.getPath('userData'), 'window-state.json');
+}
+
+export function loadWindowState(): LauncherWindowState | null {
+  if (windowStateCache !== undefined) return windowStateCache;
+  try {
+    const raw = fs.readFileSync(getWindowStatePath(), 'utf-8');
+    const parsed = JSON.parse(raw);
+    const x = Number(parsed?.x);
+    const y = Number(parsed?.y);
+    if (Number.isFinite(x) && Number.isFinite(y)) {
+      windowStateCache = { x: Math.round(x), y: Math.round(y) };
+    } else {
+      windowStateCache = null;
+    }
+  } catch {
+    windowStateCache = null;
+  }
+  return windowStateCache;
+}
+
+export function saveWindowState(state: LauncherWindowState): void {
+  windowStateCache = state;
+  try {
+    fs.writeFileSync(getWindowStatePath(), JSON.stringify(state, null, 2));
+  } catch (e) {
+    console.error('Failed to save window state:', e);
+  }
+}
+
+export function clearWindowState(): void {
+  windowStateCache = null;
+  try {
+    const p = getWindowStatePath();
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  } catch (e) {
+    console.error('Failed to clear window state:', e);
+  }
+}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2225,6 +2225,11 @@ const App: React.FC = () => {
       await window.electron.executeCommand('system-empty-trash');
       return true;
     }
+    if (commandId === 'system-reset-launcher-position') {
+      await window.electron.resetLauncherPosition();
+      await window.electron.hideWindow();
+      return true;
+    }
     return false;
   }, [memoryActionLoading, selectedTextSnapshot, showMemoryFeedback, showOnboarding, showWindowManager, openOnboarding, openWhisper, setShowWhisper, setShowWhisperOnboarding, setShowWhisperHint, openClipboardManager, openSnippetManager, openQuickLinkManager, openFileSearch, openCamera, openSpeak, openWindowManager, setShowSpeak, setShowWindowManager]);
 

--- a/src/renderer/src/CanvasSearchInline.tsx
+++ b/src/renderer/src/CanvasSearchInline.tsx
@@ -359,7 +359,7 @@ const CanvasSearchInline: React.FC<CanvasSearchInlineProps> = ({ onClose }) => {
     return (
       <div className="snippet-view flex flex-col h-full">
         {/* Same header as normal view */}
-        <div className="snippet-header flex h-16 items-center gap-2 px-4">
+        <div className="snippet-header drag-region flex h-16 items-center gap-2 px-4">
           <button onClick={onClose} className="text-white/40 hover:text-white/70 transition-colors flex-shrink-0" tabIndex={-1}>
             <ArrowLeft className="w-4 h-4" />
           </button>
@@ -399,7 +399,7 @@ const CanvasSearchInline: React.FC<CanvasSearchInlineProps> = ({ onClose }) => {
   return (
     <div className="snippet-view flex flex-col h-full">
       {/* Header (matches snippet-header pattern) */}
-      <div className="snippet-header flex h-16 items-center gap-2 px-4">
+      <div className="snippet-header drag-region flex h-16 items-center gap-2 px-4">
         <button
           onClick={onClose}
           className="text-white/40 hover:text-white/70 transition-colors flex-shrink-0"

--- a/src/renderer/src/ClipboardManager.tsx
+++ b/src/renderer/src/ClipboardManager.tsx
@@ -501,7 +501,7 @@ const ClipboardManager: React.FC<ClipboardManagerProps> = ({ onClose }) => {
   return (
     <div className="w-full h-full flex flex-col" onKeyDown={handleKeyDown} tabIndex={-1}>
       {/* Header - transparent background same as main screen */}
-      <div className="flex items-center gap-3 px-5 py-3.5 border-b border-[var(--ui-divider)]">
+      <div className="drag-region flex items-center gap-3 px-5 py-3.5 border-b border-[var(--ui-divider)]">
         <button
           onClick={onClose}
           className="text-[var(--text-subtle)] hover:text-[var(--text-muted)] transition-colors flex-shrink-0 focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"

--- a/src/renderer/src/ExtensionView.tsx
+++ b/src/renderer/src/ExtensionView.tsx
@@ -3747,7 +3747,7 @@ const ExtensionView: React.FC<ExtensionViewProps> = ({
       || (code ? `Failed to load extension module for ${extensionName}/${commandName}.` : 'Failed to load extension. No valid export found.');
     return (
       <div className="flex flex-col h-full">
-        <div className="flex items-center gap-2 px-5 py-3.5 border-b border-white/[0.06]">
+        <div className="drag-region flex items-center gap-2 px-5 py-3.5 border-b border-white/[0.06]">
           <button
             onClick={onClose}
             className="text-white/40 hover:text-white/70 transition-colors"

--- a/src/renderer/src/FileSearchExtension.tsx
+++ b/src/renderer/src/FileSearchExtension.tsx
@@ -636,7 +636,7 @@ const FileSearchExtension: React.FC<FileSearchExtensionProps> = ({ onClose, init
 
   return (
     <div className="w-full h-full flex flex-col relative" onKeyDown={handleKeyDown} tabIndex={-1}>
-      <div className="flex items-center gap-2 px-3.5 py-2 border-b border-[var(--ui-divider)]">
+      <div className="drag-region flex items-center gap-2 px-3.5 py-2 border-b border-[var(--ui-divider)]">
         <button
           onClick={() => {
             if (showDetails) {

--- a/src/renderer/src/NotesSearchInline.tsx
+++ b/src/renderer/src/NotesSearchInline.tsx
@@ -219,7 +219,7 @@ const NotesSearchInline: React.FC<NotesSearchInlineProps> = ({ onClose }) => {
   return (
     <div className="snippet-view flex flex-col h-full">
       {/* ─── Header (matches snippet-header) ─── */}
-      <div className="snippet-header flex h-16 items-center gap-2 px-4">
+      <div className="snippet-header drag-region flex h-16 items-center gap-2 px-4">
         <button
           onClick={onClose}
           className="text-white/40 hover:text-white/70 transition-colors flex-shrink-0"

--- a/src/renderer/src/QuickLinkManager.tsx
+++ b/src/renderer/src/QuickLinkManager.tsx
@@ -937,7 +937,7 @@ const QuickLinkForm: React.FC<QuickLinkFormProps> = ({ quickLink, onSave, onCanc
 
   return (
     <div className="snippet-view w-full h-full flex flex-col" onKeyDown={handleKeyDown}>
-      <div className="snippet-header flex items-center gap-3 px-5 py-3.5">
+      <div className="snippet-header drag-region flex items-center gap-3 px-5 py-3.5">
         <button
           onClick={onCancel}
           className="text-white/40 hover:text-white/70 transition-colors flex-shrink-0"
@@ -1760,7 +1760,7 @@ const QuickLinkManager: React.FC<QuickLinkManagerProps> = ({ onClose, initialVie
 
   return (
     <div className="snippet-view snippet-search-view w-full h-full flex flex-col" onKeyDown={handleKeyDown} tabIndex={-1}>
-      <div className="snippet-header flex h-16 items-center gap-2 px-4">
+      <div className="snippet-header drag-region flex h-16 items-center gap-2 px-4">
         <button
           onClick={onClose}
           className="text-white/40 hover:text-white/70 transition-colors flex-shrink-0"

--- a/src/renderer/src/ScheduleExtension.tsx
+++ b/src/renderer/src/ScheduleExtension.tsx
@@ -417,7 +417,7 @@ const ScheduleExtension: React.FC<ScheduleExtensionProps> = ({ onClose }) => {
 
   return (
     <div className="w-full h-full flex flex-col relative" onKeyDown={handleKeyDown} tabIndex={-1}>
-      <div className="flex items-center gap-3 px-5 py-3.5 border-b border-[var(--ui-divider)]">
+      <div className="drag-region flex items-center gap-3 px-5 py-3.5 border-b border-[var(--ui-divider)]">
         <button
           onClick={onClose}
           className="text-[var(--text-subtle)] hover:text-[var(--text-muted)] transition-colors flex-shrink-0 focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"

--- a/src/renderer/src/SnippetManager.tsx
+++ b/src/renderer/src/SnippetManager.tsx
@@ -240,7 +240,7 @@ const SnippetForm: React.FC<SnippetFormProps> = ({ snippet, onSave, onCancel }) 
   return (
     <div className="snippet-view w-full h-full flex flex-col" onKeyDown={handleKeyDown}>
       {/* Header */}
-      <div className="snippet-header flex items-center gap-3 px-5 py-3.5">
+      <div className="snippet-header drag-region flex items-center gap-3 px-5 py-3.5">
         <button
           onClick={onCancel}
           className="text-white/40 hover:text-white/70 transition-colors flex-shrink-0"
@@ -978,7 +978,7 @@ const SnippetManager: React.FC<SnippetManagerProps> = ({ onClose, initialView })
   return (
     <div className="snippet-view snippet-search-view w-full h-full flex flex-col" onKeyDown={handleKeyDown} tabIndex={-1}>
       {/* Header */}
-      <div className="snippet-header flex h-16 items-center gap-2 px-4">
+      <div className="snippet-header drag-region flex h-16 items-center gap-2 px-4">
         <button
           onClick={onClose}
           className="text-white/40 hover:text-white/70 transition-colors flex-shrink-0"

--- a/src/renderer/src/raycast-api/detail-runtime.tsx
+++ b/src/renderer/src/raycast-api/detail-runtime.tsx
@@ -148,7 +148,7 @@ export function createDetailRuntime(deps: CreateDetailRuntimeDeps) {
           </div>
         )}
 
-        <div className="flex items-center gap-2 px-4 py-3 border-b border-[var(--ui-divider)]">
+        <div className="drag-region flex items-center gap-2 px-4 py-3 border-b border-[var(--ui-divider)]">
           <button onClick={pop} className="sc-back-button text-[var(--text-subtle)] hover:text-[var(--text-muted)] transition-colors flex-shrink-0 p-0.5">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
           </button>

--- a/src/renderer/src/raycast-api/form-runtime.tsx
+++ b/src/renderer/src/raycast-api/form-runtime.tsx
@@ -146,7 +146,7 @@ export function createFormRuntime(deps: FormRuntimeDeps) {
             setShowActions(true);
           }}
         >
-          <div className="flex items-center gap-2 px-4 py-3 border-b border-[var(--ui-divider)]">
+          <div className="drag-region flex items-center gap-2 px-4 py-3 border-b border-[var(--ui-divider)]">
             <button onClick={pop} className="sc-back-button text-[var(--text-subtle)] hover:text-[var(--text-muted)] transition-colors flex-shrink-0 p-0.5">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M19 12H5M12 19l-7-7 7-7" />

--- a/src/renderer/src/raycast-api/grid-runtime.tsx
+++ b/src/renderer/src/raycast-api/grid-runtime.tsx
@@ -201,7 +201,7 @@ export function createGridRuntime(deps: GridRuntimeDeps) {
         </div>
 
         <div className="flex flex-col h-full" onKeyDown={handleKeyDown}>
-          <div className="flex items-center gap-2 px-4 py-3 border-b border-[var(--ui-divider)]">
+          <div className="drag-region flex items-center gap-2 px-4 py-3 border-b border-[var(--ui-divider)]">
             <button onClick={pop} className="sc-back-button text-[var(--text-subtle)] hover:text-[var(--text-muted)] transition-colors flex-shrink-0 p-0.5">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M19 12H5M12 19l-7-7 7-7" /></svg>
             </button>

--- a/src/renderer/src/raycast-api/list-runtime.tsx
+++ b/src/renderer/src/raycast-api/list-runtime.tsx
@@ -324,7 +324,7 @@ export function createListRuntime(deps: ListRuntimeDeps) {
         </div>
 
         <div className="flex flex-col h-full" onKeyDown={handleKeyDown}>
-          <div className="flex items-center gap-2 px-4 py-3 border-b border-[var(--ui-divider)]">
+          <div className="drag-region flex items-center gap-2 px-4 py-3 border-b border-[var(--ui-divider)]">
             <button onClick={pop} className="sc-back-button text-[var(--text-subtle)] hover:text-[var(--text-muted)] transition-colors flex-shrink-0 p-0.5"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M19 12H5M12 19l-7-7 7-7" /></svg></button>
             <input ref={inputRef} data-supercmd-search-input="true" type="text" placeholder={searchBarPlaceholder || t('common.search')} value={internalSearch} onChange={(event) => handleSearchChange(event.target.value)} className="flex-1 bg-transparent border-none outline-none text-[var(--text-primary)] placeholder:text-[color:var(--text-subtle)] text-[14px] font-light" autoFocus />
             {searchBarAccessory && <div className="flex-shrink-0">{searchBarAccessory}</div>}

--- a/src/renderer/src/views/AiChatView.tsx
+++ b/src/renderer/src/views/AiChatView.tsx
@@ -43,7 +43,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({
       <div className="w-full h-full">
         <div className="glass-effect overflow-hidden h-full flex flex-col">
           {/* AI header — editable input */}
-          <div className="flex items-center gap-3 px-5 py-3.5 border-b border-[var(--ui-divider)]">
+          <div className="drag-region flex items-center gap-3 px-5 py-3.5 border-b border-[var(--ui-divider)]">
             <Sparkles className="w-4 h-4 text-[var(--accent)] flex-shrink-0" />
             <input
               ref={aiInputRef}

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -1033,7 +1033,11 @@ kbd {
 /* Prevent drag on interactive elements inside drag regions */
 .drag-region button,
 .drag-region input,
-.drag-region a {
+.drag-region a,
+.drag-region select,
+.drag-region textarea,
+.drag-region [role="button"],
+.drag-region [tabindex]:not([tabindex="-1"]) {
   -webkit-app-region: no-drag;
 }
 

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -413,6 +413,7 @@ export interface ElectronAPI {
   executeCommandAsHotkey: (commandId: string) => Promise<boolean>;
   executeCommandFromWidget: (commandId: string) => Promise<boolean>;
   hideWindow: () => Promise<void>;
+  resetLauncherPosition: () => Promise<void>;
   openDevTools: () => Promise<boolean>;
   closePromptWindow: () => Promise<void>;
   setLauncherMode: (mode: 'default' | 'onboarding' | 'whisper' | 'speak' | 'prompt') => Promise<void>;


### PR DESCRIPTION
Closes #213

## Changes

- **Window position persistence**: Saves position to `window-state.json` on every move (default mode only), restores on next open clamped to display work area.
- **Drag on all views**: Added `drag-region` to header bars of all system views (ClipboardManager, SnippetManager, FileSearch, Notes, Canvas, QuickLinks, Schedule, AI Chat) and extension runtimes (List, Form, Grid, Detail).
- **Reset command**: New "Reset Launcher Position" system command clears saved position and re-centers window.

Generated with [Claude Code](https://claude.ai/code)