### PR TITLE
Add dictation mic button to search bar (fixes #251)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { X, Sparkles, ArrowRight, CornerDownLeft } from 'lucide-react';
+import { X, Sparkles, ArrowRight, CornerDownLeft, Mic } from 'lucide-react';
 import type {
   CommandInfo,
   ExtensionBundle,
@@ -3443,6 +3443,15 @@ const App: React.FC = () => {
                 <Sparkles className="w-3 h-3 text-white/30 group-hover:text-purple-400 transition-colors" />
                 <span className="text-[0.6875rem] text-white/30 group-hover:text-white/50 transition-colors">Ask AI</span>
                 <kbd className="text-[0.625rem] text-white/20 bg-[var(--soft-pill-bg)] px-1 py-0.5 rounded font-mono leading-none">Tab</kbd>
+              </button>
+            )}
+            {aiAvailable && (
+              <button
+                onClick={() => void runLocalSystemCommand('system-supercmd-whisper')}
+                title="Dictate"
+                className={`transition-colors flex-shrink-0 ${showWhisper ? 'text-red-400 hover:text-red-300' : 'text-[var(--text-subtle)] hover:text-[var(--text-muted)]'}`}
+              >
+                <Mic className="w-4 h-4" />
               </button>
             )}
             {searchQuery && (


### PR DESCRIPTION
## Summary

- Adds a microphone icon button to the launcher search header
- Clicking it triggers the existing Whisper STT system (`system-supercmd-whisper`)
- Button turns red while dictation is active to indicate recording state
- Button is only shown when AI is enabled (same gate as the Whisper feature)

## Test plan

- [ ] Open SuperCmd with AI enabled — mic button should appear in search bar
- [ ] Click mic button — Whisper dictation overlay should open
- [ ] While dictating, button should be red
- [ ] After stopping, button returns to default subtle color
- [ ] With AI disabled in settings, button should not appear

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)