### PR TITLE
fix: clear inline quick link argument values after action is completed

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2348,6 +2348,12 @@ const App: React.FC = () => {
             await updateRecentCommands(command.id);
             setSearchQuery('');
             setSelectedIndex(0);
+            setInlineQuickLinkDynamicValuesById((prev) => {
+              if (!prev[quickLinkId]) return prev;
+              const next = { ...prev };
+              delete next[quickLinkId];
+              return next;
+            });
             await window.electron.hideWindow();
             return true;
           }
@@ -2377,6 +2383,12 @@ const App: React.FC = () => {
       await updateRecentCommands(command.id);
       setSearchQuery('');
       setSelectedIndex(0);
+      setInlineQuickLinkDynamicValuesById((prev) => {
+        if (!prev[quickLinkId]) return prev;
+        const next = { ...prev };
+        delete next[quickLinkId];
+        return next;
+      });
       await window.electron.hideWindow();
       return true;
     },


### PR DESCRIPTION
When a quick link with dynamic fields is executed, the inline input values were not being cleared, causing them to persist when the launcher was reopened.

Fixes #222

Generated with [Claude Code](https://claude.ai/code)