### PR TITLE
fix(snippets): serialize clipboard ops and auto-restart expander on crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ out/
 
 
 extensions*
-extensions/*
+extensions/*.worktrees/

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -333,6 +333,12 @@ const activeAIRequests = new Map<string, AbortController>(); // requestId → co
 const pendingOAuthCallbackUrls: string[] = [];
 let snippetExpanderProcess: any = null;
 let snippetExpanderStdoutBuffer = '';
+let snippetExpanderIntentionalStop = false; // true when we kill it ourselves (prevent restart loop)
+
+// Serial queue for clipboard-based paste operations.
+// Both snippet expansion and pasteTextToActiveApp write to the clipboard temporarily.
+// Without serialization they race and paste the wrong content.
+let clipboardOpQueue: Promise<void> = Promise.resolve();
 let nativeSpeechProcess: any = null;
 let nativeSpeechStdoutBuffer = '';
 let nativeColorPickerPromise: Promise<any> | null = null;
@@ -3571,27 +3577,36 @@ async function pasteTextToActiveApp(text: string): Promise<boolean> {
   const value = String(text || '');
   if (!value) return false;
 
-  const { execFile } = require('child_process');
-  const { promisify } = require('util');
-  const execFileAsync = promisify(execFile);
-  const previousClipboardText = systemClipboard.readText();
+  // Signal caller as soon as the paste keystroke fires, but hold the queue
+  // slot until the clipboard is restored so concurrent ops don't read our
+  // temporary value as their "original".
+  let signalCaller!: (v: boolean) => void;
+  const callerPromise = new Promise<boolean>((res) => { signalCaller = res; });
 
-  try {
-    systemClipboard.writeText(value);
-    await execFileAsync('osascript', [
-      '-e',
-      'tell application "System Events" to keystroke "v" using command down',
-    ]);
-    setTimeout(() => {
-      try {
-        systemClipboard.writeText(previousClipboardText);
-      } catch {}
-    }, 250);
-    return true;
-  } catch (error) {
-    console.error('pasteTextToActiveApp failed:', error);
-    return false;
-  }
+  clipboardOpQueue = clipboardOpQueue.then(async () => {
+    const { execFile } = require('child_process');
+    const { promisify } = require('util');
+    const execFileAsync = promisify(execFile);
+    const previousClipboardText = systemClipboard.readText();
+
+    try {
+      systemClipboard.writeText(value);
+      await execFileAsync('osascript', [
+        '-e',
+        'tell application "System Events" to keystroke "v" using command down',
+      ]);
+      signalCaller(true);
+      // Hold queue slot until clipboard is restored.
+      await new Promise<void>((resolve) => setTimeout(resolve, 250));
+      systemClipboard.writeText(previousClipboardText);
+    } catch (error) {
+      console.error('pasteTextToActiveApp failed:', error);
+      signalCaller(false);
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    }
+  }).catch(() => {});
+
+  return callerPromise;
 }
 
 async function replaceTextDirectly(previousText: string, nextText: string): Promise<boolean> {
@@ -3701,47 +3716,52 @@ async function hideAndPaste(): Promise<boolean> {
 }
 
 async function expandSnippetKeywordInPlace(keyword: string, delimiter: string): Promise<void> {
-  try {
-    console.log(`[SnippetExpander] trigger keyword="${keyword}" delimiter="${delimiter}"`);
-    const snippet = getSnippetByKeyword(keyword);
-    if (!snippet) return;
+  // Enqueue so this never races with pasteTextToActiveApp or another concurrent expansion.
+  clipboardOpQueue = clipboardOpQueue.then(async () => {
+    try {
+      console.log(`[SnippetExpander] trigger keyword="${keyword}" delimiter="${delimiter}"`);
+      const snippet = getSnippetByKeyword(keyword);
+      if (!snippet) return;
 
-    const resolved = renderSnippetById(snippet.id, {});
-    if (!resolved) return;
+      const resolved = renderSnippetById(snippet.id, {});
+      if (!resolved) return;
 
-    const fullText = `${resolved}${delimiter || ''}`;
-    const backspaceCount = keyword.length + (delimiter ? 1 : 0);
-    if (backspaceCount <= 0) return;
+      const fullText = `${resolved}${delimiter || ''}`;
+      const backspaceCount = keyword.length + (delimiter ? 1 : 0);
+      if (backspaceCount <= 0) return;
 
-    const originalClipboard = electron.clipboard.readText();
-    electron.clipboard.writeText(fullText);
+      const originalClipboard = electron.clipboard.readText();
+      electron.clipboard.writeText(fullText);
 
-    const { execFile } = require('child_process');
-    const { promisify } = require('util');
-    const execFileAsync = promisify(execFile);
+      const { execFile } = require('child_process');
+      const { promisify } = require('util');
+      const execFileAsync = promisify(execFile);
 
-    const script = `
-      tell application "System Events"
-        repeat ${backspaceCount} times
-          key code 51
-        end repeat
-        keystroke "v" using command down
-      end tell
-    `;
+      const script = `
+        tell application "System Events"
+          repeat ${backspaceCount} times
+            key code 51
+          end repeat
+          keystroke "v" using command down
+        end tell
+      `;
 
-    await execFileAsync('osascript', ['-e', script]);
+      await execFileAsync('osascript', ['-e', script]);
 
-    // Restore user's clipboard after insertion.
-    setTimeout(() => {
+      // Restore user's clipboard. Await so the queue slot isn't released until
+      // the clipboard is back to normal (prevents the next op from saving our
+      // temporary snippet content as its "original").
+      await new Promise<void>((resolve) => setTimeout(resolve, 80));
       electron.clipboard.writeText(originalClipboard);
-    }, 80);
-  } catch (error) {
-    console.error('[SnippetExpander] Failed to expand keyword:', error);
-  }
+    } catch (error) {
+      console.error('[SnippetExpander] Failed to expand keyword:', error);
+    }
+  }).catch(() => {});
 }
 
 function stopSnippetExpander(): void {
   if (!snippetExpanderProcess) return;
+  snippetExpanderIntentionalStop = true;
   try {
     snippetExpanderProcess.kill();
   } catch {}
@@ -3809,6 +3829,12 @@ function refreshSnippetExpander(): void {
   snippetExpanderProcess.on('exit', () => {
     snippetExpanderProcess = null;
     snippetExpanderStdoutBuffer = '';
+    if (!snippetExpanderIntentionalStop) {
+      // Unexpected exit (crash, OS signal, etc.) — restart after a short delay.
+      console.warn('[SnippetExpander] Process exited unexpectedly, restarting...');
+      setTimeout(() => refreshSnippetExpander(), 500);
+    }
+    snippetExpanderIntentionalStop = false;
   });
 }
 


### PR DESCRIPTION
## Summary

- **Clipboard race fix**: `expandSnippetKeywordInPlace` and `pasteTextToActiveApp` both temporarily own the clipboard. Without serialization they race — fast-paste (Whisper, Prompt AI) can overwrite the snippet content mid-expansion, causing the wrong text to be pasted and leaving the clipboard permanently polluted. Both functions now run through a serial `clipboardOpQueue` that holds its slot until the clipboard is fully restored.

- **Auto-restart on crash**: If the snippet-expander Swift process died for any reason (OS signal, accessibility permission revoked, pipe break) the `exit` handler only nulled the reference — it never restarted. Users had to restart the whole app. Added a `snippetExpanderIntentionalStop` flag so the handler can distinguish a deliberate `stopSnippetExpander()` kill (already handled by `refreshSnippetExpander`) from an unexpected crash (triggers a 500ms delayed restart).

## Root cause

Regression introduced when `pasteTextToActiveApp` (clipboard + Cmd+V) was added for Whisper live-typing. Before that, only snippet expansion used the clipboard temporarily, so there was no contention.

## Test plan

- [ ] Type a snippet keyword while Whisper is actively transcribing — snippet should expand correctly, not paste Whisper text
- [ ] Verify clipboard is restored to original after expansion
- [ ] Kill the snippet-expander process manually (`pkill snippet-expander`) while the app is running — it should restart automatically within ~500ms without needing an app restart
- [ ] Normal snippet expansion still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)