### PR TITLE
Fix whisper dictation closing launcher when triggered from within SuperCmd (fixes #251)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -13370,6 +13370,13 @@ if let tiff = image?.tiffRepresentation {
       return { typed: false, fallbackClipboard: false };
     }
 
+    // If the launcher is currently visible, insert text directly into the
+    // focused input in the renderer instead of switching to another app.
+    if (isVisible && mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('whisper-insert-into-launcher', nextText);
+      return { typed: true, fallbackClipboard: false };
+    }
+
     await activateLastFrontmostApp();
     await new Promise((resolve) => setTimeout(resolve, 70));
     let typed = await pasteTextToActiveApp(nextText);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -114,6 +114,13 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.removeListener('whisper-toggle-listening', listener);
     };
   },
+  onWhisperInsertIntoLauncher: (callback: (text: string) => void) => {
+    const listener = (_event: any, text: string) => callback(text);
+    ipcRenderer.on('whisper-insert-into-launcher', listener);
+    return () => {
+      ipcRenderer.removeListener('whisper-insert-into-launcher', listener);
+    };
+  },
   onOAuthCallback: (callback: (url: string) => void) => {
     const listener = (_event: any, url: string) => callback(url);
     ipcRenderer.on('oauth-callback', listener);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { X, Sparkles, ArrowRight, CornerDownLeft } from 'lucide-react';
+import { X, Sparkles, ArrowRight, CornerDownLeft, Mic } from 'lucide-react';
 import type {
   CommandInfo,
   ExtensionBundle,
@@ -3443,6 +3443,15 @@ const App: React.FC = () => {
                 <Sparkles className="w-3 h-3 text-white/30 group-hover:text-purple-400 transition-colors" />
                 <span className="text-[0.6875rem] text-white/30 group-hover:text-white/50 transition-colors">Ask AI</span>
                 <kbd className="text-[0.625rem] text-white/20 bg-[var(--soft-pill-bg)] px-1 py-0.5 rounded font-mono leading-none">Tab</kbd>
+              </button>
+            )}
+            {aiAvailable && (
+              <button
+                onClick={() => void runLocalSystemCommand('system-supercmd-whisper')}
+                title="Dictate"
+                className={`transition-colors flex-shrink-0 ${showWhisper ? 'text-red-400 hover:text-red-300' : 'text-[var(--text-subtle)] hover:text-[var(--text-muted)]'}`}
+              >
+                <Mic className="w-4 h-4" />
               </button>
             )}
             {searchQuery && (

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { X, Sparkles, ArrowRight, CornerDownLeft, Mic } from 'lucide-react';
+import { X, Sparkles, ArrowRight, CornerDownLeft } from 'lucide-react';
 import type {
   CommandInfo,
   ExtensionBundle,
@@ -846,6 +846,29 @@ const App: React.FC = () => {
       setSelectedTextSnapshot(String(payload?.selectedTextSnapshot || '').trim());
     });
     return cleanupSelectionSnapshotUpdated;
+  }, []);
+
+  // Insert whisper-transcribed text directly into the focused launcher input
+  // when dictation was triggered from within the visible launcher window.
+  useEffect(() => {
+    const dispose = window.electron.onWhisperInsertIntoLauncher((text) => {
+      const activeEl = document.activeElement as HTMLElement | null;
+      // If no input is focused or focus is on document/body, fall back to the search bar.
+      const targetEl = (activeEl && activeEl !== document.body)
+        ? activeEl
+        : inputRef.current;
+      if (targetEl) {
+        targetEl.focus();
+      }
+      // execCommand('insertText') inserts at cursor position and fires the
+      // input event that React's synthetic system picks up in Electron.
+      const inserted = document.execCommand('insertText', false, text);
+      if (!inserted && inputRef.current) {
+        // Fallback: append to search query state directly.
+        setSearchQuery((prev) => prev + text);
+      }
+    });
+    return dispose;
   }, []);
 
   useEffect(() => {
@@ -3443,15 +3466,6 @@ const App: React.FC = () => {
                 <Sparkles className="w-3 h-3 text-white/30 group-hover:text-purple-400 transition-colors" />
                 <span className="text-[0.6875rem] text-white/30 group-hover:text-white/50 transition-colors">Ask AI</span>
                 <kbd className="text-[0.625rem] text-white/20 bg-[var(--soft-pill-bg)] px-1 py-0.5 rounded font-mono leading-none">Tab</kbd>
-              </button>
-            )}
-            {aiAvailable && (
-              <button
-                onClick={() => void runLocalSystemCommand('system-supercmd-whisper')}
-                title="Dictate"
-                className={`transition-colors flex-shrink-0 ${showWhisper ? 'text-red-400 hover:text-red-300' : 'text-[var(--text-subtle)] hover:text-[var(--text-muted)]'}`}
-              >
-                <Mic className="w-4 h-4" />
               </button>
             )}
             {searchQuery && (

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -429,6 +429,7 @@ export interface ElectronAPI {
   onWhisperStartListening: (callback: () => void) => (() => void);
   onWhisperStopListening: (callback: () => void) => (() => void);
   onWhisperToggleListening: (callback: () => void) => (() => void);
+  onWhisperInsertIntoLauncher: (callback: (text: string) => void) => (() => void);
   onOAuthCallback: (callback: (url: string) => void) => (() => void);
   oauthGetToken: (provider: string) => Promise<{ accessToken: string; tokenType?: string; scope?: string; expiresIn?: number; obtainedAt: string } | null>;
   oauthSetToken: (provider: string, token: { accessToken: string; tokenType?: string; scope?: string; expiresIn?: number; obtainedAt: string }) => Promise<void>;


### PR DESCRIPTION
## Summary

- When Whisper dictation was triggered while the SuperCmd launcher was **visible**, the transcribed text was being routed to the previously frontmost external app via `activateLastFrontmostApp()` — switching focus away from SuperCmd and effectively closing it
- This affected the search bar, notes, canvas, and any other SuperCmd screen

## Root cause

`whisper-type-text-live` IPC handler always called `activateLastFrontmostApp()` before typing, regardless of whether the launcher was open. When launched from within SuperCmd, this switched focus to a different app.

## Fix

- In `main.ts`: if the launcher window is currently visible when `whisper-type-text-live` is called, send a `whisper-insert-into-launcher` event directly to the renderer instead of activating another app
- In `preload.ts` + `electron.d.ts`: expose `onWhisperInsertIntoLauncher` bridge
- In `App.tsx`: listen for `whisper-insert-into-launcher` and insert the transcribed text at the current cursor position using `document.execCommand('insertText')`, which works for the search bar, notes, canvas, and any focused contenteditable

## Test plan

- [ ] Open SuperCmd, trigger Whisper dictation — launcher should stay open and text should appear in the search bar
- [ ] Open Notes in SuperCmd, trigger dictation — text should be inserted into the notes editor
- [ ] Open Canvas, trigger dictation — text should be inserted at cursor
- [ ] When SuperCmd is **hidden** and dictation is triggered via global hotkey, text should still go to the previously active external app (existing behavior unchanged)

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)