### PR TITLE
feat: add compact launcher mode

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1840,6 +1840,7 @@ async function getNodeSnapshot(): Promise<{ target: NodeWindowInfo | null; windo
 
 const DEFAULT_WINDOW_WIDTH = 760;
 const DEFAULT_WINDOW_HEIGHT = 480;
+const COMPACT_WINDOW_HEIGHT = 100;
 const ONBOARDING_WINDOW_WIDTH = 1120;
 const ONBOARDING_WINDOW_HEIGHT = 740;
 const CURSOR_PROMPT_WINDOW_WIDTH = 500;
@@ -7255,7 +7256,13 @@ function getLauncherSize(mode: LauncherMode) {
   if (mode === 'onboarding') {
     return { width: ONBOARDING_WINDOW_WIDTH, height: ONBOARDING_WINDOW_HEIGHT, topFactor: 0.12 };
   }
-  return { width: DEFAULT_WINDOW_WIDTH, height: DEFAULT_WINDOW_HEIGHT, topFactor: 0.2 };
+  const viewMode = loadSettings().launcherViewMode || 'expanded';
+  const height = viewMode === 'compact' ? COMPACT_WINDOW_HEIGHT : DEFAULT_WINDOW_HEIGHT;
+  return { width: DEFAULT_WINDOW_WIDTH, height, topFactor: 0.2 };
+}
+
+function getLauncherSizeForCompact(): { width: number; height: number; topFactor: number } {
+  return { width: DEFAULT_WINDOW_WIDTH, height: COMPACT_WINDOW_HEIGHT, topFactor: 0.2 };
 }
 
 function getTypingCaretRect():
@@ -11587,6 +11594,13 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('get-settings', () => {
     return loadSettings();
+  });
+
+  ipcMain.handle('resize-launcher-window', (_event: any, expanded: boolean) => {
+    if (!mainWindow) return;
+    const curBounds = mainWindow.getBounds();
+    const targetHeight = expanded ? DEFAULT_WINDOW_HEIGHT : COMPACT_WINDOW_HEIGHT;
+    mainWindow.setBounds({ x: curBounds.x, y: curBounds.y, width: curBounds.width, height: targetHeight });
   });
 
   ipcMain.handle('get-global-shortcut-status', () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -55,6 +55,7 @@ const electronAPI = {
   executeCommandFromWidget: (commandId: string): Promise<boolean> =>
     ipcRenderer.invoke('execute-command-from-widget', commandId),
   hideWindow: (): Promise<void> => ipcRenderer.invoke('hide-window'),
+  resizeLauncherWindow: (expanded: boolean): Promise<void> => ipcRenderer.invoke('resize-launcher-window', expanded),
   showWindow: (): Promise<void> => ipcRenderer.invoke('show-window'),
   activateLastFrontmostApp: (): Promise<void> => ipcRenderer.invoke('activate-last-frontmost-app'),
   reportNoViewStatus: (variant: 'processing' | 'success' | 'error', text: string): Promise<void> =>

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -57,6 +57,7 @@ export interface HyperKeySettings {
 
 export type AppFontSize = 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large';
 export type AppUiStyle = 'default' | 'glassy';
+export type LauncherViewMode = 'expanded' | 'compact';
 export type AppLanguage =
   | 'system'
   | 'en'
@@ -99,6 +100,7 @@ export interface AppSettings {
   appUpdaterLastCheckedAt: number;
   updateBannerDismissedAt?: number;
   hyperKey: HyperKeySettings;
+  launcherViewMode: LauncherViewMode;
 }
 
 const DEFAULT_HYPER_KEY_SETTINGS: HyperKeySettings = {
@@ -184,6 +186,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   launcherBackgroundImageOpacityPercent: 45,
   appUpdaterLastCheckedAt: 0,
   hyperKey: { ...DEFAULT_HYPER_KEY_SETTINGS },
+  launcherViewMode: 'expanded',
 };
 
 let settingsCache: AppSettings | null = null;
@@ -380,6 +383,7 @@ export function loadSettings(): AppSettings {
       appUpdaterLastCheckedAt: Number.isFinite(Number(parsed.appUpdaterLastCheckedAt))
         ? Math.max(0, Number(parsed.appUpdaterLastCheckedAt))
         : DEFAULT_SETTINGS.appUpdaterLastCheckedAt,
+      launcherViewMode: (parsed.launcherViewMode === 'compact' ? 'compact' : 'expanded'),
     };
   } catch {
     settingsCache = { ...DEFAULT_SETTINGS };

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,7 +7,8 @@
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { X, Sparkles, ArrowRight, CornerDownLeft, ExternalLink, Plus, Pencil, Files, Trash2 } from 'lucide-react';
+import { X, Sparkles, ArrowRight, ArrowDown, CornerDownLeft, ExternalLink, Plus, Pencil, Files, Trash2 } from 'lucide-react';
+import supercmdLogo from '../../../supercmd.png';
 import type {
   CommandInfo,
   ExtensionBundle,
@@ -2322,6 +2323,8 @@ const App: React.FC = () => {
       contextMenu,
       showActions,
       quickLinkDynamicPrompt,
+      launcherViewMode,
+      isCompactCollapsed,
     ]
   );
 
@@ -3794,10 +3797,16 @@ const App: React.FC = () => {
                 placeholder={aiMode ? t('launcher.aiMode.placeholder') : t('launcher.searchPlaceholder')}
                 value={searchQuery}
                 onChange={(e) => {
-                  setSearchQuery(e.target.value);
-                  if (launcherViewMode === 'compact' && isCompactCollapsed && e.target.value.length > 0) {
-                    setIsCompactCollapsed(false);
-                    window.electron.resizeLauncherWindow(true);
+                  const value = e.target.value;
+                  setSearchQuery(value);
+                  if (launcherViewMode === 'compact') {
+                    if (isCompactCollapsed && value.length > 0) {
+                      setIsCompactCollapsed(false);
+                      window.electron.resizeLauncherWindow(true);
+                    } else if (!isCompactCollapsed && value.length === 0) {
+                      setIsCompactCollapsed(true);
+                      window.electron.resizeLauncherWindow(false);
+                    }
                   }
                 }}
                 onBlur={handleLauncherSearchBlur}
@@ -3939,11 +3948,13 @@ const App: React.FC = () => {
             }}
           >
             <div className="flex items-center gap-2 text-[var(--text-muted)]">
-              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/><path d="m9 12 2 2 4-4"/></svg>
+              <img src={supercmdLogo} alt="SuperCmd" className="w-4 h-4" />
             </div>
             <div className="flex items-center gap-1.5 text-[var(--text-muted)]">
               <span className="text-xs font-medium">{t('launcher.compact.showMore')}</span>
-              <kbd className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded bg-[var(--kbd-bg)] text-[0.625rem] text-[var(--text-subtle)] font-medium">↓</kbd>
+              <kbd className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded bg-[var(--kbd-bg)] text-[var(--text-subtle)]">
+                <ArrowDown className="w-3 h-3" />
+              </kbd>
             </div>
           </div>
         )}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -348,6 +348,8 @@ const App: React.FC = () => {
   >({});
   const [launcherFileResults, setLauncherFileResults] = useState<IndexedFileSearchResult[]>([]);
   const [disableFileSearchResults, setDisableFileSearchResults] = useState(false);
+  const [launcherViewMode, setLauncherViewMode] = useState<'expanded' | 'compact'>('expanded');
+  const [isCompactCollapsed, setIsCompactCollapsed] = useState(true);
   const [launcherFileIcons, setLauncherFileIcons] = useState<Record<string, string>>({});
   const [fileIsDirectoryMap, setFileIsDirectoryMap] = useState<Record<string, boolean>>({});
   const [launcherFooterStatus, setLauncherFooterStatus] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
@@ -609,6 +611,7 @@ const App: React.FC = () => {
         )
       );
       setDisableFileSearchResults(Boolean(settings.disableFileSearchResults));
+      setLauncherViewMode(settings.launcherViewMode || 'expanded');
       applyAppFontSize(settings.fontSize);
       applyUiStyle(settings.uiStyle || 'default');
       applyBaseColor(settings.baseColor || '#101113');
@@ -892,6 +895,7 @@ const App: React.FC = () => {
       }
       setSearchQuery(pendingQuery ?? '');
       setSelectedIndex(0);
+      setIsCompactCollapsed(true);
       exitAiMode();
       setShowClipboardManager(false);
       setShowSnippetManager(null);
@@ -2235,6 +2239,11 @@ const App: React.FC = () => {
 
         case 'ArrowDown':
           e.preventDefault();
+          if (launcherViewMode === 'compact' && isCompactCollapsed) {
+            setIsCompactCollapsed(false);
+            window.electron.resizeLauncherWindow(true);
+            break;
+          }
           moveSelection('down');
           break;
 
@@ -2271,6 +2280,15 @@ const App: React.FC = () => {
           if (searchQuery.length > 0) {
             setSearchQuery('');
             setSelectedIndex(0);
+            if (launcherViewMode === 'compact') {
+              setIsCompactCollapsed(true);
+              window.electron.resizeLauncherWindow(false);
+            }
+            return;
+          }
+          if (launcherViewMode === 'compact' && !isCompactCollapsed) {
+            setIsCompactCollapsed(true);
+            window.electron.resizeLauncherWindow(false);
             return;
           }
           window.electron.hideWindow();
@@ -3775,7 +3793,13 @@ const App: React.FC = () => {
                 type="text"
                 placeholder={aiMode ? t('launcher.aiMode.placeholder') : t('launcher.searchPlaceholder')}
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => {
+                  setSearchQuery(e.target.value);
+                  if (launcherViewMode === 'compact' && isCompactCollapsed && e.target.value.length > 0) {
+                    setIsCompactCollapsed(false);
+                    window.electron.resizeLauncherWindow(true);
+                  }
+                }}
                 onBlur={handleLauncherSearchBlur}
                 onKeyDown={handleKeyDown}
                 className="launcher-search-input min-w-0 w-full bg-transparent border-none outline-none text-[var(--text-primary)] placeholder:text-[color:var(--text-muted)] placeholder:font-medium text-[0.9375rem] font-medium tracking-[0.005em]"
@@ -3905,10 +3929,30 @@ const App: React.FC = () => {
           </div>
         </div>
 
+        {/* Compact mode: Show More row */}
+        {launcherViewMode === 'compact' && isCompactCollapsed && (
+          <div
+            className="flex items-center justify-between px-4 py-2 cursor-pointer hover:bg-[var(--ui-segment-hover-bg)] transition-colors border-t border-[var(--ui-divider)]"
+            onClick={() => {
+              setIsCompactCollapsed(false);
+              window.electron.resizeLauncherWindow(true);
+            }}
+          >
+            <div className="flex items-center gap-2 text-[var(--text-muted)]">
+              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/><path d="m9 12 2 2 4-4"/></svg>
+            </div>
+            <div className="flex items-center gap-1.5 text-[var(--text-muted)]">
+              <span className="text-xs font-medium">{t('launcher.compact.showMore')}</span>
+              <kbd className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded bg-[var(--kbd-bg)] text-[0.625rem] text-[var(--text-subtle)] font-medium">↓</kbd>
+            </div>
+          </div>
+        )}
+
         {/* Command list */}
         <div
           ref={listRef}
           className="flex-1 overflow-y-auto custom-scrollbar p-1.5 list-area"
+          style={launcherViewMode === 'compact' && isCompactCollapsed ? { display: 'none' } : undefined}
         >
           {isLoading ? (
             <div className="flex items-center justify-center h-full text-[var(--text-muted)]">
@@ -4114,7 +4158,7 @@ const App: React.FC = () => {
         </div>
         
         {/* Footer actions */}
-        {!isLoading && (
+        {!isLoading && !(launcherViewMode === 'compact' && isCompactCollapsed) && (
           <div
             className="sc-glass-footer sc-launcher-footer absolute bottom-0 left-0 right-0 z-10 flex items-center px-4 py-2.5"
           >

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -757,6 +757,11 @@ const App: React.FC = () => {
         return;
       }
       if (routedSystemCommandId) {
+        // Launching directly into a command/extension via hotkey should bypass
+        // compact mode — expand the launcher so the command UI is visible
+        // instead of the compact search-only chrome.
+        setIsCompactCollapsed(false);
+        window.electron.resizeLauncherWindow(true);
         whisperSessionRef.current = false;
         setShowCursorPrompt(false);
         setShowWhisperHint(false);
@@ -896,7 +901,15 @@ const App: React.FC = () => {
       }
       setSearchQuery(pendingQuery ?? '');
       setSelectedIndex(0);
-      setIsCompactCollapsed(true);
+      // When a pending query is pre-filled (e.g. hotkey-triggered no-view
+      // command with missing args), expand out of compact so results are
+      // immediately visible.
+      if (pendingQuery) {
+        setIsCompactCollapsed(false);
+        window.electron.resizeLauncherWindow(true);
+      } else {
+        setIsCompactCollapsed(true);
+      }
       exitAiMode();
       setShowClipboardManager(false);
       setShowSnippetManager(null);
@@ -1027,6 +1040,9 @@ const App: React.FC = () => {
       }
 
       if (shouldOpenCommandSetup(hydrated)) {
+        // Launching into a setup form via hotkey must bypass compact mode.
+        setIsCompactCollapsed(false);
+        window.electron.resizeLauncherWindow(true);
         setShowFileSearch(false);
         setExtensionPreferenceSetup({
           bundle: hydrated,
@@ -1036,6 +1052,11 @@ const App: React.FC = () => {
       } else if (hydrated.mode === 'no-view') {
         queueNoViewBundleRun(hydrated, 'userInitiated');
       } else {
+        // Launching directly into a view/form command via hotkey must bypass
+        // compact mode so the extension UI is visible instead of the compact
+        // search-only chrome.
+        setIsCompactCollapsed(false);
+        window.electron.resizeLauncherWindow(true);
         setShowFileSearch(false);
         setExtensionView(hydrated);
       }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -131,6 +131,12 @@
         "default": "Default",
         "glassy": "Glassy"
       },
+      "launcherMode": {
+        "title": "Launcher Mode",
+        "description": "Choose how the launcher appears when opened.",
+        "expanded": "Expanded",
+        "compact": "Compact"
+      },
       "background": {
         "title": "Launcher Background Image",
         "description": "Show a softly blurred, low-opacity image behind the launcher so it reads like a hint, not a full wallpaper.",
@@ -580,6 +586,9 @@
   },
   "launcher": {
     "searchPlaceholder": "Search for apps, commands, or ask AI...",
+    "compact": {
+      "showMore": "Show More"
+    },
     "status": {
       "discoveringApps": "Discovering apps...",
       "noMatchingResults": "No matching results",

--- a/src/renderer/src/settings/GeneralTab.tsx
+++ b/src/renderer/src/settings/GeneralTab.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState, useEffect, useMemo } from 'react';
-import { Keyboard, Info, RefreshCw, Download, RotateCcw, Type, Sun, Moon, SunMoon, Sparkles, Image, Trash2, SlidersHorizontal, ChevronDown, ChevronUp, Power } from 'lucide-react';
+import { Keyboard, Info, RefreshCw, Download, RotateCcw, Type, Sun, Moon, SunMoon, Sparkles, Image, Trash2, SlidersHorizontal, ChevronDown, ChevronUp, Power, PanelTop } from 'lucide-react';
 import HotkeyRecorder from './HotkeyRecorder';
 import type { AppSettings, AppUpdaterStatus } from '../../types/electron';
 import { applyAppFontSize, getDefaultAppFontSize } from '../utils/font-size';
@@ -90,6 +90,7 @@ const GeneralTab: React.FC = () => {
   const [shortcutStatus, setShortcutStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [themePreference, setThemePreference] = useState<ThemePreference>(() => getThemePreference());
   const [uiStyle, setUiStyle] = useState<UiStylePreference>('default');
+  const [launcherViewMode, setLauncherViewMode] = useState<'expanded' | 'compact'>('expanded');
   const [launcherBackgroundBusy, setLauncherBackgroundBusy] = useState(false);
   const [launcherBackgroundControlsExpanded, setLauncherBackgroundControlsExpanded] = useState(false);
 
@@ -102,6 +103,7 @@ const GeneralTab: React.FC = () => {
         fontSize: normalizedFontSize,
       });
       setUiStyle(normalizeUiStyle(nextSettings.uiStyle));
+      setLauncherViewMode(nextSettings.launcherViewMode || 'expanded');
     });
   }, []);
 
@@ -113,6 +115,7 @@ const GeneralTab: React.FC = () => {
         fontSize: normalizedFontSize,
       });
       setUiStyle(normalizeUiStyle(nextSettings.uiStyle));
+      setLauncherViewMode(nextSettings.launcherViewMode || 'expanded');
     });
     return cleanup;
   }, []);
@@ -491,6 +494,46 @@ const GeneralTab: React.FC = () => {
                   key={option.id}
                   type="button"
                   onClick={() => void handleUiStyleChange(option.id)}
+                  className={`px-3 py-1.5 rounded-md text-[0.75rem] font-semibold transition-colors ${
+                    active
+                      ? 'bg-[var(--ui-segment-active-bg)] text-[var(--text-primary)]'
+                      : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--ui-segment-hover-bg)]'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          icon={<PanelTop className="w-4 h-4" />}
+          title={t('settings.general.launcherMode.title')}
+          description={t('settings.general.launcherMode.description')}
+        >
+          <div className="inline-flex items-center gap-0.5 rounded-lg border border-[var(--ui-divider)] bg-[var(--ui-segment-bg)] p-0.5">
+            {([
+              { id: 'expanded' as const, label: t('settings.general.launcherMode.expanded') },
+              { id: 'compact' as const, label: t('settings.general.launcherMode.compact') },
+            ]).map((option) => {
+              const active = launcherViewMode === option.id;
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={async () => {
+                    if (!settings) return;
+                    const prev = launcherViewMode;
+                    setLauncherViewMode(option.id);
+                    setSettings((s) => (s ? { ...s, launcherViewMode: option.id } : s));
+                    try {
+                      await window.electron.saveSettings({ launcherViewMode: option.id });
+                    } catch {
+                      setLauncherViewMode(prev);
+                      setSettings((s) => (s ? { ...s, launcherViewMode: prev } : s));
+                    }
+                  }}
                   className={`px-3 py-1.5 rounded-md text-[0.75rem] font-semibold transition-colors ${
                     active
                       ? 'bg-[var(--ui-segment-active-bg)] text-[var(--text-primary)]'

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -291,6 +291,7 @@ export interface AppSettings {
   launcherBackgroundImageOpacityPercent: number;
   appUpdaterLastCheckedAt: number;
   hyperKey: HyperKeySettings;
+  launcherViewMode: 'expanded' | 'compact';
 }
 
 export interface CatalogEntry {
@@ -430,6 +431,7 @@ export interface ElectronAPI {
   executeCommandAsHotkey: (commandId: string) => Promise<boolean>;
   executeCommandFromWidget: (commandId: string) => Promise<boolean>;
   hideWindow: () => Promise<void>;
+  resizeLauncherWindow: (expanded: boolean) => Promise<void>;
   showWindow: () => Promise<void>;
   activateLastFrontmostApp: () => Promise<void>;
   reportNoViewStatus: (variant: 'processing' | 'success' | 'error', text: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- Adds a compact launcher mode that shows only the search bar when opened, with a "Show More" row to expand
- New setting in Settings > General: "Launcher Mode" toggle (Expanded / Compact)
- Arrow down, clicking "Show More", or typing auto-expands to full view; Escape collapses back

# Screenshots

<img width="1214" height="773" alt="SCR-20260418-lqix" src="https://github.com/user-attachments/assets/00b48bb7-cfb3-497c-b51a-eb93fc808845" />

<img width="1214" height="773" alt="SCR-20260418-lqta" src="https://github.com/user-attachments/assets/d4bd6b79-4430-4a21-9eb8-5bc3f0fd130a" />



## Test plan
- [ ] Open Settings > General, verify "Launcher Mode" toggle appears after "Visual Style"
- [ ] Set to "Compact", reopen launcher — should show only search bar + "Show More" row
- [ ] Press ↓ or click "Show More" — expands to full results
- [ ] Type a query in compact mode — auto-expands
- [ ] Press Escape — collapses back to compact; second Escape hides window
- [ ] Set back to "Expanded" — launcher opens at full height as before