### PR TITLE
fix: don't add + between modifier keys in shortcut display

### DIFF
--- a/src/renderer/src/utils/hyper-key.ts
+++ b/src/renderer/src/utils/hyper-key.ts
@@ -6,22 +6,37 @@ export function collapseHyperShortcut(shortcut: string): string {
 
 export function formatShortcutForDisplay(shortcut: string): string {
   const collapsed = collapseHyperShortcut(shortcut);
-  return collapsed
-    .split('+')
-    .map((token) => {
-      const value = String(token || '').trim();
-      if (!value) return value;
-      if (/^hyper$/i.test(value) || value === '✦') return '✦';
-      if (/^(command|cmd)$/i.test(value)) return '⌘';
-      if (/^(control|ctrl)$/i.test(value)) return '⌃';
-      if (/^(alt|option)$/i.test(value)) return '⌥';
-      if (/^shift$/i.test(value)) return '⇧';
-      if (/^(function|fn)$/i.test(value)) return 'fn';
-      if (/^arrowup$/i.test(value)) return '↑';
-      if (/^arrowdown$/i.test(value)) return '↓';
-      if (/^(backspace|delete)$/i.test(value)) return '⌫';
-      if (/^period$/i.test(value)) return '.';
-      return value.length === 1 ? value.toUpperCase() : value;
-    })
-    .join(' + ');
+  const parts = collapsed.split('+').map((token) => {
+    const value = String(token || '').trim();
+    if (!value) return value;
+    if (/^hyper$/i.test(value) || value === '✦') return '✦';
+    if (/^(command|cmd)$/i.test(value)) return '⌘';
+    if (/^(control|ctrl)$/i.test(value)) return '⌃';
+    if (/^(alt|option)$/i.test(value)) return '⌥';
+    if (/^shift$/i.test(value)) return '⇧';
+    if (/^(function|fn)$/i.test(value)) return 'fn';
+    if (/^arrowup$/i.test(value)) return '↑';
+    if (/^arrowdown$/i.test(value)) return '↓';
+    if (/^(backspace|delete)$/i.test(value)) return '⌫';
+    if (/^period$/i.test(value)) return '.';
+    return value.length === 1 ? value.toUpperCase() : value;
+  });
+
+  const modifierSymbols = new Set(['⌘', '⌃', '⌥', '⇧', '✦', 'fn']);
+  const modifiers: string[] = [];
+  const keys: string[] = [];
+
+  for (const part of parts) {
+    if (modifierSymbols.has(part)) {
+      modifiers.push(part);
+    } else if (part) {
+      keys.push(part);
+    }
+  }
+
+  const modifierStr = modifiers.join('');
+  const keyStr = keys.join('+');
+
+  if (modifierStr && keyStr) return modifierStr + '+' + keyStr;
+  return modifierStr || keyStr;
 }


### PR DESCRIPTION
Fixes #268

Modifier symbols (⌘⌃⌥⇧✦fn) are now concatenated directly without `+` separators, with `+` placed only before the final non-modifier key.

Generated with [Claude Code](https://claude.ai/code)