### PR TITLE
feat: rename "Other" section label to "Results" in launcher

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3635,7 +3635,7 @@ const App: React.FC = () => {
                   { title: t('launcher.sections.selectedText'), items: strip(groupedCommands.contextual) },
                   { title: t('launcher.sections.pinned'), items: strip(groupedCommands.pinned) },
                   { title: t('launcher.categories.recent'), items: strip(groupedCommands.recent) },
-                  { title: t('common.other'), items: strip(groupedCommands.other) },
+                  { title: t('launcher.sections.results'), items: strip(groupedCommands.other) },
                   { title: t('launcher.categories.files'), items: strip(groupedCommands.files) },
                 ];
               })()

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -645,7 +645,8 @@
     },
     "sections": {
       "selectedText": "Selected Text",
-      "pinned": "Pinned"
+      "pinned": "Pinned",
+      "results": "Results"
     },
     "calculator": {
       "pressEnterToCopy": "Press Enter to copy",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -641,7 +641,8 @@
     },
     "sections": {
       "selectedText": "선택한 텍스트",
-      "pinned": "고정됨"
+      "pinned": "고정됨",
+      "results": "결과"
     },
     "calculator": {
       "pressEnterToCopy": "복사하려면 Enter를 누르세요.",

--- a/src/renderer/src/i18n/locales/ru.json
+++ b/src/renderer/src/i18n/locales/ru.json
@@ -139,7 +139,8 @@
     },
     "sections": {
       "selectedText": "Выделенный текст",
-      "pinned": "Закреплённое"
+      "pinned": "Закреплённое",
+      "results": "Результаты"
     },
     "calculator": {
       "pressEnterToCopy": "Нажмите Enter, чтобы скопировать",

--- a/src/renderer/src/i18n/locales/zh-Hans.json
+++ b/src/renderer/src/i18n/locales/zh-Hans.json
@@ -641,7 +641,8 @@
     },
     "sections": {
       "selectedText": "选中文本",
-      "pinned": "已固定"
+      "pinned": "已固定",
+      "results": "结果"
     },
     "calculator": {
       "pressEnterToCopy": "按回车复制",

--- a/src/renderer/src/i18n/locales/zh-Hant.json
+++ b/src/renderer/src/i18n/locales/zh-Hant.json
@@ -598,7 +598,8 @@
     },
     "sections": {
       "selectedText": "已選文字",
-      "pinned": "已固定"
+      "pinned": "已固定",
+      "results": "結果"
     },
     "calculator": {
       "pressEnterToCopy": "按 Enter 複製",


### PR DESCRIPTION
Renames the section heading shown in the launcher search results from "OTHER" to "RESULTS" across all supported locales.

Ref: #255

Generated with [Claude Code](https://claude.ai/code)