### PR TITLE
Use localized bundle names for discovered apps

### DIFF
--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -948,7 +948,13 @@ async function discoverApplications(): Promise<CommandInfo[]> {
         }
 
         const rawName = path.basename(appPath, '.app');
-        const name = canonicalAppTitle(rawName);
+        const fallbackDisplayName = String(info?.CFBundleDisplayName || info?.CFBundleName || '').trim();
+        const localizedDisplayName = await resolveLocalizedBundleDisplayName(
+          appPath,
+          'CFBundleDisplayName',
+          'CFBundleName'
+        );
+        const name = canonicalAppTitle(localizedDisplayName || fallbackDisplayName || rawName);
         const bundleId =
           typeof info?.CFBundleIdentifier === 'string'
             ? info.CFBundleIdentifier


### PR DESCRIPTION
## Summary
- prefer localized `CFBundleDisplayName` / `CFBundleName` when discovering app commands
- fall back to plist values and finally the `.app` basename when no localized display name exists
- fix app titles such as WeChat DevTools being shown as the internal bundle name

## Test Plan
- npm run build:main