### PR TITLE
feat: multi-turn Ask AI with history, markdown, and launcher-style UI

### DIFF
--- a/src/main/ai-provider.ts
+++ b/src/main/ai-provider.ts
@@ -16,6 +16,19 @@ export interface AIRequestOptions {
   signal?: AbortSignal;
 }
 
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AIChatRequestOptions {
+  messages: ChatMessage[];
+  model?: string;
+  creativity?: number;
+  systemPrompt?: string;
+  signal?: AbortSignal;
+}
+
 // ─── Model routing ────────────────────────────────────────────────────
 
 interface ModelRoute {
@@ -153,6 +166,240 @@ export async function* streamAI(
       );
       break;
   }
+}
+
+// ─── Chat (multi-turn) ───────────────────────────────────────────────
+
+export async function* streamAIChat(
+  config: AISettings,
+  options: AIChatRequestOptions
+): AsyncGenerator<string> {
+  const route = resolveModel(options.model, config);
+  const temperature = options.creativity ?? 0.7;
+
+  switch (route.provider) {
+    case 'openai':
+      yield* streamOpenAIChat(config.openaiApiKey, route.modelId, options.messages, temperature, options.systemPrompt, options.signal);
+      break;
+    case 'anthropic':
+      yield* streamAnthropicChat(config.anthropicApiKey, route.modelId, options.messages, temperature, options.systemPrompt, options.signal);
+      break;
+    case 'gemini':
+      yield* streamGeminiChat(config.geminiApiKey, route.modelId, options.messages, temperature, options.systemPrompt, options.signal);
+      break;
+    case 'ollama':
+      yield* streamOllamaChat(config.ollamaBaseUrl, route.modelId, options.messages, temperature, options.systemPrompt, options.signal);
+      break;
+    case 'openai-compatible':
+      yield* streamOpenAICompatibleChat(
+        config.openaiCompatibleBaseUrl,
+        config.openaiCompatibleApiKey,
+        route.modelId,
+        options.messages,
+        temperature,
+        options.systemPrompt,
+        options.signal
+      );
+      break;
+  }
+}
+
+async function* streamOpenAIChat(
+  apiKey: string,
+  model: string,
+  messages: ChatMessage[],
+  temperature: number,
+  systemPrompt?: string,
+  signal?: AbortSignal
+): AsyncGenerator<string> {
+  const full: any[] = [];
+  if (systemPrompt) full.push({ role: 'system', content: systemPrompt });
+  for (const m of messages) full.push({ role: m.role, content: m.content });
+
+  const body = JSON.stringify({ model, messages: full, temperature, stream: true });
+
+  const response = await httpRequest({
+    hostname: 'api.openai.com',
+    path: '/v1/chat/completions',
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
+    body,
+    signal,
+    useHttps: true,
+  });
+
+  yield* parseSSE(response, (data) => {
+    if (data === '[DONE]') return null;
+    try {
+      const parsed = JSON.parse(data);
+      return parsed.choices?.[0]?.delta?.content || null;
+    } catch {
+      return null;
+    }
+  });
+}
+
+async function* streamOpenAICompatibleChat(
+  baseUrl: string,
+  apiKey: string,
+  model: string,
+  messages: ChatMessage[],
+  temperature: number,
+  systemPrompt?: string,
+  signal?: AbortSignal
+): AsyncGenerator<string> {
+  const full: any[] = [];
+  if (systemPrompt) full.push({ role: 'system', content: systemPrompt });
+  for (const m of messages) full.push({ role: m.role, content: m.content });
+
+  const body = JSON.stringify({ model, messages: full, temperature, stream: true });
+
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '');
+  const chatUrl = normalizedBaseUrl.endsWith('/v1')
+    ? `${normalizedBaseUrl}/chat/completions`
+    : `${normalizedBaseUrl}/v1/chat/completions`;
+  const url = new URL(chatUrl);
+  const useHttps = url.protocol === 'https:';
+
+  const response = await httpRequest({
+    hostname: url.hostname,
+    port: url.port ? parseInt(url.port) : undefined,
+    path: url.pathname,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
+    body,
+    signal,
+    useHttps,
+  });
+
+  yield* parseSSE(response, (data) => {
+    if (data === '[DONE]') return null;
+    try {
+      const parsed = JSON.parse(data);
+      return parsed.choices?.[0]?.delta?.content || null;
+    } catch {
+      return null;
+    }
+  });
+}
+
+async function* streamAnthropicChat(
+  apiKey: string,
+  model: string,
+  messages: ChatMessage[],
+  temperature: number,
+  systemPrompt?: string,
+  signal?: AbortSignal
+): AsyncGenerator<string> {
+  const body: any = {
+    model,
+    max_tokens: 4096,
+    messages: messages.map((m) => ({ role: m.role, content: m.content })),
+    stream: true,
+  };
+  if (temperature !== undefined) body.temperature = temperature;
+  if (systemPrompt) body.system = systemPrompt;
+
+  const response = await httpRequest({
+    hostname: 'api.anthropic.com',
+    path: '/v1/messages',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify(body),
+    signal,
+    useHttps: true,
+  });
+
+  yield* parseSSE(response, (data) => {
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed.type === 'content_block_delta' && parsed.delta?.text) {
+        return parsed.delta.text;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  });
+}
+
+async function* streamGeminiChat(
+  apiKey: string,
+  model: string,
+  messages: ChatMessage[],
+  temperature: number,
+  systemPrompt?: string,
+  signal?: AbortSignal
+): AsyncGenerator<string> {
+  const contents = messages.map((m) => ({
+    role: m.role === 'assistant' ? 'model' : 'user',
+    parts: [{ text: m.content }],
+  }));
+
+  const body: any = { contents, generationConfig: { temperature } };
+  if (systemPrompt) body.systemInstruction = { parts: [{ text: systemPrompt }] };
+
+  const response = await httpRequest({
+    hostname: 'generativelanguage.googleapis.com',
+    path: `/v1beta/models/${encodeURIComponent(model)}:streamGenerateContent?alt=sse&key=${encodeURIComponent(apiKey)}`,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+    useHttps: true,
+  });
+
+  yield* parseSSE(response, (data) => {
+    try {
+      const parsed = JSON.parse(data);
+      const parts = parsed?.candidates?.[0]?.content?.parts;
+      if (Array.isArray(parts)) {
+        return parts.map((p: any) => (typeof p?.text === 'string' ? p.text : '')).join('') || null;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  });
+}
+
+async function* streamOllamaChat(
+  baseUrl: string,
+  model: string,
+  messages: ChatMessage[],
+  temperature: number,
+  systemPrompt?: string,
+  signal?: AbortSignal
+): AsyncGenerator<string> {
+  const url = new URL('/api/chat', baseUrl);
+  const full: any[] = [];
+  if (systemPrompt) full.push({ role: 'system', content: systemPrompt });
+  for (const m of messages) full.push({ role: m.role, content: m.content });
+
+  const body = {
+    model,
+    messages: full,
+    stream: true,
+    options: { temperature },
+  };
+
+  const useHttps = url.protocol === 'https:';
+  const response = await httpRequest({
+    hostname: url.hostname,
+    port: url.port ? parseInt(url.port) : undefined,
+    path: url.pathname,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+    useHttps,
+  });
+
+  yield* parseNDJSON(response, (obj) => obj?.message?.content || null);
 }
 
 // ─── OpenAI ──────────────────────────────────────────────────────────

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -17,7 +17,7 @@ import { fork, type ChildProcess } from 'child_process';
 import { getAvailableCommands, executeCommand, invalidateCache } from './commands';
 import { loadSettings, saveSettings, setOAuthToken, getOAuthToken, removeOAuthToken, loadWindowState, saveWindowState, clearWindowState, loadNotesWindowState, saveNotesWindowState } from './settings-store';
 import type { AppSettings } from './settings-store';
-import { streamAI, isAIAvailable, transcribeAudio } from './ai-provider';
+import { streamAI, streamAIChat, isAIAvailable, transcribeAudio } from './ai-provider';
 import * as soulverCalculator from './soulver-calculator';
 import { addMemory, buildMemoryContextSystemPrompt } from './memory';
 import {
@@ -14188,6 +14188,64 @@ if let tiff = image?.tiffRepresentation {
       activeAIRequests.delete(requestId);
     }
   });
+
+  ipcMain.handle(
+    'ai-chat',
+    async (
+      event: any,
+      requestId: string,
+      messages: Array<{ role: 'user' | 'assistant'; content: string }>,
+      options?: { model?: string; creativity?: number; systemPrompt?: string }
+    ) => {
+      const s = loadSettings();
+      if (s.ai?.llmEnabled === false) {
+        event.sender.send('ai-stream-error', { requestId, error: 'LLM is disabled in Settings → AI.' });
+        return;
+      }
+      if (!isAIAvailable(s.ai)) {
+        event.sender.send('ai-stream-error', { requestId, error: 'AI is not configured. Please set up an API key in Settings → AI.' });
+        return;
+      }
+
+      const controller = new AbortController();
+      activeAIRequests.set(requestId, controller);
+
+      try {
+        const latestUser = [...(messages || [])].reverse().find((m) => m.role === 'user');
+        const memoryContextSystemPrompt = await buildMemoryContextSystemPrompt(
+          s,
+          String(latestUser?.content || ''),
+          { limit: 6 }
+        );
+        const mergedSystemPrompt = [options?.systemPrompt, memoryContextSystemPrompt]
+          .filter((part) => typeof part === 'string' && part.trim().length > 0)
+          .join('\n\n');
+
+        const gen = streamAIChat(s.ai, {
+          messages: (messages || []).map((m) => ({ role: m.role, content: String(m.content || '') })),
+          model: options?.model,
+          creativity: options?.creativity,
+          systemPrompt: mergedSystemPrompt || undefined,
+          signal: controller.signal,
+        });
+
+        for await (const chunk of gen) {
+          if (controller.signal.aborted) break;
+          event.sender.send('ai-stream-chunk', { requestId, chunk });
+        }
+
+        if (!controller.signal.aborted) {
+          event.sender.send('ai-stream-done', { requestId });
+        }
+      } catch (e: any) {
+        if (!controller.signal.aborted) {
+          event.sender.send('ai-stream-error', { requestId, error: e?.message || 'AI request failed' });
+        }
+      } finally {
+        activeAIRequests.delete(requestId);
+      }
+    }
+  );
 
   ipcMain.handle('ai-is-available', () => {
     const s = loadSettings();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -782,6 +782,8 @@ const electronAPI = {
   // ─── AI ────────────────────────────────────────────────────────
   aiAsk: (requestId: string, prompt: string, options?: { model?: string; creativity?: number; systemPrompt?: string }): Promise<void> =>
     ipcRenderer.invoke('ai-ask', requestId, prompt, options),
+  aiChat: (requestId: string, messages: Array<{ role: 'user' | 'assistant'; content: string }>, options?: { model?: string; creativity?: number; systemPrompt?: string }): Promise<void> =>
+    ipcRenderer.invoke('ai-chat', requestId, messages, options),
   aiCancel: (requestId: string): Promise<void> =>
     ipcRenderer.invoke('ai-cancel', requestId),
   aiIsAvailable: (): Promise<boolean> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -447,13 +447,21 @@ const App: React.FC = () => {
   }, [setBackgroundNoViewRuns]);
 
   const onExitAiMode = useCallback(() => {
+    if (launcherViewMode === 'compact') {
+      setSearchQuery('');
+      setIsCompactCollapsed(true);
+      window.electron.resizeLauncherWindow(false);
+    }
     setTimeout(() => inputRef.current?.focus(), 50);
-  }, []);
+  }, [launcherViewMode]);
 
   const {
-    aiResponse, aiStreaming, aiAvailable, aiQuery, setAiQuery,
+    messages: aiMessages, aiStreaming, aiAvailable, aiQuery, setAiQuery,
     aiResponseRef, aiInputRef, setAiAvailable,
-    startAiChat, submitAiQuery, exitAiMode,
+    conversations: aiConversations, activeConversationId: aiActiveConversationId,
+    startAiChat, sendMessage: aiSendMessage, stopStreaming: aiStopStreaming,
+    newChat: aiNewChat, selectConversation: aiSelectConversation,
+    deleteConversation: aiDeleteConversation, exitAiMode,
   } = useAiChat({
     setAiMode,
     onExitAiMode,
@@ -2243,8 +2251,12 @@ const App: React.FC = () => {
               return;
             }
           }
-          if (isSearchInputTarget && searchQuery.trim() && aiAvailable && !shouldHideAskAi) {
+          if (isSearchInputTarget && aiAvailable && !shouldHideAskAi) {
             e.preventDefault();
+            if (launcherViewMode === 'compact') {
+              setIsCompactCollapsed(false);
+              window.electron.resizeLauncherWindow(true);
+            }
             startAiChat(searchQuery);
           }
           break;
@@ -3766,11 +3778,17 @@ const App: React.FC = () => {
         alwaysMountedRunners={alwaysMountedRunners}
         aiQuery={aiQuery}
         setAiQuery={setAiQuery}
-        aiResponse={aiResponse}
+        messages={aiMessages}
         aiStreaming={aiStreaming}
         aiInputRef={aiInputRef as React.RefObject<HTMLInputElement>}
         aiResponseRef={aiResponseRef as React.RefObject<HTMLDivElement>}
-        submitAiQuery={submitAiQuery}
+        conversations={aiConversations}
+        activeConversationId={aiActiveConversationId}
+        sendMessage={aiSendMessage}
+        stopStreaming={aiStopStreaming}
+        newChat={aiNewChat}
+        selectConversation={aiSelectConversation}
+        deleteConversation={aiDeleteConversation}
         exitAiMode={exitAiMode}
       />
     );

--- a/src/renderer/src/NotesManager.tsx
+++ b/src/renderer/src/NotesManager.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 import type { Note, NoteTheme } from '../types/electron';
 import ExtensionActionFooter from './components/ExtensionActionFooter';
+import ConfirmDeleteDialog from './components/ConfirmDeleteDialog';
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -2260,7 +2261,8 @@ const NotesManager: React.FC<NotesManagerProps> = ({ initialView }) => {
 
       {confirmDelete && targetNote && (
         <ConfirmDeleteDialog
-          title={targetNote.title || 'Untitled'}
+          title="Delete Note"
+          target={targetNote.title || 'Untitled'}
           onCancel={() => setConfirmDelete(false)}
           onConfirm={async () => {
             await window.electron.noteDelete(targetNote.id);
@@ -2277,70 +2279,6 @@ const NotesManager: React.FC<NotesManagerProps> = ({ initialView }) => {
 export default NotesManager;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Confirm Delete Dialog
+// (ConfirmDeleteDialog moved to components/ConfirmDeleteDialog.tsx for reuse)
 // ─────────────────────────────────────────────────────────────────────────────
 
-interface ConfirmDeleteDialogProps {
-  title: string;
-  onConfirm: () => void | Promise<void>;
-  onCancel: () => void;
-}
-
-const ConfirmDeleteDialog: React.FC<ConfirmDeleteDialogProps> = ({ title, onConfirm, onCancel }) => {
-  const confirmRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    // Move focus to the Delete button so the active editor no longer
-    // receives keystrokes while the dialog is open.
-    confirmRef.current?.focus();
-  }, []);
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        e.stopPropagation();
-        onConfirm();
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-        e.stopPropagation();
-        onCancel();
-      }
-    };
-    // Capture-phase so we intercept before the editor / other listeners.
-    window.addEventListener('keydown', handler, true);
-    return () => window.removeEventListener('keydown', handler, true);
-  }, [onConfirm, onCancel]);
-
-  return (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center" style={{ background: 'rgba(0,0,0,0.5)' }}>
-      <div className="w-[320px] rounded-xl shadow-2xl overflow-hidden"
-        style={{
-          // Layer the translucent card color over an opaque surface so the
-          // 0.5 black overlay behind the dialog can't bleed through and dim
-          // the card. Skip backdrop-filter for the same reason (it would
-          // blur the dark overlay and darken the card).
-          background: 'linear-gradient(var(--card-bg), var(--card-bg)), var(--bg-primary)',
-          border: '1px solid var(--border-primary)',
-        }}>
-        <div className="px-5 pt-5 pb-3">
-          <h3 className="text-[14px] font-semibold text-[var(--text-primary)] mb-1.5">Delete Note</h3>
-          <p className="text-[12px] text-[var(--text-muted)] leading-relaxed">
-            Are you sure you want to delete "<span className="text-[var(--text-secondary)]">{title}</span>"? This action cannot be undone.
-          </p>
-        </div>
-        <div className="flex items-center justify-end gap-2 px-5 pb-4 pt-2">
-          <button onClick={onCancel}
-            className="px-3 py-1.5 rounded-md text-[12px] text-[var(--text-muted)] hover:bg-[var(--bg-secondary)] transition-colors">
-            Cancel
-          </button>
-          <button ref={confirmRef} onClick={() => onConfirm()}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] text-white bg-red-400/70 hover:bg-red-400/90 transition-colors focus:outline-none focus:ring-2 focus:ring-red-400/50">
-            Delete
-            <kbd className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded bg-white/15 text-[10px] font-medium">↩</kbd>
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-};

--- a/src/renderer/src/components/ConfirmDeleteDialog.tsx
+++ b/src/renderer/src/components/ConfirmDeleteDialog.tsx
@@ -1,0 +1,112 @@
+/**
+ * ConfirmDeleteDialog.tsx
+ *
+ * Shared destructive-action confirmation dialog.
+ * - Matches NotesManager's delete dialog styling (card over dimmed scrim)
+ * - Enter confirms, Escape cancels (capture phase to beat editors/inputs)
+ * - Confirm button autofocuses so keyboard input doesn't leak to whatever
+ *   was active before the dialog opened
+ */
+
+import React, { useEffect, useRef } from 'react';
+
+export interface ConfirmDeleteDialogProps {
+  /** Heading text, e.g. "Delete Note" or "Delete Chat" */
+  title: string;
+  /**
+   * Body text. Use `target` to highlight the subject name inline.
+   * If `message` is supplied it is rendered verbatim.
+   */
+  message?: React.ReactNode;
+  /** Highlighted target name injected into the default message. */
+  target?: string;
+  /** Confirm button label. Defaults to "Delete". */
+  confirmLabel?: string;
+  onConfirm: () => void | Promise<void>;
+  onCancel: () => void;
+}
+
+export const ConfirmDeleteDialog: React.FC<ConfirmDeleteDialogProps> = ({
+  title,
+  message,
+  target,
+  confirmLabel = 'Delete',
+  onConfirm,
+  onCancel,
+}) => {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    confirmRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        onConfirm();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [onConfirm, onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center"
+      style={{ background: 'rgba(0,0,0,0.5)' }}
+    >
+      <div
+        className="w-[320px] rounded-xl shadow-2xl overflow-hidden"
+        style={{
+          background: 'linear-gradient(var(--card-bg), var(--card-bg)), var(--bg-primary)',
+          border: '1px solid var(--border-primary)',
+        }}
+      >
+        <div className="px-5 pt-5 pb-3">
+          <h3 className="text-[14px] font-semibold text-[var(--text-primary)] mb-1.5">{title}</h3>
+          <p className="text-[12px] text-[var(--text-muted)] leading-relaxed">
+            {message ?? (
+              <>
+                Are you sure you want to delete
+                {target ? (
+                  <>
+                    {' "'}
+                    <span className="text-[var(--text-secondary)]">{target}</span>
+                    {'"'}
+                  </>
+                ) : (
+                  ' this item'
+                )}
+                ? This action cannot be undone.
+              </>
+            )}
+          </p>
+        </div>
+        <div className="flex items-center justify-end gap-2 px-5 pb-4 pt-2">
+          <button
+            onClick={onCancel}
+            className="px-3 py-1.5 rounded-md text-[12px] text-[var(--text-muted)] hover:bg-[var(--bg-secondary)] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            ref={confirmRef}
+            onClick={() => onConfirm()}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] text-white bg-red-400/70 hover:bg-red-400/90 transition-colors focus:outline-none focus:ring-2 focus:ring-red-400/50"
+          >
+            {confirmLabel}
+            <kbd className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded bg-white/15 text-[10px] font-medium">↩</kbd>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDeleteDialog;

--- a/src/renderer/src/hooks/useAiChat.ts
+++ b/src/renderer/src/hooks/useAiChat.ts
@@ -1,22 +1,38 @@
 /**
  * useAiChat.ts
  *
- * State and streaming logic for the AI chat mode (the full-screen AI panel).
- * - Manages aiQuery, aiResponse, aiStreaming, aiAvailable state
- * - Listens for ai-stream-chunk / ai-stream-done / ai-stream-error IPC events,
- *   routing them by requestId so cursor-prompt streams don't bleed in
- * - startAiChat(query): enter AI mode and fire the first request
- * - submitAiQuery(query): re-submit a new query inside AI mode (cancels in-flight)
- * - exitAiMode(): cancel any in-flight request, reset state, restore launcher focus
- *
- * Uses aiStreamingRef (a mirror of aiStreaming state) to keep exitAiMode/submitAiQuery
- * stable (no aiStreaming in their dep arrays) and avoid triggering the mount-time
- * fetchCommands effect on every streaming update.
+ * Multi-turn AI chat state with conversation history.
+ * - Owns `messages` array for the active conversation
+ * - Persists conversation list + bodies in localStorage
+ * - Streams assistant responses into the last message
+ * - startAiChat(query): enter AI mode; if query present, auto-send
+ * - sendMessage(text): append user msg, stream assistant reply
+ * - stopStreaming(): cancel in-flight
+ * - newChat(): start a fresh conversation
+ * - selectConversation(id): load an existing conversation
+ * - deleteConversation(id): remove from history
+ * - exitAiMode(): leave AI mode (conversation is kept in history)
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
 
-// ─── Interfaces ──────────────────────────────────────────────────────
+// ─── Types ──────────────────────────────────────────────────────────
+
+export interface AiMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  createdAt: number;
+  cancelled?: boolean;
+}
+
+export interface AiConversation {
+  id: string;
+  title: string;
+  messages: AiMessage[];
+  createdAt: number;
+  updatedAt: number;
+}
 
 export interface UseAiChatOptions {
   onExitAiMode?: () => void;
@@ -24,51 +40,159 @@ export interface UseAiChatOptions {
 }
 
 export interface UseAiChatReturn {
-  aiResponse: string;
+  // Active conversation
+  messages: AiMessage[];
   aiStreaming: boolean;
   aiAvailable: boolean;
   aiQuery: string;
   setAiQuery: (value: string) => void;
-  aiResponseRef: React.RefObject<HTMLDivElement>;
   aiInputRef: React.RefObject<HTMLInputElement>;
+  aiResponseRef: React.RefObject<HTMLDivElement>;
   setAiAvailable: (value: boolean) => void;
+
+  // History
+  conversations: AiConversation[];
+  activeConversationId: string | null;
+
+  // Actions
   startAiChat: (searchQuery: string) => void;
-  submitAiQuery: (query: string) => void;
+  sendMessage: (text: string) => void;
+  stopStreaming: () => void;
+  newChat: () => void;
+  selectConversation: (id: string) => void;
+  deleteConversation: (id: string) => void;
   exitAiMode: () => void;
 }
 
-// ─── Hook ────────────────────────────────────────────────────────────
+// ─── Persistence ────────────────────────────────────────────────────
+
+const STORAGE_KEY = 'sc.aiChat.conversations';
+const MAX_CONVERSATIONS = 50;
+
+function loadConversations(): AiConversation[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (c) =>
+        c &&
+        typeof c.id === 'string' &&
+        Array.isArray(c.messages)
+    );
+  } catch {
+    return [];
+  }
+}
+
+function saveConversations(convs: AiConversation[]) {
+  try {
+    const trimmed = convs.slice(0, MAX_CONVERSATIONS);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+  } catch {}
+}
+
+function makeTitle(text: string): string {
+  const t = (text || '').trim().replace(/\s+/g, ' ');
+  if (!t) return 'New Chat';
+  return t.length > 48 ? t.slice(0, 48) + '…' : t;
+}
+
+function uid(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// ─── Hook ───────────────────────────────────────────────────────────
 
 export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiChatReturn {
-  const [aiResponse, setAiResponse] = useState('');
+  const [conversations, setConversations] = useState<AiConversation[]>(() => loadConversations());
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<AiMessage[]>([]);
   const [aiStreaming, setAiStreaming] = useState(false);
   const [aiAvailable, setAiAvailable] = useState(false);
   const [aiQuery, setAiQuery] = useState('');
 
   const aiRequestIdRef = useRef<string | null>(null);
   const aiStreamingRef = useRef(false);
-  const aiResponseRef = useRef<HTMLDivElement>(null);
+  const streamingMessageIdRef = useRef<string | null>(null);
+  const activeConversationIdRef = useRef<string | null>(null);
   const aiInputRef = useRef<HTMLInputElement>(null);
+  const aiResponseRef = useRef<HTMLDivElement>(null);
 
-  // ── AI streaming listeners (only for AI chat requests) ──────────
+  // Keep ref in sync
+  useEffect(() => {
+    activeConversationIdRef.current = activeConversationId;
+  }, [activeConversationId]);
+
+  // Persist conversations on change
+  useEffect(() => {
+    saveConversations(conversations);
+  }, [conversations]);
+
+  // ── Streaming listeners ────────────────────────────────────────
 
   useEffect(() => {
+    const appendToStreamingMessage = (chunk: string) => {
+      const msgId = streamingMessageIdRef.current;
+      if (!msgId) return;
+      setMessages((prev) =>
+        prev.map((m) => (m.id === msgId ? { ...m, content: m.content + chunk } : m))
+      );
+    };
+
+    const finalizeConversation = () => {
+      const convId = activeConversationIdRef.current;
+      if (!convId) return;
+      setMessages((current) => {
+        setConversations((convs) => {
+          const idx = convs.findIndex((c) => c.id === convId);
+          const updated: AiConversation = {
+            id: convId,
+            title:
+              convs[idx]?.title && convs[idx].title !== 'New Chat'
+                ? convs[idx].title
+                : makeTitle(current.find((m) => m.role === 'user')?.content || 'New Chat'),
+            messages: current,
+            createdAt: convs[idx]?.createdAt ?? Date.now(),
+            updatedAt: Date.now(),
+          };
+          const rest = convs.filter((c) => c.id !== convId);
+          return [updated, ...rest];
+        });
+        return current;
+      });
+    };
+
     const handleChunk = (data: { requestId: string; chunk: string }) => {
       if (data.requestId === aiRequestIdRef.current) {
-        setAiResponse((prev) => prev + data.chunk);
+        appendToStreamingMessage(data.chunk);
       }
     };
     const handleDone = (data: { requestId: string }) => {
       if (data.requestId === aiRequestIdRef.current) {
         aiStreamingRef.current = false;
         setAiStreaming(false);
+        streamingMessageIdRef.current = null;
+        finalizeConversation();
       }
     };
     const handleError = (data: { requestId: string; error: string }) => {
       if (data.requestId === aiRequestIdRef.current) {
         aiStreamingRef.current = false;
-        setAiResponse((prev) => prev + `\n\nError: ${data.error}`);
+        const msgId = streamingMessageIdRef.current;
+        if (msgId) {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === msgId
+                ? { ...m, content: m.content + (m.content ? '\n\n' : '') + `Error: ${data.error}` }
+                : m
+            )
+          );
+        }
         setAiStreaming(false);
+        streamingMessageIdRef.current = null;
+        finalizeConversation();
       }
     };
 
@@ -83,72 +207,171 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
     };
   }, []);
 
-  // ── Auto-scroll AI response ─────────────────────────────────────
+  // ── Auto-scroll on new content ─────────────────────────────────
 
   useEffect(() => {
     if (aiResponseRef.current) {
       aiResponseRef.current.scrollTop = aiResponseRef.current.scrollHeight;
     }
-  }, [aiResponse]);
+  }, [messages]);
 
-  // ── Escape to exit AI mode ──────────────────────────────────────
-  // The parent passes `aiMode` implicitly via setAiMode, but we listen
-  // for Escape only when we have an active query or response.
-
-  useEffect(() => {
-    // We can detect "ai mode is active" from internal state: if aiQuery
-    // is set, we're in AI mode. This avoids needing aiMode as a param.
-    if (!aiQuery && !aiResponse && !aiStreaming) return;
-
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        exitAiMode();
-      }
-    };
-    window.addEventListener('keydown', handleEsc);
-    return () => window.removeEventListener('keydown', handleEsc);
-  }, [aiQuery, aiResponse, aiStreaming]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // ── AI availability check on mount ──────────────────────────────
+  // ── Availability check ────────────────────────────────────────
 
   useEffect(() => {
     window.electron.aiIsAvailable().then(setAiAvailable);
   }, []);
 
-  // ── Callbacks ───────────────────────────────────────────────────
+  // ── Internal: send a chat turn ────────────────────────────────
+
+  const sendChatTurn = useCallback((allMessages: AiMessage[]) => {
+    // Cancel any in-flight
+    if (aiRequestIdRef.current && aiStreamingRef.current) {
+      window.electron.aiCancel(aiRequestIdRef.current);
+    }
+    const requestId = uid('ai');
+    aiRequestIdRef.current = requestId;
+    aiStreamingRef.current = true;
+    setAiStreaming(true);
+    const payload = allMessages.map((m) => ({ role: m.role, content: m.content }));
+    window.electron.aiChat(requestId, payload);
+  }, []);
+
+  // ── Actions ───────────────────────────────────────────────────
+
+  const sendMessage = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || !aiAvailable) return;
+
+      // Ensure we have an active conversation
+      let convId = activeConversationIdRef.current;
+      if (!convId) {
+        convId = uid('conv');
+        activeConversationIdRef.current = convId;
+        setActiveConversationId(convId);
+        const newConv: AiConversation = {
+          id: convId,
+          title: makeTitle(trimmed),
+          messages: [],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
+        setConversations((prev) => [newConv, ...prev]);
+      }
+
+      const userMsg: AiMessage = {
+        id: uid('msg'),
+        role: 'user',
+        content: trimmed,
+        createdAt: Date.now(),
+      };
+      const assistantMsg: AiMessage = {
+        id: uid('msg'),
+        role: 'assistant',
+        content: '',
+        createdAt: Date.now(),
+      };
+      streamingMessageIdRef.current = assistantMsg.id;
+
+      setMessages((prev) => {
+        const next = [...prev, userMsg, assistantMsg];
+        sendChatTurn([...prev, userMsg]); // assistant is empty, send context up to user msg
+        return next;
+      });
+      setAiQuery('');
+    },
+    [aiAvailable, sendChatTurn]
+  );
 
   const startAiChat = useCallback(
     (searchQuery: string) => {
-      if (!searchQuery.trim() || !aiAvailable) return;
-      const requestId = `ai-${Date.now()}`;
-      aiRequestIdRef.current = requestId;
-      aiStreamingRef.current = true;
-      setAiQuery(searchQuery);
-      setAiResponse('');
-      setAiStreaming(true);
+      if (!aiAvailable) return;
+      // Start a fresh conversation
+      activeConversationIdRef.current = null;
+      setActiveConversationId(null);
+      setMessages([]);
       setAiMode(true);
-      window.electron.aiAsk(requestId, searchQuery);
+      const trimmed = searchQuery.trim();
+      if (trimmed) {
+        // Send immediately
+        setTimeout(() => sendMessage(trimmed), 0);
+      } else {
+        setAiQuery('');
+      }
     },
-    [aiAvailable, setAiMode],
+    [aiAvailable, setAiMode, sendMessage]
   );
 
-  const submitAiQuery = useCallback(
-    (query: string) => {
-      if (!query.trim()) return;
-      // Cancel any in-flight request
-      if (aiRequestIdRef.current && aiStreamingRef.current) {
-        window.electron.aiCancel(aiRequestIdRef.current);
+  const stopStreaming = useCallback(() => {
+    if (aiRequestIdRef.current && aiStreamingRef.current) {
+      window.electron.aiCancel(aiRequestIdRef.current);
+    }
+    aiStreamingRef.current = false;
+    setAiStreaming(false);
+    const msgId = streamingMessageIdRef.current;
+    if (msgId) {
+      setMessages((prev) =>
+        prev.map((m) => (m.id === msgId ? { ...m, cancelled: true } : m))
+      );
+    }
+    streamingMessageIdRef.current = null;
+    aiRequestIdRef.current = null;
+  }, []);
+
+  const newChat = useCallback(() => {
+    if (aiRequestIdRef.current && aiStreamingRef.current) {
+      window.electron.aiCancel(aiRequestIdRef.current);
+    }
+    aiRequestIdRef.current = null;
+    aiStreamingRef.current = false;
+    streamingMessageIdRef.current = null;
+    activeConversationIdRef.current = null;
+    setActiveConversationId(null);
+    setMessages([]);
+    setAiStreaming(false);
+    setAiQuery('');
+    setTimeout(() => aiInputRef.current?.focus(), 0);
+  }, []);
+
+  const selectConversation = useCallback((id: string) => {
+    if (aiRequestIdRef.current && aiStreamingRef.current) {
+      window.electron.aiCancel(aiRequestIdRef.current);
+    }
+    aiRequestIdRef.current = null;
+    aiStreamingRef.current = false;
+    streamingMessageIdRef.current = null;
+    setAiStreaming(false);
+
+    setConversations((convs) => {
+      const conv = convs.find((c) => c.id === id);
+      if (conv) {
+        activeConversationIdRef.current = id;
+        setActiveConversationId(id);
+        setMessages(conv.messages);
       }
-      const requestId = `ai-${Date.now()}`;
-      aiRequestIdRef.current = requestId;
-      aiStreamingRef.current = true;
-      setAiQuery(query);
-      setAiResponse('');
-      setAiStreaming(true);
-      window.electron.aiAsk(requestId, query);
+      return convs;
+    });
+    setAiQuery('');
+    setTimeout(() => aiInputRef.current?.focus(), 0);
+  }, []);
+
+  const deleteConversation = useCallback(
+    (id: string) => {
+      setConversations((prev) => prev.filter((c) => c.id !== id));
+      if (activeConversationIdRef.current === id) {
+        activeConversationIdRef.current = null;
+        setActiveConversationId(null);
+        setMessages([]);
+        if (aiRequestIdRef.current && aiStreamingRef.current) {
+          window.electron.aiCancel(aiRequestIdRef.current);
+        }
+        aiRequestIdRef.current = null;
+        aiStreamingRef.current = false;
+        streamingMessageIdRef.current = null;
+        setAiStreaming(false);
+      }
     },
-    [],
+    []
   );
 
   const exitAiMode = useCallback(() => {
@@ -157,24 +380,45 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
     }
     aiRequestIdRef.current = null;
     aiStreamingRef.current = false;
+    streamingMessageIdRef.current = null;
     setAiMode(false);
-    setAiResponse('');
     setAiStreaming(false);
     setAiQuery('');
+    // Keep messages + activeConversationId so returning shows the same chat.
     onExitAiMode?.();
   }, [setAiMode, onExitAiMode]);
 
+  // ── Escape to exit AI mode (only while messages/query/streaming) ──
+
+  useEffect(() => {
+    if (messages.length === 0 && !aiQuery && !aiStreaming) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        exitAiMode();
+      }
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [messages.length, aiQuery, aiStreaming, exitAiMode]);
+
   return {
-    aiResponse,
+    messages,
     aiStreaming,
     aiAvailable,
     aiQuery,
     setAiQuery,
-    aiResponseRef,
     aiInputRef,
+    aiResponseRef,
     setAiAvailable,
+    conversations,
+    activeConversationId,
     startAiChat,
-    submitAiQuery,
+    sendMessage,
+    stopStreaming,
+    newChat,
+    selectConversation,
+    deleteConversation,
     exitAiMode,
   };
 }

--- a/src/renderer/src/views/AiChatView.tsx
+++ b/src/renderer/src/views/AiChatView.tsx
@@ -15,6 +15,7 @@ import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { ArrowLeft, Plus, ChevronLeft, ChevronRight, History, Trash2, Eraser } from 'lucide-react';
 import { renderSimpleMarkdown } from '../raycast-api/detail-markdown';
 import type { AiMessage, AiConversation } from '../hooks/useAiChat';
+import ConfirmDeleteDialog from '../components/ConfirmDeleteDialog';
 import supercmdLogo from '../../../../supercmd.png';
 
 interface AiChatViewProps {
@@ -438,6 +439,16 @@ const AiChatView: React.FC<AiChatViewProps> = ({
 
   const [actionsOpen, setActionsOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [confirm, setConfirm] = useState<
+    | {
+        title: string;
+        target?: string;
+        message?: React.ReactNode;
+        confirmLabel: string;
+        onConfirm: () => void;
+      }
+    | null
+  >(null);
 
   // Keep the latest card pinned to the TOP of the viewport:
   // when a new pair is added, scroll container so the new card's offsetTop
@@ -490,18 +501,60 @@ const AiChatView: React.FC<AiChatViewProps> = ({
   }, [hasNext, activeIdx, conversations, selectConversation]);
 
   const deleteCurrentChat = useCallback(() => {
-    if (activeConversationId) deleteConversation(activeConversationId);
-    else newChat();
-  }, [activeConversationId, deleteConversation, newChat]);
+    if (!activeConversationId) {
+      newChat();
+      return;
+    }
+    const active = conversations.find((c) => c.id === activeConversationId);
+    setConfirm({
+      title: 'Delete Chat',
+      target: active?.title || 'this chat',
+      confirmLabel: 'Delete',
+      onConfirm: () => {
+        deleteConversation(activeConversationId);
+        setConfirm(null);
+      },
+    });
+  }, [activeConversationId, conversations, deleteConversation, newChat]);
 
   const deleteAllHistory = useCallback(() => {
-    for (const c of [...conversations]) deleteConversation(c.id);
-    newChat();
+    if (conversations.length === 0) return;
+    const n = conversations.length;
+    setConfirm({
+      title: 'Delete All History',
+      message: (
+        <>
+          {n} conversation{n === 1 ? '' : 's'} will be permanently removed. This action cannot be undone.
+        </>
+      ),
+      confirmLabel: 'Delete All',
+      onConfirm: () => {
+        for (const c of [...conversations]) deleteConversation(c.id);
+        newChat();
+        setConfirm(null);
+      },
+    });
   }, [conversations, deleteConversation, newChat]);
+
+  const requestDeleteConversation = useCallback(
+    (id: string) => {
+      const c = conversations.find((x) => x.id === id);
+      setConfirm({
+        title: 'Delete Chat',
+        target: c?.title || 'this chat',
+        confirmLabel: 'Delete',
+        onConfirm: () => {
+          deleteConversation(id);
+          setConfirm(null);
+        },
+      });
+    },
+    [conversations, deleteConversation]
+  );
 
   const actions: ActionItem[] = useMemo(() => {
     const list: ActionItem[] = [
-      { id: 'new', title: 'New Question', icon: <Plus size={14} />, shortcut: ['⌘', 'N'], onRun: newChat, section: '' },
+      { id: 'new', title: 'New Chat', icon: <Plus size={14} />, shortcut: ['⌘', 'N'], onRun: newChat, section: '' },
     ];
     if (hasPrev) list.push({ id: 'prev', title: 'Previous Chat', icon: <ChevronLeft size={14} />, shortcut: ['⌘', '['], onRun: goPrevChat });
     if (hasNext) list.push({ id: 'next', title: 'Next Chat', icon: <ChevronRight size={14} />, shortcut: ['⌘', ']'], onRun: goNextChat });
@@ -514,7 +567,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({
   // Global hotkeys (suppressed while overlays open — they own their keys)
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (actionsOpen || historyOpen) return;
+      if (actionsOpen || historyOpen || confirm) return;
       const meta = e.metaKey || e.ctrlKey;
       if (!meta) return;
       const k = e.key.toLowerCase();
@@ -535,7 +588,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [actionsOpen, historyOpen, newChat, goPrevChat, goNextChat, deleteCurrentChat, deleteAllHistory, hasCurrentChat, hasHistory]);
+  }, [actionsOpen, historyOpen, confirm, newChat, goPrevChat, goNextChat, deleteCurrentChat, deleteAllHistory, hasCurrentChat, hasHistory]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -667,9 +720,22 @@ const AiChatView: React.FC<AiChatViewProps> = ({
               conversations={conversations}
               activeId={activeConversationId}
               onSelect={selectConversation}
-              onDelete={deleteConversation}
+              onDelete={requestDeleteConversation}
               onClose={() => {
                 setHistoryOpen(false);
+                setTimeout(() => aiInputRef.current?.focus(), 0);
+              }}
+            />
+          )}
+          {confirm && (
+            <ConfirmDeleteDialog
+              title={confirm.title}
+              target={confirm.target}
+              message={confirm.message}
+              confirmLabel={confirm.confirmLabel}
+              onConfirm={confirm.onConfirm}
+              onCancel={() => {
+                setConfirm(null);
                 setTimeout(() => aiInputRef.current?.focus(), 0);
               }}
             />

--- a/src/renderer/src/views/AiChatView.tsx
+++ b/src/renderer/src/views/AiChatView.tsx
@@ -1,116 +1,679 @@
 /**
  * AiChatView.tsx
  *
- * Full-screen AI chat panel shown when the launcher is in AI mode.
- * - Editable query input at the top (pre-filled with the search text that triggered AI mode)
- * - Streaming response area that auto-scrolls as chunks arrive
- * - Enter re-submits, Escape exits AI mode
- * - "Ask / Enter" button visible only when the input has content
+ * Multi-turn AI chat panel (Raycast-style, single-column).
+ * Header: back arrow + single-line "Ask follow-up…" input
+ * Body: list of QA cards; newest card scrolls to top (old cards slide up)
+ * Footer: SuperCmd logo + "Ask AI" label, plain "Actions ⌘K" text button
  *
- * State is managed by useAiChat (hooks/useAiChat.ts); this component is pure UI.
- * Rendered by App.tsx when aiMode === true.
+ * Popups:
+ * - Actions overlay: mirrors NotesManager ActionsOverlay (bottom-right panel, search)
+ * - History overlay: mirrors NotesManager BrowseOverlay (centered 360px modal)
  */
 
-import React from 'react';
-import { X, Sparkles } from 'lucide-react';
+import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import { ArrowLeft, Plus, ChevronLeft, ChevronRight, History, Trash2, Eraser } from 'lucide-react';
+import { renderSimpleMarkdown } from '../raycast-api/detail-markdown';
+import type { AiMessage, AiConversation } from '../hooks/useAiChat';
+import supercmdLogo from '../../../../supercmd.png';
 
 interface AiChatViewProps {
   alwaysMountedRunners: React.ReactNode;
   aiQuery: string;
   setAiQuery: (query: string) => void;
-  aiResponse: string;
+  messages: AiMessage[];
   aiStreaming: boolean;
   aiInputRef: React.RefObject<HTMLInputElement>;
   aiResponseRef: React.RefObject<HTMLDivElement>;
-  submitAiQuery: (query: string) => void;
+  conversations: AiConversation[];
+  activeConversationId: string | null;
+  sendMessage: (text: string) => void;
+  stopStreaming: () => void;
+  newChat: () => void;
+  selectConversation: (id: string) => void;
+  deleteConversation: (id: string) => void;
   exitAiMode: () => void;
 }
+
+// ─── Menu panel style (matches launcher + NotesManager) ──────────────
+
+function getMenuPanelStyle(): { className: string; style: React.CSSProperties } {
+  const isGlassyTheme =
+    document.documentElement.classList.contains('sc-glassy') ||
+    document.body.classList.contains('sc-glassy');
+  const isNativeLiquidGlass =
+    document.documentElement.classList.contains('sc-native-liquid-glass') ||
+    document.body.classList.contains('sc-native-liquid-glass');
+
+  const className = (isNativeLiquidGlass || isGlassyTheme)
+    ? 'rounded-3xl p-1'
+    : 'rounded-xl shadow-2xl';
+
+  const style: React.CSSProperties = isNativeLiquidGlass
+    ? {
+        background: 'rgba(var(--surface-base-rgb), 0.72)',
+        backdropFilter: 'blur(44px) saturate(155%)',
+        WebkitBackdropFilter: 'blur(44px) saturate(155%)' as any,
+        border: '1px solid rgba(var(--on-surface-rgb), 0.22)',
+        boxShadow: '0 18px 38px -12px rgba(var(--backdrop-rgb), 0.26), inset 0 -1px 0 0 rgba(var(--on-surface-rgb), 0.05)',
+      }
+    : isGlassyTheme
+    ? {
+        background: 'linear-gradient(160deg, rgba(255,255,255,0.16) 0%, rgba(255,255,255,0.035) 38%, rgba(255,255,255,0.07) 100%), rgba(var(--surface-base-rgb), 0.58)',
+        backdropFilter: 'blur(128px) saturate(195%) contrast(107%) brightness(1.03)',
+        WebkitBackdropFilter: 'blur(128px) saturate(195%) contrast(107%) brightness(1.03)' as any,
+        border: '1px solid rgba(255, 255, 255, 0.14)',
+        boxShadow: '0 28px 58px -14px rgba(0,0,0,0.42), inset 0 -1px 0 0 rgba(0,0,0,0.08)',
+      }
+    : {
+        background: 'linear-gradient(var(--card-bg), var(--card-bg)), var(--bg-primary)',
+        border: '1px solid var(--border-primary)',
+      };
+
+  return { className, style };
+}
+
+// ─── QA pair grouping ────────────────────────────────────────────────
+
+interface QAPair {
+  id: string;
+  question: string;
+  answer: AiMessage | null;
+}
+
+function groupIntoPairs(messages: AiMessage[]): QAPair[] {
+  const pairs: QAPair[] = [];
+  let i = 0;
+  while (i < messages.length) {
+    const m = messages[i];
+    if (m.role === 'user') {
+      const next = messages[i + 1];
+      if (next && next.role === 'assistant') {
+        pairs.push({ id: m.id, question: m.content, answer: next });
+        i += 2;
+      } else {
+        pairs.push({ id: m.id, question: m.content, answer: null });
+        i += 1;
+      }
+    } else {
+      pairs.push({ id: m.id, question: '', answer: m });
+      i += 1;
+    }
+  }
+  return pairs;
+}
+
+function formatRelativeTime(ts: number): string {
+  const diff = Date.now() - ts;
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return 'just now';
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+// ─── QA Card ────────────────────────────────────────────────────────
+
+const QACard: React.FC<{ pair: QAPair; isStreaming: boolean }> = ({ pair, isStreaming }) => {
+  const answerContent = pair.answer?.content || '';
+  const cancelled = pair.answer?.cancelled;
+  const showThinking = isStreaming && !answerContent;
+
+  return (
+    <div
+      className="rounded-lg px-4 py-3"
+      style={{
+        background: cancelled
+          ? 'color-mix(in srgb, var(--danger, #ef4444) 8%, var(--ui-segment-active-bg))'
+          : 'var(--ui-segment-active-bg)',
+        border: cancelled
+          ? '1px solid color-mix(in srgb, var(--danger, #ef4444) 40%, transparent)'
+          : '1px solid var(--ui-segment-border)',
+      }}
+    >
+      {pair.question && (
+        <div className="text-[13px] text-[var(--text-muted)] mb-2">{pair.question}</div>
+      )}
+      {showThinking ? (
+        <div className="flex items-center gap-1 py-1">
+          <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent)] animate-pulse" />
+          <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent)] animate-pulse" style={{ animationDelay: '0.2s' }} />
+          <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent)] animate-pulse" style={{ animationDelay: '0.4s' }} />
+        </div>
+      ) : answerContent ? (
+        <div className="text-[14px] leading-relaxed text-[var(--text-primary)] ai-markdown">
+          {renderSimpleMarkdown(answerContent, (src) => src)}
+        </div>
+      ) : null}
+      {cancelled && (
+        <div className="mt-2 inline-flex items-center gap-1.5 text-[11px] text-[var(--danger,#ef4444)]">
+          <span className="w-1.5 h-1.5 rounded-full bg-[var(--danger,#ef4444)]" />
+          Cancelled
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── Actions Overlay (launcher-style) ───────────────────────────────
+
+interface ActionItem {
+  id: string;
+  title: string;
+  icon: React.ReactNode;
+  shortcut: string[];
+  onRun: () => void;
+  danger?: boolean;
+  section?: string;
+}
+
+const ActionsOverlay: React.FC<{ actions: ActionItem[]; onClose: () => void }> = ({ actions, onClose }) => {
+  const [query, setQuery] = useState('');
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return actions;
+    const q = query.toLowerCase();
+    return actions.filter((a) => a.title.toLowerCase().includes(q));
+  }, [actions, query]);
+
+  useEffect(() => setSelectedIdx(0), [query]);
+  useEffect(() => { inputRef.current?.focus(); }, []);
+  useEffect(() => {
+    const items = listRef.current?.querySelectorAll('[data-action-item]');
+    (items?.[selectedIdx] as HTMLElement | undefined)?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIdx]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); onClose(); return; }
+      if (e.key === 'ArrowDown') { e.preventDefault(); setSelectedIdx((i) => Math.min(i + 1, filtered.length - 1)); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); setSelectedIdx((i) => Math.max(0, i - 1)); return; }
+      if (e.key === 'Enter' && filtered[selectedIdx]) {
+        e.preventDefault();
+        e.stopPropagation();
+        filtered[selectedIdx].onRun();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [filtered, selectedIdx, onClose]);
+
+  // Group by section, preserving order
+  const grouped = useMemo(() => {
+    const groups: Array<{ section: string; items: ActionItem[] }> = [];
+    let current = '__init__';
+    for (const a of filtered) {
+      const section = a.section || '';
+      if (section !== current) {
+        groups.push({ section, items: [] });
+        current = section;
+      }
+      groups[groups.length - 1].items.push(a);
+    }
+    return groups;
+  }, [filtered]);
+
+  const panel = getMenuPanelStyle();
+  let flatIdx = 0;
+
+  return (
+    <div className="fixed inset-0 z-[9999]" style={{ background: 'var(--bg-scrim)' }}>
+      <div className="absolute inset-0" onClick={onClose} />
+      <div
+        className={`absolute bottom-12 right-3 w-80 max-h-[65vh] overflow-hidden flex flex-col ${panel.className}`}
+        style={panel.style}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div ref={listRef} className="flex-1 overflow-y-auto custom-scrollbar py-1">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-4 text-center text-[var(--text-disabled)] text-sm">No matching actions</div>
+          ) : (
+            grouped.map((group, gi) => (
+              <div key={group.section || `__${gi}`}>
+                {gi > 0 && <hr className="border-[var(--ui-divider)] my-0.5" />}
+                {group.section && (
+                  <div className="px-3 pt-1.5 pb-0.5 text-[10px] uppercase tracking-wider text-[var(--text-subtle)] font-medium select-none">
+                    {group.section}
+                  </div>
+                )}
+                {group.items.map((action) => {
+                  const idx = flatIdx++;
+                  return (
+                    <div
+                      key={action.id}
+                      data-action-item
+                      onClick={() => { action.onRun(); onClose(); }}
+                      onMouseEnter={() => setSelectedIdx(idx)}
+                      className={`flex items-center gap-3 px-3 py-[7px] cursor-pointer transition-colors ${action.danger ? 'text-red-400' : 'text-[var(--text-secondary)]'}`}
+                      style={idx === selectedIdx ? { background: 'rgba(255,255,255,0.08)' } : undefined}
+                    >
+                      <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center opacity-60">
+                        {action.icon}
+                      </span>
+                      <span className="flex-1 text-[12px]">{action.title}</span>
+                      <span className="flex items-center gap-0.5 flex-shrink-0">
+                        {action.shortcut.map((k, ki) => (
+                          <kbd key={ki} className="inline-flex items-center justify-center min-w-[20px] h-[18px] px-1 rounded bg-[var(--kbd-bg)] text-[10px] text-[var(--text-subtle)] font-medium">
+                            {k}
+                          </kbd>
+                        ))}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            ))
+          )}
+        </div>
+        <div className="border-t border-[var(--ui-divider)] px-3 py-2">
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search for actions..."
+            className="w-full bg-transparent text-sm text-[var(--text-primary)] placeholder:text-[var(--text-subtle)] outline-none"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── History Overlay (Browse-style centered modal) ──────────────────
+
+const HistoryOverlay: React.FC<{
+  conversations: AiConversation[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+  onClose: () => void;
+}> = ({ conversations, activeId, onSelect, onDelete, onClose }) => {
+  const [query, setQuery] = useState('');
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return conversations;
+    const q = query.toLowerCase();
+    return conversations.filter(
+      (c) =>
+        c.title.toLowerCase().includes(q) ||
+        c.messages.some((m) => m.content.toLowerCase().includes(q))
+    );
+  }, [conversations, query]);
+
+  useEffect(() => setSelectedIdx(0), [query]);
+  useEffect(() => { inputRef.current?.focus(); }, []);
+  useEffect(() => {
+    const items = listRef.current?.querySelectorAll('[data-history-item]');
+    (items?.[selectedIdx] as HTMLElement | undefined)?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIdx]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); onClose(); return; }
+      if (e.key === 'ArrowDown') { e.preventDefault(); setSelectedIdx((i) => Math.min(i + 1, filtered.length - 1)); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); setSelectedIdx((i) => Math.max(0, i - 1)); return; }
+      if (e.key === 'Enter' && filtered[selectedIdx]) {
+        e.preventDefault();
+        onSelect(filtered[selectedIdx].id);
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [filtered, selectedIdx, onSelect, onClose]);
+
+  const panel = getMenuPanelStyle();
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center">
+      <div className="absolute inset-0" onClick={onClose} style={{ background: 'var(--bg-scrim)' }} />
+      <div
+        className={`relative z-10 w-full max-w-[360px] mx-4 overflow-hidden ${panel.className}`}
+        style={panel.style}
+      >
+        <div className="px-3 py-2.5 border-b border-[var(--ui-divider)]">
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search for chats..."
+            className="w-full bg-transparent text-[var(--text-primary)] text-[13px] placeholder:text-[var(--text-subtle)] outline-none"
+          />
+        </div>
+        <div className="flex items-center justify-between px-3 pt-2 pb-1">
+          <span className="text-[10px] font-semibold text-[var(--text-subtle)] uppercase tracking-wider">Chats</span>
+          <span className="text-[10px] text-[var(--text-disabled)]">{filtered.length} chats</span>
+        </div>
+        <div ref={listRef} className="max-h-[280px] overflow-y-auto custom-scrollbar">
+          {filtered.map((c, idx) => {
+            const isCurrent = c.id === activeId;
+            const isSelected = idx === selectedIdx;
+            const charCount = c.messages.reduce((n, m) => n + m.content.length, 0);
+            return (
+              <div
+                key={c.id}
+                data-history-item
+                onClick={() => { onSelect(c.id); onClose(); }}
+                onMouseEnter={() => setSelectedIdx(idx)}
+                className="group px-3 py-2 cursor-pointer transition-colors"
+                style={isSelected ? { background: 'rgba(255,255,255,0.08)' } : undefined}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-[12px] text-[var(--text-primary)] font-medium truncate flex-1">
+                    {c.title || 'New Chat'}
+                  </span>
+                  <div className={`flex items-center gap-0.5 flex-shrink-0 ${isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}>
+                    <button
+                      title="Delete"
+                      onClick={(e) => { e.stopPropagation(); onDelete(c.id); }}
+                      className="p-1 rounded text-[var(--text-subtle)] hover:text-red-400 hover:bg-[var(--bg-secondary)] transition-colors"
+                    >
+                      <Trash2 size={11} />
+                    </button>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1.5 mt-0.5">
+                  {isCurrent ? (
+                    <>
+                      <span className="w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ background: 'var(--accent)' }} />
+                      <span className="text-[10px] text-[var(--text-muted)]">Current</span>
+                    </>
+                  ) : (
+                    <span className="text-[10px] text-[var(--text-disabled)]">{formatRelativeTime(c.updatedAt)}</span>
+                  )}
+                  <span className="text-[10px] text-[var(--text-disabled)]">&middot;</span>
+                  <span className="text-[10px] text-[var(--text-disabled)]">{c.messages.length} messages</span>
+                  <span className="text-[10px] text-[var(--text-disabled)]">&middot;</span>
+                  <span className="text-[10px] text-[var(--text-disabled)]">{charCount} chars</span>
+                </div>
+              </div>
+            );
+          })}
+          {filtered.length === 0 && (
+            <div className="px-3 py-4 text-center text-[11px] text-[var(--text-disabled)]">
+              No chats found
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── Main View ──────────────────────────────────────────────────────
 
 const AiChatView: React.FC<AiChatViewProps> = ({
   alwaysMountedRunners,
   aiQuery,
   setAiQuery,
-  aiResponse,
+  messages,
   aiStreaming,
   aiInputRef,
   aiResponseRef,
-  submitAiQuery,
+  conversations,
+  activeConversationId,
+  sendMessage,
+  stopStreaming,
+  newChat,
+  selectConversation,
+  deleteConversation,
   exitAiMode,
 }) => {
+  const pairs = useMemo(() => groupIntoPairs(messages), [messages]);
+  const prevPairCountRef = useRef(pairs.length);
+  const pairRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const spacerRef = useRef<HTMLDivElement>(null);
+
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  // Keep the latest card pinned to the TOP of the viewport:
+  // when a new pair is added, scroll container so the new card's offsetTop
+  // lines up with the top of the scrollable area.
+  useEffect(() => {
+    if (pairs.length > prevPairCountRef.current) {
+      const lastId = pairs[pairs.length - 1]?.id;
+      const container = aiResponseRef.current;
+      // defer to next frame so the new DOM node (+ spacer) is measured
+      const r = requestAnimationFrame(() => {
+        const el = lastId ? pairRefs.current.get(lastId) : null;
+        if (el && container) {
+          const top = el.offsetTop - container.offsetTop;
+          container.scrollTo({ top, behavior: 'smooth' });
+        }
+      });
+      return () => cancelAnimationFrame(r);
+    }
+    prevPairCountRef.current = pairs.length;
+  }, [pairs.length, aiResponseRef]);
+
+  // Ensure spacer is tall enough to allow latest card to reach the top of the viewport.
+  // spacerHeight = container.clientHeight - card.offsetHeight
+  useEffect(() => {
+    const container = aiResponseRef.current;
+    const spacer = spacerRef.current;
+    if (!container || !spacer || pairs.length === 0) return;
+    const lastId = pairs[pairs.length - 1]?.id;
+    const el = lastId ? pairRefs.current.get(lastId) : null;
+    if (!el) return;
+    const target = Math.max(0, container.clientHeight - el.offsetHeight - 24);
+    spacer.style.height = `${target}px`;
+  }, [pairs, aiResponseRef]);
+
+  // Navigation across conversations: conversations[] is newest-first.
+  const activeIdx = conversations.findIndex((c) => c.id === activeConversationId);
+  const hasPrev = activeIdx >= 0 && activeIdx < conversations.length - 1;
+  const hasNext = activeIdx > 0;
+  const hasCurrentChat = pairs.length > 0;
+  const hasHistory = conversations.length > 0;
+
+  const goPrevChat = useCallback(() => {
+    if (!hasPrev) return;
+    selectConversation(conversations[activeIdx + 1].id);
+  }, [hasPrev, activeIdx, conversations, selectConversation]);
+
+  const goNextChat = useCallback(() => {
+    if (!hasNext) return;
+    selectConversation(conversations[activeIdx - 1].id);
+  }, [hasNext, activeIdx, conversations, selectConversation]);
+
+  const deleteCurrentChat = useCallback(() => {
+    if (activeConversationId) deleteConversation(activeConversationId);
+    else newChat();
+  }, [activeConversationId, deleteConversation, newChat]);
+
+  const deleteAllHistory = useCallback(() => {
+    for (const c of [...conversations]) deleteConversation(c.id);
+    newChat();
+  }, [conversations, deleteConversation, newChat]);
+
+  const actions: ActionItem[] = useMemo(() => {
+    const list: ActionItem[] = [
+      { id: 'new', title: 'New Question', icon: <Plus size={14} />, shortcut: ['⌘', 'N'], onRun: newChat, section: '' },
+    ];
+    if (hasPrev) list.push({ id: 'prev', title: 'Previous Chat', icon: <ChevronLeft size={14} />, shortcut: ['⌘', '['], onRun: goPrevChat });
+    if (hasNext) list.push({ id: 'next', title: 'Next Chat', icon: <ChevronRight size={14} />, shortcut: ['⌘', ']'], onRun: goNextChat });
+    list.push({ id: 'history', title: 'Show History', icon: <History size={14} />, shortcut: ['⌘', 'H'], onRun: () => setHistoryOpen(true) });
+    if (hasCurrentChat) list.push({ id: 'delete-chat', title: 'Delete Chat', icon: <Trash2 size={14} />, shortcut: ['⌘', 'X'], onRun: deleteCurrentChat, danger: true });
+    if (hasHistory) list.push({ id: 'delete-history', title: 'Delete History', icon: <Eraser size={14} />, shortcut: ['⌘', '⇧', 'X'], onRun: deleteAllHistory, danger: true });
+    return list;
+  }, [hasPrev, hasNext, hasCurrentChat, hasHistory, newChat, goPrevChat, goNextChat, deleteCurrentChat, deleteAllHistory]);
+
+  // Global hotkeys (suppressed while overlays open — they own their keys)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (actionsOpen || historyOpen) return;
+      const meta = e.metaKey || e.ctrlKey;
+      if (!meta) return;
+      const k = e.key.toLowerCase();
+      if (k === 'k') { e.preventDefault(); setActionsOpen(true); }
+      else if (k === 'n') { e.preventDefault(); newChat(); }
+      else if (e.key === '[') { e.preventDefault(); goPrevChat(); }
+      else if (e.key === ']') { e.preventDefault(); goNextChat(); }
+      else if (k === 'h') { e.preventDefault(); setHistoryOpen(true); }
+      else if (k === 'x' && e.shiftKey) {
+        if (!hasHistory) return;
+        e.preventDefault();
+        deleteAllHistory();
+      } else if (k === 'x') {
+        if (!hasCurrentChat) return;
+        e.preventDefault();
+        deleteCurrentChat();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [actionsOpen, historyOpen, newChat, goPrevChat, goNextChat, deleteCurrentChat, deleteAllHistory, hasCurrentChat, hasHistory]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (aiStreaming) {
+        stopStreaming();
+        return;
+      }
+      if (aiQuery.trim()) sendMessage(aiQuery);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      exitAiMode();
+    }
+  };
+
+  const placeholder = pairs.length === 0 ? 'Ask AI anything…' : 'Ask follow-up…';
+
   return (
     <>
       {alwaysMountedRunners}
       <div className="w-full h-full">
-        <div className="glass-effect overflow-hidden h-full flex flex-col">
-          {/* AI header — editable input */}
-          <div className="drag-region flex items-center gap-3 px-5 py-3.5 border-b border-[var(--ui-divider)]">
-            <Sparkles className="w-4 h-4 text-[var(--accent)] flex-shrink-0" />
+        <div className="glass-effect overflow-hidden h-full flex flex-col relative">
+          {/* Header */}
+          <div className="drag-region flex items-center gap-3 px-4 py-3 border-b border-[var(--ui-divider)]">
+            <button
+              onClick={exitAiMode}
+              className="w-7 h-7 flex items-center justify-center rounded-md hover:bg-[var(--ui-segment-hover-bg)] text-[var(--text-primary)] transition-colors flex-shrink-0"
+              title="Back"
+              style={{ background: 'var(--ui-segment-active-bg)', border: '1px solid var(--ui-segment-border)' }}
+            >
+              <ArrowLeft className="w-3.5 h-3.5" />
+            </button>
             <input
               ref={aiInputRef}
               type="text"
               value={aiQuery}
               onChange={(e) => setAiQuery(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && aiQuery.trim()) {
-                  e.preventDefault();
-                  submitAiQuery(aiQuery);
-                } else if (e.key === 'Escape') {
-                  e.preventDefault();
-                  exitAiMode();
-                }
-              }}
-              placeholder="Ask AI anything..."
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
               className="flex-1 bg-transparent border-none outline-none text-[var(--text-primary)] placeholder:text-[color:var(--text-muted)] text-[15px] font-light tracking-wide min-w-0"
               autoFocus
             />
-            {aiQuery.trim() && (
-              <button
-                onClick={() => submitAiQuery(aiQuery)}
-                className="flex items-center gap-1.5 px-2 py-1 rounded-md border border-[var(--ui-segment-border)] bg-[var(--ui-segment-active-bg)] hover:bg-[var(--ui-segment-hover-bg)] transition-colors flex-shrink-0 group"
-              >
-                <span className="text-[11px] text-[var(--text-secondary)] group-hover:text-[var(--text-primary)] transition-colors">Ask</span>
-                <kbd className="text-[10px] text-[var(--text-muted)] bg-[var(--kbd-bg)] px-1 py-0.5 rounded font-mono leading-none">Enter</kbd>
-              </button>
-            )}
-            <button
-              onClick={exitAiMode}
-              className="text-[var(--text-subtle)] hover:text-[var(--text-muted)] transition-colors flex-shrink-0"
-            >
-              <X className="w-4 h-4" />
-            </button>
           </div>
 
-          {/* AI response */}
+          {/* Body: QA cards + tall spacer to let latest card anchor at top */}
           <div
             ref={aiResponseRef}
-            className="flex-1 overflow-y-auto custom-scrollbar p-5"
+            className="flex-1 overflow-y-auto custom-scrollbar px-4 py-3 space-y-3"
           >
-            {aiResponse ? (
-              <div className="text-[var(--text-primary)] text-sm leading-relaxed whitespace-pre-wrap font-normal">
-                {aiResponse}
+            {pairs.length === 0 ? (
+              <div className="h-full flex items-center justify-center text-center">
+                <div className="text-sm text-[var(--text-muted)]">Ask anything to get started</div>
               </div>
-            ) : aiStreaming ? (
-              <div className="flex items-center gap-2 text-[var(--text-muted)] text-sm">
-                <div className="flex gap-1">
-                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent)] animate-pulse" />
-                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent)] animate-pulse" style={{ animationDelay: '0.2s' }} />
-                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent)] animate-pulse" style={{ animationDelay: '0.4s' }} />
-                </div>
-                Thinking...
-              </div>
-            ) : null}
+            ) : (
+              <>
+                {pairs.map((p, idx) => {
+                  const isLast = idx === pairs.length - 1;
+                  const isStreamingThis = aiStreaming && isLast;
+                  return (
+                    <div
+                      key={p.id}
+                      ref={(el) => {
+                        if (el) pairRefs.current.set(p.id, el);
+                        else pairRefs.current.delete(p.id);
+                      }}
+                    >
+                      <QACard pair={p} isStreaming={isStreamingThis} />
+                    </div>
+                  );
+                })}
+                <div ref={spacerRef} aria-hidden="true" />
+              </>
+            )}
           </div>
 
-          {/* Footer */}
-          <div className="sc-glass-footer px-4 py-2.5 flex items-center justify-between text-xs text-[var(--text-subtle)] font-normal">
-            <span>{aiStreaming ? 'Streaming...' : 'AI Response'}</span>
+          {/* Footer (launcher-style: plain text + kbd badges, no pill) */}
+          <div className="sc-glass-footer px-4 py-2.5 flex items-center justify-between text-xs">
             <div className="flex items-center gap-2">
-              <kbd className="text-[10px] text-[var(--text-muted)] bg-[var(--kbd-bg)] px-1.5 py-0.5 rounded font-mono">Enter</kbd>
-              <span className="text-[10px] text-[var(--text-muted)]">Ask</span>
-              <kbd className="text-[10px] text-[var(--text-muted)] bg-[var(--kbd-bg)] px-1.5 py-0.5 rounded font-mono">Esc</kbd>
-              <span className="text-[10px] text-[var(--text-muted)]">Back</span>
+              <img src={supercmdLogo} alt="SuperCmd" className="w-4 h-4 rounded-sm" />
+              <span className="text-[12px] text-[var(--text-primary)]">Ask AI</span>
+            </div>
+            <div className="flex items-center gap-3">
+              {(() => {
+                const hasMessages = messages.length > 0;
+                const hasQuery = aiQuery.trim().length > 0;
+                let label: string | null = null;
+                let onClick: (() => void) | null = null;
+                if (aiStreaming) {
+                  label = 'Cancel';
+                  onClick = stopStreaming;
+                } else if (hasQuery) {
+                  label = hasMessages ? 'Ask Follow-up' : 'Ask AI';
+                  onClick = () => sendMessage(aiQuery);
+                }
+                if (!label) return null;
+                return (
+                  <button
+                    onClick={onClick ?? undefined}
+                    className="flex items-center gap-1.5 text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+                  >
+                    <span className="text-xs font-normal">{label}</span>
+                    <kbd className="inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 rounded bg-[var(--kbd-bg)] text-[0.6875rem] text-[var(--text-subtle)] font-medium">↵</kbd>
+                  </button>
+                );
+              })()}
+              <div className="w-px h-4 bg-[var(--border-subtle)]" />
+              <button
+                onClick={() => setActionsOpen(true)}
+                className="flex items-center gap-1.5 text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+              >
+                <span className="text-xs font-normal">Actions</span>
+                <kbd className="inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 rounded bg-[var(--kbd-bg)] text-[0.6875rem] text-[var(--text-subtle)] font-medium">⌘</kbd>
+                <kbd className="inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 rounded bg-[var(--kbd-bg)] text-[0.6875rem] text-[var(--text-subtle)] font-medium">K</kbd>
+              </button>
             </div>
           </div>
+
+          {actionsOpen && (
+            <ActionsOverlay
+              actions={actions}
+              onClose={() => {
+                setActionsOpen(false);
+                setTimeout(() => aiInputRef.current?.focus(), 0);
+              }}
+            />
+          )}
+          {historyOpen && (
+            <HistoryOverlay
+              conversations={conversations}
+              activeId={activeConversationId}
+              onSelect={selectConversation}
+              onDelete={deleteConversation}
+              onClose={() => {
+                setHistoryOpen(false);
+                setTimeout(() => aiInputRef.current?.focus(), 0);
+              }}
+            />
+          )}
         </div>
       </div>
     </>

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -783,6 +783,7 @@ export interface ElectronAPI {
 
   // AI
   aiAsk: (requestId: string, prompt: string, options?: { model?: string; creativity?: number; systemPrompt?: string }) => Promise<void>;
+  aiChat: (requestId: string, messages: Array<{ role: 'user' | 'assistant'; content: string }>, options?: { model?: string; creativity?: number; systemPrompt?: string }) => Promise<void>;
   aiCancel: (requestId: string) => Promise<void>;
   aiIsAvailable: () => Promise<boolean>;
   onAIStreamChunk: (callback: (data: { requestId: string; chunk: string }) => void) => (() => void);


### PR DESCRIPTION
## Summary

Rebuilds the Ask AI feature into a full multi-turn chat with persistent history, markdown rendering, and a UI that matches the launcher / NotesManager aesthetic.

### Core
- **Multi-turn chat** — new \`useAiChat\` hook owns \`messages\` + \`conversations\` state. Conversations auto-title from the first user message and persist in \`localStorage\` (\`sc.aiChat.conversations\`, capped at 50, newest-first).
- **Streaming chat across all providers** — new \`streamAIChat\` (\`ai-provider.ts\`) + \`ai-chat\` IPC. Full messages array is sent to OpenAI \`/chat/completions\`, Anthropic \`/v1/messages\`, Gemini \`:streamGenerateContent?alt=sse\` (role user↔user, assistant↔model — fixes the old single-shot Gemini bug), Ollama \`/api/chat\`, and OpenAI-compatible base URLs. Memory context injection preserved.
- **Markdown answers** — responses rendered via \`renderSimpleMarkdown\`.

### UI (Raycast-style, single column)
- Back-arrow header + single-line input (\`Ask AI anything…\` / \`Ask follow-up…\`).
- QA cards; newest card anchors to the **top** of the viewport (spacer + \`scrollTo\` in \`requestAnimationFrame\`).
- Footer: SuperCmd logo + \"Ask AI\" on left; primary action + divider + \"Actions ⌘K\" on right, all plain text + kbd badges (no pill).
- Primary action is context-aware: **Ask AI ↵**, **Ask Follow-up ↵**, or **Cancel ↵** while streaming.

### Actions & History overlays
- \`⌘K\` Actions overlay mirrors NotesManager style (bottom-right panel, search at bottom, arrow/enter nav).
- Items: New Question (⌘N), Previous Chat (⌘[), Next Chat (⌘]), Show History (⌘H), Delete Chat (⌘X), Delete History (⌘⇧X). Prev/Next/Delete items are conditional on state.
- \`⌘H\` History overlay mirrors Browse Notes (centered 360px modal, search, title + relative timestamp + message count + delete).

### Interaction polish
- **Tab** opens Ask AI even with an empty query; if the launcher is in **compact** mode, it expands first so the chat renders at full size.
- Exiting Ask AI (Escape or back arrow) collapses back to compact directly — no second Escape needed.
- Focus returns to the input automatically when the Actions or History overlay closes.
- **Cancel** aborts the in-flight stream (via button or Enter-during-stream), marks the assistant message \`cancelled\`, and the QA card renders a red-tinted background + \"Cancelled\" badge. The cancelled flag persists in history.

## Test plan

- [ ] Open launcher, press **Tab** with empty query → Ask AI opens
- [ ] In **compact** mode: Tab expands launcher into Ask AI; Escape / back arrow collapses back to compact
- [ ] Ask a question → streaming response with dot indicator → newest card anchors at top
- [ ] Ask a follow-up → previous card pushes up, new card at top
- [ ] Footer label switches: Ask AI → Cancel (while streaming) → Ask Follow-up (after done)
- [ ] Press Enter (or click Cancel) while streaming → stream stops, card shows red-tinted Cancelled badge
- [ ] ⌘K opens Actions overlay (launcher style); Escape closes, focus returns to input
- [ ] ⌘H opens History overlay (Browse Notes style); selecting a chat loads it; delete button works
- [ ] ⌘N / ⌘[ / ⌘] / ⌘X / ⌘⇧X shortcuts behave correctly; conditional items hidden when not applicable
- [ ] Conversations persist across app restart; Gemini / OpenAI / Anthropic / Ollama all stream correctly