### PR TITLE
notes: floating window + UX fixes + confirm-dialog dimming fix

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -15,7 +15,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { fork, type ChildProcess } from 'child_process';
 import { getAvailableCommands, executeCommand, invalidateCache } from './commands';
-import { loadSettings, saveSettings, setOAuthToken, getOAuthToken, removeOAuthToken, loadWindowState, saveWindowState, clearWindowState } from './settings-store';
+import { loadSettings, saveSettings, setOAuthToken, getOAuthToken, removeOAuthToken, loadWindowState, saveWindowState, clearWindowState, loadNotesWindowState, saveNotesWindowState } from './settings-store';
 import type { AppSettings } from './settings-store';
 import { streamAI, isAIAvailable, transcribeAudio } from './ai-provider';
 import * as soulverCalculator from './soulver-calculator';
@@ -10038,30 +10038,66 @@ function openNotesWindow(mode?: 'search' | 'create'): void {
     // Send mode + pending note JSON to the existing window
     notesWindow.webContents.send('notes-mode-changed', { mode: mode || 'create', noteJson: pendingNoteJson });
     pendingNoteJson = null;
+    // Re-assert cross-Space / fullscreen float — macOS can drop this flag
+    // across hide/show cycles, so reapply it defensively on every show.
+    try {
+      notesWindow.setVisibleOnAllWorkspaces(true, {
+        visibleOnFullScreen: true,
+        skipTransformProcessType: true,
+      } as any);
+    } catch {}
     notesWindow.show();
     notesWindow.focus();
     return;
   }
 
-  if (process.platform === 'darwin') {
-    app.dock.show();
-  }
+  // Note: intentionally NOT calling app.dock.show() here. On macOS,
+  // transformProcessType (triggered by dock.show) forces the app onto the
+  // primary Desktop Space, so opening Notes while a fullscreen app is
+  // active would cause macOS to Space-switch away from the fullscreen app.
+  // The floating setup below keeps Notes visible on the current Space —
+  // including the fullscreen Space — without a dock/process transform.
 
-  const { x: displayX, y: displayY, width: displayWidth, height: displayHeight } = (() => {
-    if (mainWindow) {
-      const b = mainWindow.getBounds();
-      const center = {
-        x: b.x + Math.floor(b.width / 2),
-        y: b.y + Math.floor(b.height / 2),
-      };
-      return screen.getDisplayNearestPoint(center).workArea;
-    }
-    return screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea;
-  })();
-  const notesWidth = Math.max(520, Math.min(680, displayWidth - 300));
-  const notesHeight = Math.max(420, Math.min(560, displayHeight - 250));
-  const notesX = displayX + Math.floor((displayWidth - notesWidth) / 2);
-  const notesY = displayY + Math.floor((displayHeight - notesHeight) / 2);
+  // Prefer persisted bounds from the last session if they still land on an
+  // attached display; otherwise fall back to the centered-default layout.
+  const savedNotesBounds = loadNotesWindowState();
+  const notesBoundsOnScreen = (b: { x: number; y: number; width: number; height: number }): boolean => {
+    const displays = screen.getAllDisplays();
+    const cx = b.x + b.width / 2;
+    const cy = b.y + b.height / 2;
+    return displays.some((d: Electron.Display) => {
+      const wa = d.workArea;
+      return cx >= wa.x && cx <= wa.x + wa.width && cy >= wa.y && cy <= wa.y + wa.height;
+    });
+  };
+
+  let notesX: number;
+  let notesY: number;
+  let notesWidth: number;
+  let notesHeight: number;
+
+  if (savedNotesBounds && notesBoundsOnScreen(savedNotesBounds)) {
+    notesX = savedNotesBounds.x;
+    notesY = savedNotesBounds.y;
+    notesWidth = savedNotesBounds.width;
+    notesHeight = savedNotesBounds.height;
+  } else {
+    const { x: displayX, y: displayY, width: displayWidth, height: displayHeight } = (() => {
+      if (mainWindow) {
+        const b = mainWindow.getBounds();
+        const center = {
+          x: b.x + Math.floor(b.width / 2),
+          y: b.y + Math.floor(b.height / 2),
+        };
+        return screen.getDisplayNearestPoint(center).workArea;
+      }
+      return screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea;
+    })();
+    notesWidth = Math.max(520, Math.min(680, displayWidth - 300));
+    notesHeight = Math.max(420, Math.min(560, displayHeight - 250));
+    notesX = displayX + Math.floor((displayWidth - notesWidth) / 2);
+    notesY = displayY + Math.floor((displayHeight - notesHeight) / 2);
+  }
   const useNativeLiquidGlass = shouldUseNativeLiquidGlass();
 
   notesWindow = new BrowserWindow({
@@ -10079,6 +10115,7 @@ function openNotesWindow(mode?: 'search' | 'create'): void {
     visualEffectState: 'active',
     hasShadow: false,
     alwaysOnTop: true,
+    fullscreenable: false,
     show: false,
     webPreferences: {
       nodeIntegration: false,
@@ -10086,6 +10123,19 @@ function openNotesWindow(mode?: 'search' | 'create'): void {
       preload: path.join(__dirname, 'preload.js'),
     },
   });
+  // Make Notes follow the user across Desktop Spaces and overlay fullscreen
+  // apps — mirrors the launcher / cursor prompt / memory status bar pattern.
+  // 'pop-up-menu' level is required to sit above native macOS fullscreen apps;
+  // the lower 'floating' level gets covered by fullscreen windows.
+  // skipTransformProcessType prevents a Space-switch when called while a
+  // fullscreen app is active.
+  try {
+    notesWindow.setVisibleOnAllWorkspaces(true, {
+      visibleOnFullScreen: true,
+      skipTransformProcessType: true,
+    } as any);
+  } catch {}
+  try { notesWindow.setAlwaysOnTop(true, 'pop-up-menu'); } catch {}
   applyLiquidGlassToWindow(notesWindow, {
     cornerRadius: 14,
     fallbackVibrancy: 'hud',
@@ -10099,6 +10149,27 @@ function openNotesWindow(mode?: 'search' | 'create'): void {
 
   notesWindow.once('ready-to-show', () => {
     notesWindow?.show();
+  });
+
+  // Persist window position/size so Notes reopens where the user left it.
+  // Debounce move/resize events so we don't rewrite the JSON on every pixel.
+  let notesPersistTimer: NodeJS.Timeout | null = null;
+  const persistNotesBounds = () => {
+    if (notesPersistTimer) clearTimeout(notesPersistTimer);
+    notesPersistTimer = setTimeout(() => {
+      notesPersistTimer = null;
+      if (!notesWindow || notesWindow.isDestroyed()) return;
+      const b = notesWindow.getBounds();
+      saveNotesWindowState({ x: b.x, y: b.y, width: b.width, height: b.height });
+    }, 250);
+  };
+  notesWindow.on('move', persistNotesBounds);
+  notesWindow.on('resize', persistNotesBounds);
+  notesWindow.on('close', () => {
+    if (notesPersistTimer) { clearTimeout(notesPersistTimer); notesPersistTimer = null; }
+    if (!notesWindow || notesWindow.isDestroyed()) return;
+    const b = notesWindow.getBounds();
+    saveNotesWindowState({ x: b.x, y: b.y, width: b.width, height: b.height });
   });
 
   notesWindow.on('closed', () => {

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -535,3 +535,63 @@ export function clearWindowState(): void {
     console.error('Failed to clear window state:', e);
   }
 }
+
+// ─── Notes window state ────────────────────────────────────────────
+// Separate from LauncherWindowState because Notes persists width/height as
+// well as position. Stored in its own JSON file so migrating/clearing one
+// doesn't affect the other.
+
+export interface NotesWindowState {
+  /** Last saved X position of the notes window. */
+  x: number;
+  /** Last saved Y position of the notes window. */
+  y: number;
+  /** Last saved width of the notes window. */
+  width: number;
+  /** Last saved height of the notes window. */
+  height: number;
+}
+
+let notesWindowStateCache: NotesWindowState | null | undefined = undefined;
+
+function getNotesWindowStatePath(): string {
+  return path.join(app.getPath('userData'), 'notes-window-state.json');
+}
+
+export function loadNotesWindowState(): NotesWindowState | null {
+  if (notesWindowStateCache !== undefined) return notesWindowStateCache;
+  try {
+    const raw = fs.readFileSync(getNotesWindowStatePath(), 'utf-8');
+    const parsed = JSON.parse(raw);
+    const x = Number(parsed?.x);
+    const y = Number(parsed?.y);
+    const width = Number(parsed?.width);
+    const height = Number(parsed?.height);
+    if (
+      [x, y, width, height].every(Number.isFinite) &&
+      width > 0 &&
+      height > 0
+    ) {
+      notesWindowStateCache = {
+        x: Math.round(x),
+        y: Math.round(y),
+        width: Math.round(width),
+        height: Math.round(height),
+      };
+    } else {
+      notesWindowStateCache = null;
+    }
+  } catch {
+    notesWindowStateCache = null;
+  }
+  return notesWindowStateCache;
+}
+
+export function saveNotesWindowState(state: NotesWindowState): void {
+  notesWindowStateCache = state;
+  try {
+    fs.writeFileSync(getNotesWindowStatePath(), JSON.stringify(state, null, 2));
+  } catch (e) {
+    console.error('Failed to save notes window state:', e);
+  }
+}

--- a/src/renderer/src/CanvasSearchInline.tsx
+++ b/src/renderer/src/CanvasSearchInline.tsx
@@ -523,7 +523,7 @@ const CanvasSearchInline: React.FC<CanvasSearchInlineProps> = ({ onClose }) => {
       {/* Rename dialog */}
       {renameCanvas && (
         <div className="absolute inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="rounded-xl p-5 w-72" style={{ background: 'var(--card-bg)', backdropFilter: 'blur(40px)', border: '1px solid var(--border-primary)', boxShadow: '0 8px 32px rgba(0,0,0,0.18)' }}>
+          <div className="rounded-xl p-5 w-72" style={{ background: 'linear-gradient(var(--card-bg), var(--card-bg)), var(--bg-primary)', border: '1px solid var(--border-primary)', boxShadow: '0 8px 32px rgba(0,0,0,0.18)' }}>
             <p className="text-[13px] font-medium text-white/90 mb-3">{t('canvas.rename.title')}</p>
             <input
               ref={renameInputRef}
@@ -574,7 +574,7 @@ const CanvasSearchInline: React.FC<CanvasSearchInlineProps> = ({ onClose }) => {
       {/* Delete confirmation */}
       {confirmDelete && selectedCanvas && (
         <div className="absolute inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="rounded-xl p-5 max-w-sm" style={{ background: 'var(--card-bg)', backdropFilter: 'blur(40px)' }}>
+          <div className="rounded-xl p-5 max-w-sm" style={{ background: 'linear-gradient(var(--card-bg), var(--card-bg)), var(--bg-primary)', border: '1px solid var(--border-primary)' }}>
             <p className="text-[14px] font-medium text-white/90 mb-2">{t('canvas.delete.title', { title: selectedCanvas.title })}</p>
             <p className="text-[12px] text-white/50 mb-4">{t('canvas.delete.description')}</p>
             <div className="flex gap-2 justify-end">

--- a/src/renderer/src/NotesManager.tsx
+++ b/src/renderer/src/NotesManager.tsx
@@ -1268,6 +1268,7 @@ interface EditorViewProps {
   onNavigateForward: () => void;
   onDuplicate: () => void;
   onTogglePin: () => void;
+  onDelete: () => void;
   showFind: boolean;
   setShowFind: (v: boolean) => void;
 }
@@ -1275,7 +1276,7 @@ interface EditorViewProps {
 const EditorView: React.FC<EditorViewProps> = ({
   note, onSave, onBack, onBrowse, onNewNote, onShowActions,
   onNavigateBack, onNavigateForward,
-  onDuplicate, onTogglePin, showFind, setShowFind,
+  onDuplicate, onTogglePin, onDelete, showFind, setShowFind,
 }) => {
   const [icon, setIcon] = useState(note?.icon || '');
   const [content, setContent] = useState(note?.content || '');
@@ -1302,9 +1303,10 @@ const EditorView: React.FC<EditorViewProps> = ({
     if (showFind) setTimeout(() => findInputRef.current?.focus(), 50);
   }, [showFind]);
 
-  // Auto-save debounce
+  // Auto-save debounce. Runs even when `note` is null (draft / new-note
+  // path) so the first keystroke triggers a create; handleEditorSave gates
+  // whether to actually persist based on non-empty content.
   useEffect(() => {
-    if (!note) return;
     if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
     saveTimeoutRef.current = setTimeout(() => {
       onSave({ title, icon, content, theme });
@@ -1322,8 +1324,12 @@ const EditorView: React.FC<EditorViewProps> = ({
       if (e.key === 'Escape') {
         if (showFind) { setShowFind(false); e.preventDefault(); return; }
         if (showToolbar) { setShowToolbar(false); e.preventDefault(); return; }
-        // Save and close the window
-        if (note) onSave({ title: title || 'Untitled', icon, content, theme });
+        // Save and close the window — but only persist if there's real
+        // content. Empty drafts are discarded rather than saved as Untitled.
+        // `title` comes from extractTitleFromContent and falls back to 'Untitled',
+        // so we can't rely on it — only check `content`.
+        const hasContent = (content || '').trim().length > 0;
+        if (hasContent) onSave({ title: title || 'Untitled', icon, content, theme });
         e.preventDefault();
         window.close();
         return;
@@ -1333,6 +1339,12 @@ const EditorView: React.FC<EditorViewProps> = ({
       if (meta && !shift && !alt && e.key === 'p') { e.preventDefault(); onBrowse(); return; }
       if (meta && shift && e.key === 'p') { e.preventDefault(); onTogglePin(); return; }
       if (meta && !shift && !alt && e.key === 'd') { e.preventDefault(); onDuplicate(); return; }
+      // Control+X (not Cmd+X — that is cut) deletes the current note.
+      if (e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey && (e.key === 'x' || e.key === 'X')) {
+        e.preventDefault();
+        onDelete();
+        return;
+      }
       if (meta && !shift && !alt && e.key === 'f') {
         e.preventDefault();
         setShowFind(true);
@@ -1348,7 +1360,7 @@ const EditorView: React.FC<EditorViewProps> = ({
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [showToolbar, showFind, note, title, icon, content, theme, onBack, onNewNote, onBrowse, onShowActions, onNavigateBack, onNavigateForward, onDuplicate, onTogglePin, setShowFind]);
+  }, [showToolbar, showFind, note, title, icon, content, theme, onBack, onNewNote, onBrowse, onShowActions, onNavigateBack, onNavigateForward, onDuplicate, onTogglePin, onDelete, setShowFind]);
 
   const formatWrap = useCallback((prefix: string, suffix: string) => {
     blockEditorRef.current?.wrapSelection(prefix, suffix);
@@ -2022,19 +2034,31 @@ const NotesManager: React.FC<NotesManagerProps> = ({ initialView }) => {
   // ─── Handlers ────────────────────────────────────────────────────
 
   const handleNewNote = useCallback(async () => {
-    const newNote = await window.electron.noteCreate({ title: 'Untitled' });
-    setCurrentNote(newNote);
+    // Don't pre-create the note — we want an in-memory draft so that if the
+    // user closes the editor without typing anything, nothing gets persisted.
+    // The actual DB row is created by handleEditorSave below when the first
+    // auto-save fires with non-empty content.
+    setCurrentNote(null);
     setViewMode('editor');
-    pushToHistory(newNote.id);
-    loadNotes();
-  }, [loadNotes, pushToHistory]);
+  }, []);
 
   const handleEditorSave = useCallback(async (data: { title: string; icon: string; content: string; theme: NoteTheme }) => {
+    // Don't save empty notes — applies to both draft creation and existing-note
+    // updates. If the user clears an existing note to empty, we simply skip
+    // the auto-save so we don't persist empty content.
+    // NOTE: `data.title` is derived from `data.content` via extractTitleFromContent
+    // and falls back to 'Untitled', so it's NEVER empty. Only gate on content.
+    const hasContent = (data.content || '').trim().length > 0;
     if (currentNote) {
+      if (!hasContent) return;
       await window.electron.noteUpdate(currentNote.id, { title: data.title, icon: data.icon, content: data.content, theme: data.theme });
       setCurrentNote(prev => prev ? { ...prev, ...data } : null);
     } else {
-      const created = await window.electron.noteCreate({ title: data.title, icon: data.icon, content: data.content, theme: data.theme });
+      // Draft path: only persist once the user has typed something. An empty
+      // draft (no title and no content) is intentionally discarded so we
+      // don't leave "Untitled" stubs behind.
+      if (!hasContent) return;
+      const created = await window.electron.noteCreate({ title: data.title || 'Untitled', icon: data.icon, content: data.content, theme: data.theme });
       setCurrentNote(created);
       pushToHistory(created.id);
     }
@@ -2094,6 +2118,7 @@ const NotesManager: React.FC<NotesManagerProps> = ({ initialView }) => {
     if (targetNote) a.push({ title: targetNote.pinned ? 'Unpin Note' : 'Pin Note', icon: targetNote.pinned ? <PinOff size={14} /> : <Pin size={14} />, shortcut: ['⇧', '⌘', 'P'], section: 'settings', execute: () => handleTogglePin() });
     a.push({ title: 'Import Notes', icon: <Download size={14} />, section: 'settings', execute: async () => { await window.electron.noteImport(); loadNotes(); setShowActions(false); } });
     a.push({ title: 'Export All Notes', icon: <Upload size={14} />, section: 'settings', execute: async () => { await window.electron.noteExport(); setShowActions(false); } });
+    if (targetNote) a.push({ title: 'Delete Note', icon: <Trash2 size={14} />, shortcut: ['⌃', 'X'], section: 'danger', style: 'destructive', execute: () => { setConfirmDelete(true); setShowActions(false); } });
     return a;
   }, [targetNote, viewMode, loadNotes, handleNewNote, handleDuplicate, handleTogglePin, handleExport, notes]);
 
@@ -2103,6 +2128,7 @@ const NotesManager: React.FC<NotesManagerProps> = ({ initialView }) => {
     if (viewMode !== 'search') return;
     const handler = (e: KeyboardEvent) => {
       if (showActions || showBrowse) return;
+      if (e.key === 'Escape') { e.preventDefault(); window.close(); return; }
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); setShowActions(true); return; }
       if (e.key === 'n' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); handleNewNote(); return; }
       if (e.key === 'ArrowDown') { e.preventDefault(); setSelectedIndex(i => Math.min(i + 1, notes.length - 1)); return; }
@@ -2122,6 +2148,12 @@ const NotesManager: React.FC<NotesManagerProps> = ({ initialView }) => {
       if (meta && e.shiftKey && e.key === 'p') { e.preventDefault(); handleTogglePin(); return; }
       if (meta && e.shiftKey && e.key === 'e') { e.preventDefault(); handleExport(); return; }
       if (meta && e.shiftKey && e.key === 'c' && targetNote) { e.preventDefault(); window.electron.noteCopyToClipboard(targetNote.id, 'markdown'); return; }
+      // Control+X (not Cmd+X — that is cut) opens the delete confirmation.
+      if (e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey && (e.key === 'x' || e.key === 'X') && targetNote) {
+        e.preventDefault();
+        setConfirmDelete(true);
+        return;
+      }
       if (meta && !e.shiftKey && !e.altKey && e.key >= '0' && e.key <= '9') {
         const idx = e.key === '0' ? 0 : parseInt(e.key) - 1;
         if (pinnedNotes[idx]) { e.preventDefault(); handleOpenNote(pinnedNotes[idx]); }
@@ -2192,6 +2224,7 @@ const NotesManager: React.FC<NotesManagerProps> = ({ initialView }) => {
           onNavigateForward={navigateForward}
           onDuplicate={handleDuplicate}
           onTogglePin={handleTogglePin}
+          onDelete={() => { if (currentNote) setConfirmDelete(true); }}
           showFind={showFind}
           setShowFind={setShowFind}
         />
@@ -2226,36 +2259,88 @@ const NotesManager: React.FC<NotesManagerProps> = ({ initialView }) => {
       {showActions && <ActionsOverlay actions={actions} onClose={() => setShowActions(false)} />}
 
       {confirmDelete && targetNote && (
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center" style={{ background: 'rgba(0,0,0,0.5)' }}>
-          <div className="w-[320px] rounded-xl shadow-2xl overflow-hidden"
-            style={{ background: 'var(--card-bg)', backdropFilter: 'blur(40px)', border: '1px solid var(--border-primary)' }}>
-            <div className="px-5 pt-5 pb-3">
-              <h3 className="text-[14px] font-semibold text-[var(--text-primary)] mb-1.5">Delete Note</h3>
-              <p className="text-[12px] text-[var(--text-muted)] leading-relaxed">
-                Are you sure you want to delete "<span className="text-[var(--text-secondary)]">{targetNote.title || 'Untitled'}</span>"? This action cannot be undone.
-              </p>
-            </div>
-            <div className="flex items-center justify-end gap-2 px-5 pb-4 pt-2">
-              <button onClick={() => setConfirmDelete(false)}
-                className="px-3 py-1.5 rounded-md text-[12px] text-[var(--text-muted)] hover:bg-[var(--bg-secondary)] transition-colors">
-                Cancel
-              </button>
-              <button onClick={async () => {
-                await window.electron.noteDelete(targetNote.id);
-                setConfirmDelete(false);
-                if (viewMode === 'editor') { setCurrentNote(null); window.close(); }
-                else { setSelectedIndex(i => Math.max(0, i - 1)); loadNotes(); }
-              }}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] text-white bg-red-400/70 hover:bg-red-400/90 transition-colors">
-                Delete
-                <kbd className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded bg-white/15 text-[10px] font-medium">↩</kbd>
-              </button>
-            </div>
-          </div>
-        </div>
+        <ConfirmDeleteDialog
+          title={targetNote.title || 'Untitled'}
+          onCancel={() => setConfirmDelete(false)}
+          onConfirm={async () => {
+            await window.electron.noteDelete(targetNote.id);
+            setConfirmDelete(false);
+            if (viewMode === 'editor') { setCurrentNote(null); window.close(); }
+            else { setSelectedIndex(i => Math.max(0, i - 1)); loadNotes(); }
+          }}
+        />
       )}
     </div>
   );
 };
 
 export default NotesManager;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Confirm Delete Dialog
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ConfirmDeleteDialogProps {
+  title: string;
+  onConfirm: () => void | Promise<void>;
+  onCancel: () => void;
+}
+
+const ConfirmDeleteDialog: React.FC<ConfirmDeleteDialogProps> = ({ title, onConfirm, onCancel }) => {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    // Move focus to the Delete button so the active editor no longer
+    // receives keystrokes while the dialog is open.
+    confirmRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        onConfirm();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    // Capture-phase so we intercept before the editor / other listeners.
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [onConfirm, onCancel]);
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center" style={{ background: 'rgba(0,0,0,0.5)' }}>
+      <div className="w-[320px] rounded-xl shadow-2xl overflow-hidden"
+        style={{
+          // Layer the translucent card color over an opaque surface so the
+          // 0.5 black overlay behind the dialog can't bleed through and dim
+          // the card. Skip backdrop-filter for the same reason (it would
+          // blur the dark overlay and darken the card).
+          background: 'linear-gradient(var(--card-bg), var(--card-bg)), var(--bg-primary)',
+          border: '1px solid var(--border-primary)',
+        }}>
+        <div className="px-5 pt-5 pb-3">
+          <h3 className="text-[14px] font-semibold text-[var(--text-primary)] mb-1.5">Delete Note</h3>
+          <p className="text-[12px] text-[var(--text-muted)] leading-relaxed">
+            Are you sure you want to delete "<span className="text-[var(--text-secondary)]">{title}</span>"? This action cannot be undone.
+          </p>
+        </div>
+        <div className="flex items-center justify-end gap-2 px-5 pb-4 pt-2">
+          <button onClick={onCancel}
+            className="px-3 py-1.5 rounded-md text-[12px] text-[var(--text-muted)] hover:bg-[var(--bg-secondary)] transition-colors">
+            Cancel
+          </button>
+          <button ref={confirmRef} onClick={() => onConfirm()}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] text-white bg-red-400/70 hover:bg-red-400/90 transition-colors focus:outline-none focus:ring-2 focus:ring-red-400/50">
+            Delete
+            <kbd className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded bg-white/15 text-[10px] font-medium">↩</kbd>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/src/NotesSearchInline.tsx
+++ b/src/renderer/src/NotesSearchInline.tsx
@@ -569,7 +569,12 @@ const ConfirmDeleteModal: React.FC<{
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center" style={{ background: 'rgba(0,0,0,0.5)' }}>
       <div className="w-[320px] rounded-xl shadow-2xl overflow-hidden"
-        style={{ background: 'var(--card-bg)', backdropFilter: 'blur(40px)', border: '1px solid var(--border-primary)' }}>
+        style={{
+          // Paint the translucent card color over an opaque surface so the
+          // scrim behind the dialog can't bleed through and dim the card.
+          background: 'linear-gradient(var(--card-bg), var(--card-bg)), var(--bg-primary)',
+          border: '1px solid var(--border-primary)',
+        }}>
         <div className="px-5 pt-5 pb-3">
           <h3 className="text-[14px] font-semibold text-[var(--text-primary)] mb-1.5">Delete Note</h3>
           <p className="text-[12px] text-[var(--text-muted)] leading-relaxed">


### PR DESCRIPTION
## Summary

- **Notes window floats across spaces/fullscreen** — the detached notes window now stays visible across all desktop spaces and over fullscreen apps, and follows when the active space changes. Position & size are persisted in a dedicated state file so the window restores where the user left it.
- **"Delete Note" moved to end of actions list** — now lives in its own `danger` section after Import / Export All, matching common destructive-action conventions.
- **Empty notes are no longer persisted** — `title` is derived from content via `extractTitleFromContent` and always falls back to `'Untitled'`, so the previous `hasContent = title || content` guard was never false. Gate on `content.trim()` only, and apply the guard to the existing-note update path (not just draft creation).
- **Delete-confirm dialog responds to Enter/Escape** — extracted `ConfirmDeleteDialog`, auto-focuses the Delete button on mount, and handles Enter/Escape via a capture-phase `keydown` listener so the contentEditable editor can't swallow the keystroke.
- **Confirm/rename dialogs no longer get dimmed along with the scrim** (app-wide, not notes-specific). Translucent `var(--card-bg)` + `backdrop-filter: blur(40px)` was pulling the scrim through the card. Paint the card color over an opaque surface and drop the backdrop filter:
  ```
  background: linear-gradient(var(--card-bg), var(--card-bg)), var(--bg-primary);
  ```
  Applied to Notes (window + launcher overlay) and Canvas (rename + delete).

## Test plan
- [ ] Open the notes window, switch to another desktop space / a fullscreen app — notes window remains visible and follows.
- [ ] Quit and reopen notes — window restores to its last position and size.
- [ ] Open actions menu (⌘K) in a note — "Delete Note" appears last, visually separated, in destructive styling.
- [ ] Create a new note and close it without typing — no "Untitled" stub is saved.
- [ ] Open an existing note, clear all content — the empty state is not persisted.
- [ ] Press Ctrl+X in the editor → confirm dialog opens → press Enter → note deletes (no newline inserted in editor).
- [ ] Press Ctrl+X → Escape → dialog closes, note remains.
- [ ] Press Escape in the notes search view — window closes.
- [ ] Open any confirm dialog (Notes delete / Canvas rename / Canvas delete) — only the background dims; the dialog card stays bright.