### PR TITLE
fix: remove blur-to-hide on inline AI prompt window

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7022,9 +7022,6 @@ function createPromptWindow(initialBounds?: { x: number; y: number; width: numbe
   });
   promptWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
   loadWindowUrl(promptWindow, '/prompt');
-  promptWindow.on('blur', () => {
-    hidePromptWindow();
-  });
   promptWindow.on('closed', () => {
     promptWindow = null;
   });

--- a/src/renderer/src/PromptApp.tsx
+++ b/src/renderer/src/PromptApp.tsx
@@ -153,24 +153,6 @@ const PromptApp: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const handleFocus = () => {
-      void (async () => {
-        await resetPromptState(true);
-        const available = await window.electron.aiIsAvailable().catch(() => false);
-        setAiAvailable(available);
-        if (!available) {
-          setStatus('error');
-          setErrorText(NO_AI_MODEL_ERROR);
-        }
-        setTimeout(() => textareaRef.current?.focus(), 20);
-      })();
-    };
-
-    window.addEventListener('focus', handleFocus);
-    return () => window.removeEventListener('focus', handleFocus);
-  }, [resetPromptState]);
-
-  useEffect(() => {
     let cancelled = false;
     window.electron.aiIsAvailable()
       .then((available) => {
@@ -238,6 +220,9 @@ const PromptApp: React.FC = () => {
               if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
                 void submitPrompt();
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                void closePrompt();
               }
             }}
             placeholder="Tell AI what to do with selected text..."


### PR DESCRIPTION
Fixes #199

The prompt window was closing whenever the user clicked elsewhere (e.g. to open snippets or clipboard history). Removes the blur event handler that triggered `hidePromptWindow()`. Users can now close the prompt via the X button or the Escape key.

## Changes
- Remove `promptWindow.on('blur', hidePromptWindow)` from `main.ts`
- Add Escape key handler in `PromptApp.tsx` to close the prompt
- Remove focus-based state reset that relied on the blur-to-hide flow

Generated with [Claude Code](https://claude.ai/code)