### PR TITLE
fix: add randomInt to node:crypto stub for extensions

### DIFF
--- a/src/renderer/src/ExtensionView.tsx
+++ b/src/renderer/src/ExtensionView.tsx
@@ -1343,6 +1343,64 @@ const cryptoStub = {
     const cb = args[args.length - 1];
     try { cryptoStub.randomFillSync(buf); if (typeof cb === 'function') cb(null, buf); } catch (e) { if (typeof cb === 'function') cb(e); }
   },
+  // Node's crypto.randomInt([min], max, [callback]) — returns an integer n where min <= n < max.
+  // Extensions like "Random Password Generator" and "Passphrase Generator" rely on this.
+  // Uses rejection sampling over crypto.getRandomValues for a uniform distribution.
+  randomInt: (...args: any[]) => {
+    let min = 0;
+    let max: number;
+    let cb: Function | undefined;
+    if (args.length >= 2 && typeof args[args.length - 1] === 'function') {
+      cb = args[args.length - 1];
+      if (args.length === 2) {
+        max = args[0];
+      } else {
+        min = args[0];
+        max = args[1];
+      }
+    } else if (args.length === 1) {
+      max = args[0];
+    } else {
+      min = args[0];
+      max = args[1];
+    }
+    const compute = (): number => {
+      if (!Number.isInteger(min) || !Number.isInteger(max)) {
+        throw new TypeError('The "min" and "max" arguments must be safe integers');
+      }
+      if (max <= min) {
+        throw new RangeError('The value of "max" must be greater than "min"');
+      }
+      const range = max - min;
+      if (range > 2 ** 48) {
+        throw new RangeError('The range is too large (must be <= 2^48)');
+      }
+      const bitsNeeded = Math.ceil(Math.log2(range));
+      const bytesNeeded = Math.max(1, Math.ceil(bitsNeeded / 8));
+      const maxValue = 2 ** (bytesNeeded * 8);
+      const threshold = maxValue - (maxValue % range);
+      const buf = new Uint8Array(bytesNeeded);
+      // Rejection sampling to avoid modulo bias.
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        crypto.getRandomValues(buf);
+        let value = 0;
+        for (let i = 0; i < bytesNeeded; i++) value = value * 256 + buf[i];
+        if (value < threshold) return min + (value % range);
+      }
+    };
+    if (cb) {
+      try {
+        const result = compute();
+        setTimeout(() => cb!(null, result), 0);
+        return undefined as any;
+      } catch (e) {
+        setTimeout(() => cb!(e), 0);
+        return undefined as any;
+      }
+    }
+    return compute();
+  },
   getRandomValues: (arr: any) => crypto.getRandomValues(arr),
   createCipheriv: () => ({ update: () => BufferPolyfill.alloc(0), final: () => BufferPolyfill.alloc(0) }),
   createDecipheriv: () => ({ update: () => BufferPolyfill.alloc(0), final: () => BufferPolyfill.alloc(0) }),


### PR DESCRIPTION
## Summary

Fixes #253.

Extensions that use `crypto.randomInt()` — e.g. **Random Password Generator** and **Passphrase Generator** — failed with `(0, import_node_crypto.randomInt) is not a function` because the renderer's `node:crypto` stub in `src/renderer/src/ExtensionView.tsx` never implemented `randomInt`.

## Changes

- Added `randomInt` to the `cryptoStub` at `src/renderer/src/ExtensionView.tsx`.
- Supports all Node call shapes: `randomInt(max)`, `randomInt(min, max)`, `randomInt(max, cb)`, `randomInt(min, max, cb)`.
- Uses rejection sampling over `crypto.getRandomValues` so the distribution stays uniform (no modulo bias), which matches Node's behavior — important for security-sensitive extensions like password generators.
- Throws `TypeError` / `RangeError` for the same bad inputs Node rejects (non-integer args, `max <= min`, range `> 2^48`).

## Test plan

- [ ] Install **Random Password Generator** and generate a password — should succeed.
- [ ] Install **Passphrase Generator** and generate a passphrase — should succeed.
- [ ] Verify any other extension using `crypto.randomInt` (e.g. password/token generators) no longer throws.

https://claude.ai/code/session_01BaEqDKuWxP2Da5Qyb8JSfR