### PR TITLE
fix: prevent settings window flash when Whisper opens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ out/
 
 
 extensions*
-extensions/*
+extensions/*.worktrees/

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2716,7 +2716,10 @@ function createWindow(): void {
         focusable: detachedPopupName !== DETACHED_WHISPER_WINDOW_NAME,
         skipTaskbar: true,
         alwaysOnTop: true,
-        show: true,
+        // Whisper window must not auto-show via window.open() — showing it normally activates
+        // the parent app, which causes any visible SuperCmd windows (e.g. settings) to flash.
+        // We call showInactive() in did-create-window instead.
+        show: detachedPopupName !== DETACHED_WHISPER_WINDOW_NAME,
         acceptFirstMouse: true,
         webPreferences: {
           nodeIntegration: false,
@@ -2752,6 +2755,9 @@ function createWindow(): void {
       try { childWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true }); } catch {}
       // Ignore mouse events by default so clicks pass through; widget will re-enable on hover
       try { childWindow.setIgnoreMouseEvents(true, { forward: true }); } catch {}
+      // showInactive() uses NSWindow.orderFrontRegardless() — shows the window without
+      // activating the parent app, so the settings window never gets a spurious flash.
+      try { childWindow.showInactive(); } catch {}
       childWindow.on('closed', () => {
         if (whisperChildWindow === childWindow) whisperChildWindow = null;
       });


### PR DESCRIPTION
## Summary
- When the Whisper overlay is created via `window.open()`, Electron's default `show: true` causes macOS to activate the SuperCmd app, briefly flashing any visible windows (e.g. settings)
- Fixed by setting `show: false` for the Whisper window in `setWindowOpenHandler`, then calling `childWindow.showInactive()` (`NSWindow.orderFrontRegardless`) in `did-create-window`
- This shows the overlay without transferring app activation, so the settings window no longer flashes

## Test plan
- [ ] Open Settings window
- [ ] Activate Whisper (e.g. via hotkey)
- [ ] Confirm Whisper overlay appears seamlessly with no settings window flash
- [ ] Confirm Whisper overlay still appears, is always-on-top, and passes mouse events through as before
- [ ] Confirm other detached popup windows (non-Whisper) still show normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)