### PR TITLE
feat: add navigation style setting with Vim and macOS options

### DIFF
--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -58,6 +58,7 @@ export interface HyperKeySettings {
 export type AppFontSize = 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large';
 export type AppUiStyle = 'default' | 'glassy';
 export type LauncherViewMode = 'expanded' | 'compact';
+export type AppNavigationStyle = 'vim' | 'macos';
 export type AppLanguage =
   | 'system'
   | 'en'
@@ -101,6 +102,7 @@ export interface AppSettings {
   updateBannerDismissedAt?: number;
   hyperKey: HyperKeySettings;
   launcherViewMode: LauncherViewMode;
+  navigationStyle: AppNavigationStyle;
 }
 
 const DEFAULT_HYPER_KEY_SETTINGS: HyperKeySettings = {
@@ -187,6 +189,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   appUpdaterLastCheckedAt: 0,
   hyperKey: { ...DEFAULT_HYPER_KEY_SETTINGS },
   launcherViewMode: 'expanded',
+  navigationStyle: 'vim',
 };
 
 let settingsCache: AppSettings | null = null;
@@ -211,6 +214,12 @@ function normalizeUiStyle(value: any): AppUiStyle {
   const normalized = String(value || '').trim().toLowerCase();
   if (normalized === 'glassy') return 'glassy';
   return 'default';
+}
+
+function normalizeNavigationStyle(value: any): AppNavigationStyle {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (normalized === 'macos') return 'macos';
+  return 'vim';
 }
 
 function normalizeAppLanguage(value: any): AppLanguage {
@@ -384,6 +393,7 @@ export function loadSettings(): AppSettings {
         ? Math.max(0, Number(parsed.appUpdaterLastCheckedAt))
         : DEFAULT_SETTINGS.appUpdaterLastCheckedAt,
       launcherViewMode: (parsed.launcherViewMode === 'compact' ? 'compact' : 'expanded'),
+      navigationStyle: normalizeNavigationStyle(parsed.navigationStyle),
     };
   } catch {
     settingsCache = { ...DEFAULT_SETTINGS };

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -357,6 +357,7 @@ const App: React.FC = () => {
   const launcherFooterStatusTimerRef = useRef<number | null>(null);
   const [fileSearchInitialDetailPath, setFileSearchInitialDetailPath] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [navigationStyle, setNavigationStyle] = useState<'vim' | 'macos'>('vim');
   const [isLoading, setIsLoading] = useState(true);
   const homeDir = String((window.electron as any).homeDir || '');
   const {
@@ -616,6 +617,7 @@ const App: React.FC = () => {
       applyAppFontSize(settings.fontSize);
       applyUiStyle(settings.uiStyle || 'default');
       applyBaseColor(settings.baseColor || '#101113');
+      setNavigationStyle(settings.navigationStyle === 'macos' ? 'macos' : 'vim');
       const shouldShowOnboarding = !settings.hasSeenOnboarding;
       setShowOnboarding(shouldShowOnboarding);
       setOnboardingRequiresShortcutFix(shouldShowOnboarding && !shortcutStatus.ok);
@@ -953,6 +955,7 @@ const App: React.FC = () => {
       );
       setLauncherShortcut(settings.globalShortcut || 'Alt+Space');
       setDisableFileSearchResults(Boolean(settings.disableFileSearchResults));
+      setNavigationStyle(settings.navigationStyle === 'macos' ? 'macos' : 'vim');
     });
     return cleanup;
   }, []);
@@ -2143,15 +2146,28 @@ const App: React.FC = () => {
       }
 
       if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
-        if (e.key === 'j' || e.key === 'J') {
-          e.preventDefault();
-          moveSelection('down');
-          return;
-        }
-        if (e.key === 'k' || e.key === 'K') {
-          e.preventDefault();
-          moveSelection('up');
-          return;
+        if (navigationStyle === 'vim') {
+          if (e.key === 'j' || e.key === 'J') {
+            e.preventDefault();
+            moveSelection('down');
+            return;
+          }
+          if (e.key === 'k' || e.key === 'K') {
+            e.preventDefault();
+            moveSelection('up');
+            return;
+          }
+        } else {
+          if (e.key === 'n' || e.key === 'N') {
+            e.preventDefault();
+            moveSelection('down');
+            return;
+          }
+          if (e.key === 'p' || e.key === 'P') {
+            e.preventDefault();
+            moveSelection('up');
+            return;
+          }
         }
       }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2145,32 +2145,6 @@ const App: React.FC = () => {
         return;
       }
 
-      if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
-        if (navigationStyle === 'vim') {
-          if (e.key === 'j' || e.key === 'J') {
-            e.preventDefault();
-            moveSelection('down');
-            return;
-          }
-          if (e.key === 'k' || e.key === 'K') {
-            e.preventDefault();
-            moveSelection('up');
-            return;
-          }
-        } else {
-          if (e.key === 'n' || e.key === 'N') {
-            e.preventDefault();
-            moveSelection('down');
-            return;
-          }
-          if (e.key === 'p' || e.key === 'P') {
-            e.preventDefault();
-            moveSelection('up');
-            return;
-          }
-        }
-      }
-
       if (showActions || contextMenu) {
         if (e.key === 'Escape') {
           e.preventDefault();
@@ -2780,6 +2754,33 @@ const App: React.FC = () => {
     window.addEventListener('keydown', onKeyDown, true);
     return () => window.removeEventListener('keydown', onKeyDown, true);
   }, [cancelQuickLinkDynamicPrompt, quickLinkDynamicPrompt, submitQuickLinkDynamicPrompt]);
+
+  // Global nav-key rebinding — works in the main launcher AND inside
+  // extensions. Ctrl+<key> is translated into a synthetic arrow key event
+  // dispatched at the original target so whichever component handles arrow
+  // keys (list, grid, submenu, text input) picks it up naturally.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
+      const keyLower = event.key.toLowerCase();
+      const navMap: Record<string, 'ArrowDown' | 'ArrowUp' | 'ArrowLeft' | 'ArrowRight'> =
+        navigationStyle === 'vim'
+          ? { j: 'ArrowDown', k: 'ArrowUp', h: 'ArrowLeft', l: 'ArrowRight' }
+          : { n: 'ArrowDown', p: 'ArrowUp', b: 'ArrowLeft', f: 'ArrowRight' };
+      const mapped = navMap[keyLower];
+      if (!mapped) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      const target =
+        (event.target as HTMLElement | null) ||
+        (document.activeElement as HTMLElement | null);
+      target?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: mapped, bubbles: true, cancelable: true })
+      );
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [navigationStyle]);
 
   const handleCommandExecute = async (command: CommandInfo) => {
     try {

--- a/src/renderer/src/settings/AdvancedTab.tsx
+++ b/src/renderer/src/settings/AdvancedTab.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Bug, FolderSearch, Languages, Sparkles } from 'lucide-react';
-import type { AppSettings, HyperKeySourceKey, HyperKeyCapsLockTapBehavior } from '../../types/electron';
+import { Bug, FolderSearch, Keyboard, Languages, Sparkles } from 'lucide-react';
+import type { AppNavigationStyle, AppSettings, HyperKeySourceKey, HyperKeyCapsLockTapBehavior } from '../../types/electron';
 import { APP_LANGUAGE_OPTIONS, DEFAULT_APP_LANGUAGE, type AppLanguageSetting, useI18n } from '../i18n';
 
 type SettingsRowProps = {
@@ -53,6 +53,11 @@ const CAPS_LOCK_TAP_OPTIONS: { value: HyperKeyCapsLockTapBehavior; label: string
   { value: 'nothing', label: 'Do Nothing' },
   { value: 'escape', label: 'Simulate Escape' },
   { value: 'toggle', label: 'Toggles Caps Lock' },
+];
+
+const NAVIGATION_STYLE_OPTIONS: { value: AppNavigationStyle; label: string }[] = [
+  { value: 'vim', label: 'Vim Style (^J, ^K)' },
+  { value: 'macos', label: 'macOS Style (^N, ^P)' },
 ];
 
 const AdvancedTab: React.FC = () => {
@@ -209,6 +214,28 @@ const AdvancedTab: React.FC = () => {
             />
             Disable file and folder search results
           </label>
+        </SettingsRow>
+
+        <SettingsRow
+          icon={<Keyboard className="w-4 h-4" />}
+          title="Navigation Style"
+          description="Choose the keyboard shortcuts for navigating up and down in the launcher."
+        >
+          <div className="w-full max-w-[320px]">
+            <select
+              value={settings.navigationStyle || 'vim'}
+              onChange={(event) => {
+                void applySettingsPatch({ navigationStyle: event.target.value as AppNavigationStyle });
+              }}
+              className={selectClassName}
+            >
+              {NAVIGATION_STYLE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
         </SettingsRow>
 
         <SettingsRow

--- a/src/renderer/src/settings/AdvancedTab.tsx
+++ b/src/renderer/src/settings/AdvancedTab.tsx
@@ -56,8 +56,8 @@ const CAPS_LOCK_TAP_OPTIONS: { value: HyperKeyCapsLockTapBehavior; label: string
 ];
 
 const NAVIGATION_STYLE_OPTIONS: { value: AppNavigationStyle; label: string }[] = [
-  { value: 'vim', label: 'Vim Style (^J, ^K)' },
-  { value: 'macos', label: 'macOS Style (^N, ^P)' },
+  { value: 'vim', label: 'Vim Style (^J, ^K, ^H, ^L)' },
+  { value: 'macos', label: 'macOS Style (^N, ^P, ^B, ^F)' },
 ];
 
 const AdvancedTab: React.FC = () => {
@@ -219,7 +219,7 @@ const AdvancedTab: React.FC = () => {
         <SettingsRow
           icon={<Keyboard className="w-4 h-4" />}
           title="Navigation Style"
-          description="Choose the keyboard shortcuts for navigating up and down in the launcher."
+          description="Choose the keyboard shortcuts for navigating up, down, left, and right in the launcher."
         >
           <div className="w-full max-w-[320px]">
             <select

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -262,6 +262,8 @@ export interface HyperKeySettings {
   capsLockTapBehavior: HyperKeyCapsLockTapBehavior;
 }
 
+export type AppNavigationStyle = 'vim' | 'macos';
+
 export interface AppSettings {
   globalShortcut: string;
   openAtLogin: boolean;
@@ -292,6 +294,7 @@ export interface AppSettings {
   appUpdaterLastCheckedAt: number;
   hyperKey: HyperKeySettings;
   launcherViewMode: 'expanded' | 'compact';
+  navigationStyle: AppNavigationStyle;
 }
 
 export interface CatalogEntry {


### PR DESCRIPTION
Add a Navigation Style setting in Advanced settings that lets users choose between Vim-style (ctrl+j/ctrl+k) and macOS-style (ctrl+n/ctrl+p) keyboard shortcuts for launcher item navigation. Labels show the shortcuts inline (e.g. ^J, ^K / ^N, ^P). Defaults to Vim style.

Closes #170

Generated with [Claude Code](https://claude.ai/code)