### PR TITLE
feat: display alias badge and hotkey shortcut in command list

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -52,6 +52,7 @@ import {
   getCommandTypeBadgeLabel,
   renderShortcutLabel,
   matchesLauncherShortcut,
+  getShortcutDisplayParts,
 } from './utils/command-helpers';
 import {
   readJsonObject, writeJsonObject,
@@ -322,6 +323,7 @@ const App: React.FC = () => {
   const { t } = useI18n();
   const [commands, setCommands] = useState<CommandInfo[]>([]);
   const [commandAliases, setCommandAliases] = useState<Record<string, string>>({});
+  const [commandHotkeys, setCommandHotkeys] = useState<Record<string, string>>({});
   const [pinnedCommands, setPinnedCommands] = useState<string[]>([]);
   const [pinnedFiles, setPinnedFiles] = useState<string[]>([]);
   const [recentCommands, setRecentCommands] = useState<string[]>([]);
@@ -576,6 +578,15 @@ const App: React.FC = () => {
           return acc;
         }, {} as Record<string, string>)
       );
+      setCommandHotkeys(
+        Object.entries(settings.commandHotkeys || {}).reduce((acc, [commandId, hotkey]) => {
+          const normalizedCommandId = String(commandId || '').trim();
+          const normalizedHotkey = String(hotkey || '').trim();
+          if (!normalizedCommandId || !normalizedHotkey) return acc;
+          acc[normalizedCommandId] = normalizedHotkey;
+          return acc;
+        }, {} as Record<string, string>)
+      );
       setLauncherShortcut(settings.globalShortcut || 'Alt+Space');
       const speakToggleHotkey = settings.commandHotkeys?.['system-supercmd-whisper-speak-toggle'] ?? '';
       setWhisperSpeakToggleLabel(formatShortcutLabel(speakToggleHotkey));
@@ -609,6 +620,7 @@ const App: React.FC = () => {
       setRecentCommands([]);
       setRecentCommandLaunchCounts({});
       setCommandAliases({});
+      setCommandHotkeys({});
       setLauncherShortcut('Alt+Space');
       setConfiguredEdgeTtsVoice('en-US-EricNeural');
       setConfiguredTtsModel('edge-tts');
@@ -4018,10 +4030,8 @@ const App: React.FC = () => {
                       const typeBadgeLabel = getCommandTypeBadgeLabel(command, t);
                       const fallbackCategory = getCategoryLabel(command.category, t);
                       const commandAlias = String(commandAliases[command.id] || '').trim();
-                      const aliasMatchesSearch =
-                        Boolean(commandAlias) &&
-                        Boolean(searchQuery.trim()) &&
-                        commandAlias.toLowerCase().includes(searchQuery.trim().toLowerCase());
+                      const commandHotkey = String(commandHotkeys[command.id] || '').trim();
+                      const hotkeyParts = commandHotkey ? getShortcutDisplayParts(commandHotkey) : [];
                       acc.nodes.push(
                         <div
                           key={command.id}
@@ -4061,7 +4071,7 @@ const App: React.FC = () => {
                                   {fallbackCategory}
                                 </div>
                               )}
-                              {aliasMatchesSearch ? (
+                              {commandAlias ? (
                                 <div className="inline-flex items-center h-5 rounded-md border border-[var(--launcher-chip-border)] bg-[var(--launcher-chip-bg)] px-1.5 text-[0.625rem] font-mono text-[var(--text-subtle)] leading-none flex-shrink-0">
                                   {commandAlias}
                                 </div>
@@ -4072,12 +4082,20 @@ const App: React.FC = () => {
                                 {typeBadgeLabel}
                               </div>
                             ) : null}
-                            {flatIndex < 9 && (
+                            {hotkeyParts.length > 0 ? (
+                              <span className="inline-flex items-center gap-0.5 flex-shrink-0">
+                                {hotkeyParts.map((part, idx) => (
+                                  <kbd key={idx} className="inline-flex items-center justify-center min-w-[18px] h-[18px] rounded bg-[var(--kbd-bg)] px-1 text-[10px] font-medium text-[var(--text-muted)]">
+                                    {part}
+                                  </kbd>
+                                ))}
+                              </span>
+                            ) : flatIndex < 9 ? (
                               <span className="inline-flex items-center gap-0.5 flex-shrink-0">
                                 <kbd className="inline-flex items-center justify-center w-[18px] h-[18px] rounded bg-[var(--kbd-bg)] text-[10px] font-medium text-[var(--text-muted)]">⌘</kbd>
                                 <kbd className="inline-flex items-center justify-center w-[18px] h-[18px] rounded bg-[var(--kbd-bg)] text-[10px] font-medium text-[var(--text-muted)]">{flatIndex + 1}</kbd>
                               </span>
-                            )}
+                            ) : null}
                           </div>
                         </div>
                       );

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4076,26 +4076,27 @@ const App: React.FC = () => {
                                   {commandAlias}
                                 </div>
                               ) : null}
+                              {hotkeyParts.length > 0 ? (
+                                <span className="inline-flex items-center gap-0.5 flex-shrink-0">
+                                  {hotkeyParts.map((part, idx) => (
+                                    <kbd key={idx} className="inline-flex items-center justify-center min-w-[18px] h-[18px] rounded bg-[var(--kbd-bg)] px-1 text-[10px] font-medium text-[var(--text-muted)]">
+                                      {part}
+                                    </kbd>
+                                  ))}
+                                </span>
+                              ) : null}
                             </div>
                             {typeBadgeLabel ? (
                               <div className="text-[var(--text-muted)] text-[0.6875rem] font-medium leading-none flex-shrink-0 truncate">
                                 {typeBadgeLabel}
                               </div>
                             ) : null}
-                            {hotkeyParts.length > 0 ? (
-                              <span className="inline-flex items-center gap-0.5 flex-shrink-0">
-                                {hotkeyParts.map((part, idx) => (
-                                  <kbd key={idx} className="inline-flex items-center justify-center min-w-[18px] h-[18px] rounded bg-[var(--kbd-bg)] px-1 text-[10px] font-medium text-[var(--text-muted)]">
-                                    {part}
-                                  </kbd>
-                                ))}
-                              </span>
-                            ) : flatIndex < 9 ? (
+                            {flatIndex < 9 && (
                               <span className="inline-flex items-center gap-0.5 flex-shrink-0">
                                 <kbd className="inline-flex items-center justify-center w-[18px] h-[18px] rounded bg-[var(--kbd-bg)] text-[10px] font-medium text-[var(--text-muted)]">⌘</kbd>
                                 <kbd className="inline-flex items-center justify-center w-[18px] h-[18px] rounded bg-[var(--kbd-bg)] text-[10px] font-medium text-[var(--text-muted)]">{flatIndex + 1}</kbd>
                               </span>
-                            ) : null}
+                            )}
                           </div>
                         </div>
                       );

--- a/src/renderer/src/utils/command-helpers.tsx
+++ b/src/renderer/src/utils/command-helpers.tsx
@@ -1185,6 +1185,36 @@ export function renderShortcutLabel(shortcut?: string): string {
   return formatShortcutForDisplay(shortcut).replace(/ \+ /g, ' ');
 }
 
+/**
+ * Split a hotkey string (e.g. "Command+Shift+L") into individual display symbols
+ * (e.g. ["⌘", "⇧", "L"]) so each part can be rendered as a separate kbd badge.
+ */
+export function getShortcutDisplayParts(shortcut: string): string[] {
+  if (!shortcut) return [];
+  const parts = String(shortcut).split('+').map((token) => {
+    const value = String(token || '').trim();
+    if (!value) return '';
+    if (/^hyper$/i.test(value) || value === '✦') return '✦';
+    if (/^(command|cmd)$/i.test(value)) return '⌘';
+    if (/^(control|ctrl)$/i.test(value)) return '⌃';
+    if (/^(alt|option)$/i.test(value)) return '⌥';
+    if (/^shift$/i.test(value)) return '⇧';
+    if (/^(function|fn)$/i.test(value)) return 'fn';
+    if (/^arrowup$/i.test(value)) return '↑';
+    if (/^arrowdown$/i.test(value)) return '↓';
+    if (/^arrowleft$/i.test(value)) return '←';
+    if (/^arrowright$/i.test(value)) return '→';
+    if (/^(backspace|delete)$/i.test(value)) return '⌫';
+    if (/^period$/i.test(value)) return '.';
+    if (/^return$/i.test(value)) return '↩';
+    if (/^escape$/i.test(value)) return '⎋';
+    if (/^space$/i.test(value)) return '␣';
+    if (/^tab$/i.test(value)) return '⇥';
+    return value.length === 1 ? value.toUpperCase() : value;
+  });
+  return parts.filter(Boolean);
+}
+
 export function parseIntervalToMs(interval?: string): number | null {
   if (!interval) return null;
   const trimmed = interval.trim();


### PR DESCRIPTION
Closes #267

## Summary

- Alias badge now always shown when set (previously only when alias matched search query)
- Hotkey keys shown as individual `kbd` badges on right side when a global shortcut is assigned
- Both light and dark mode handled via existing CSS variables

Generated with [Claude Code](https://claude.ai/code)