### PR TITLE
feat: add Extension Store system command

### DIFF
--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -1548,6 +1548,12 @@ async function discoverAndBuildCommands(): Promise<CommandInfo[]> {
       category: 'system',
     },
     {
+      id: 'system-open-extension-store',
+      title: 'Extension Store',
+      keywords: ['extension', 'store', 'browse', 'install', 'community', 'marketplace', 'supercmd'],
+      category: 'system',
+    },
+    {
       id: 'system-open-onboarding',
       title: 'SuperCmd Onboarding',
       keywords: ['welcome', 'onboarding', 'intro', 'setup', 'supercmd'],

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8609,6 +8609,11 @@ async function runCommandById(commandId: string, source: 'launcher' | 'hotkey' |
     if (source === 'launcher') hideWindow();
     return true;
   }
+  if (commandId === 'system-open-extension-store') {
+    openExtensionStoreWindow();
+    if (source === 'launcher') hideWindow();
+    return true;
+  }
   if (commandId === 'system-close-all-apps') {
     try {
       const confirmed = await confirmQuitAllApps(source);

--- a/src/renderer/src/utils/command-helpers.tsx
+++ b/src/renderer/src/utils/command-helpers.tsx
@@ -13,7 +13,7 @@
  */
 
 import React from 'react';
-import { Search, Power, Settings, Puzzle, Sparkles, FileText, Mic, Volume2, Brain, TerminalSquare, RefreshCw, LayoutGrid, Lock, Trash2 } from 'lucide-react';
+import { Search, Power, Settings, Puzzle, Sparkles, FileText, Mic, Volume2, Brain, TerminalSquare, RefreshCw, LayoutGrid, Lock, Trash2, Store } from 'lucide-react';
 import type { CommandInfo, EdgeTtsVoice } from '../../types/electron';
 import supercmdLogo from '../../../../supercmd.svg';
 import IconCalendar from '../icons/Calendar';
@@ -1096,6 +1096,14 @@ export function getSystemCommandFallbackIcon(commandId: string): React.ReactNode
     return (
       <div className="w-5 h-5 rounded bg-indigo-500/20 flex items-center justify-center">
         <Volume2 className="w-3 h-3 text-indigo-200" />
+      </div>
+    );
+  }
+
+  if (commandId === 'system-open-extension-store') {
+    return (
+      <div className="w-5 h-5 rounded bg-purple-500/20 flex items-center justify-center">
+        <Store className="w-3 h-3 text-purple-300" />
       </div>
     );
   }


### PR DESCRIPTION
Adds a dedicated "Extension Store" command so users can open the extension store window directly from the launcher instead of going through the Extensions settings page first.

Closes #258