### PR TITLE
feat: add suport for importing data from raycast exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ SuperCmd is an Electron + React launcher that focuses on Raycast extension compa
 ## Key Features
 
 - **Raycast extension compatibility** — `@raycast/api` and `@raycast/utils` shims; install extensions directly from the Raycast store
+- **Raycast backup import** — import encrypted `.rayconfig` backups with settings, hotkeys, extensions, scripts, quicklinks, snippets, notes, and extension prefs
 - **AI cursor prompt** — inline AI suggestions at your cursor position across any app
 - **AI chat** — chat with configurable providers (OpenAI / Anthropic / Ollama / Gemini / OpenAI-compatible)
 - **Hold-to-speak dictation** — Wispr Flow-style voice input; hold hotkey, speak, release to type (Whisper, Parakeet, or native macOS STT)
@@ -131,6 +132,31 @@ SuperCmd needs the following permissions. The app will prompt you on first use, 
 ### Auto-updates
 
 SuperCmd includes a built-in auto-updater backed by GitHub Releases. You can check for updates manually by searching "Check for Updates" in the launcher, or install a downloaded update on next launch.
+
+### Raycast Backup Import
+
+SuperCmd can import encrypted Raycast `.rayconfig` backups from the General settings tab.
+
+It currently imports:
+- Raycast settings that map cleanly to SuperCmd
+- the global launcher hotkey
+- command hotkeys
+- quicklinks
+- snippets
+- notes
+- installed Raycast extensions
+- extension preferences
+- script command folders
+- disabled script commands
+- disabled extension commands
+
+It intentionally skips or only partially maps:
+- AI chats
+- clipboard history
+- MCP server config
+- Raycast aliases, where the backup does not expose a clean first-class field
+
+The importer decrypts backups locally and prompts for the backup password before reading the file.
 
 ---
 

--- a/src/main/ai-chat-store.ts
+++ b/src/main/ai-chat-store.ts
@@ -1,0 +1,248 @@
+import { app } from 'electron';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface AiChatMessageRecord {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  createdAt: number;
+  cancelled?: boolean;
+}
+
+export interface AiChatConversationRecord {
+  id: string;
+  title: string;
+  messages: AiChatMessageRecord[];
+  createdAt: number;
+  updatedAt: number;
+  source?: 'local' | 'raycast';
+  sourceConversationId?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface AiChatStoreData {
+  version: 1;
+  conversations: AiChatConversationRecord[];
+}
+
+const DEFAULT_STORE: AiChatStoreData = {
+  version: 1,
+  conversations: [],
+};
+
+let cache: AiChatStoreData | null = null;
+
+function getStorePath(): string {
+  return path.join(app.getPath('userData'), 'ai-chat-conversations.json');
+}
+
+function normalizeTimestamp(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value > 1e11) return Math.round(value);
+    if (value > 1e9) return Math.round(value * 1000);
+    if (value > 5e8) return Math.round((value + 978307200) * 1000);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) {
+      const parsedNumber = Number(trimmed);
+      if (Number.isFinite(parsedNumber)) {
+        return normalizeTimestamp(parsedNumber, fallback);
+      }
+      const parsedDate = Date.parse(trimmed);
+      if (Number.isFinite(parsedDate)) return parsedDate;
+    }
+  }
+  return fallback;
+}
+
+function normalizeMessage(value: unknown, index: number, fallbackTimestamp: number): AiChatMessageRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const raw = value as Record<string, any>;
+  const content = typeof raw.content === 'string' ? raw.content : '';
+  if (!content.trim()) return null;
+  const role = raw.role === 'user' ? 'user' : 'assistant';
+  const createdAt = normalizeTimestamp(raw.createdAt, fallbackTimestamp + index);
+  const id = typeof raw.id === 'string' && raw.id.trim()
+    ? raw.id.trim()
+    : `msg-${createdAt}-${index}-${createHash('sha1').update(`${role}:${content}`).digest('hex').slice(0, 8)}`;
+  return {
+    id,
+    role,
+    content,
+    createdAt,
+    ...(raw.cancelled ? { cancelled: true } : {}),
+  };
+}
+
+function stableConversationId(raw: {
+  id?: unknown;
+  source?: unknown;
+  sourceConversationId?: unknown;
+  title?: unknown;
+  messages?: Array<{ role: string; content: string }>;
+}): string {
+  const provided = typeof raw.id === 'string' ? raw.id.trim() : '';
+  if (provided) return provided;
+  const source = typeof raw.source === 'string' ? raw.source.trim() : '';
+  const sourceConversationId = typeof raw.sourceConversationId === 'string' ? raw.sourceConversationId.trim() : '';
+  if (source && sourceConversationId) {
+    return `${source}-${sourceConversationId}`;
+  }
+  const title = typeof raw.title === 'string' ? raw.title.trim() : 'Imported Chat';
+  const body = JSON.stringify({
+    source,
+    sourceConversationId,
+    title,
+    messages: Array.isArray(raw.messages) ? raw.messages.map((message) => ({
+      role: message.role,
+      content: message.content,
+    })) : [],
+  });
+  return `conv-${createHash('sha1').update(body).digest('hex').slice(0, 16)}`;
+}
+
+function normalizeConversation(value: unknown): AiChatConversationRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const raw = value as Record<string, any>;
+  const now = Date.now();
+  const normalizedMessages = Array.isArray(raw.messages)
+    ? raw.messages
+        .map((message, index) => normalizeMessage(message, index, now))
+        .filter((message): message is AiChatMessageRecord => Boolean(message))
+    : [];
+  if (normalizedMessages.length === 0) return null;
+  const createdAt = normalizeTimestamp(
+    raw.createdAt,
+    normalizedMessages[0]?.createdAt || now
+  );
+  const updatedAt = normalizeTimestamp(
+    raw.updatedAt,
+    normalizedMessages[normalizedMessages.length - 1]?.createdAt || createdAt
+  );
+  const title = typeof raw.title === 'string' && raw.title.trim()
+    ? raw.title.trim()
+    : 'New Chat';
+  const source = raw.source === 'raycast' ? 'raycast' : raw.source === 'local' ? 'local' : undefined;
+  const sourceConversationId = typeof raw.sourceConversationId === 'string' && raw.sourceConversationId.trim()
+    ? raw.sourceConversationId.trim()
+    : undefined;
+  const metadata = raw.metadata && typeof raw.metadata === 'object' && !Array.isArray(raw.metadata)
+    ? { ...(raw.metadata as Record<string, any>) }
+    : undefined;
+  return {
+    id: stableConversationId({
+      id: raw.id,
+      source,
+      sourceConversationId,
+      title,
+      messages: normalizedMessages,
+    }),
+    title,
+    messages: normalizedMessages,
+    createdAt,
+    updatedAt,
+    ...(source ? { source } : {}),
+    ...(sourceConversationId ? { sourceConversationId } : {}),
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function normalizeStore(value: unknown): AiChatStoreData {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { ...DEFAULT_STORE, conversations: [] };
+  }
+  const raw = value as Partial<AiChatStoreData>;
+  const conversations = Array.isArray(raw.conversations)
+    ? raw.conversations
+        .map((conversation) => normalizeConversation(conversation))
+        .filter((conversation): conversation is AiChatConversationRecord => Boolean(conversation))
+        .sort((a, b) => b.updatedAt - a.updatedAt)
+    : [];
+  return {
+    version: 1,
+    conversations,
+  };
+}
+
+function loadStore(): AiChatStoreData {
+  if (cache) return cache;
+  try {
+    const raw = fs.readFileSync(getStorePath(), 'utf8');
+    cache = normalizeStore(JSON.parse(raw));
+  } catch {
+    cache = normalizeStore(DEFAULT_STORE);
+  }
+  return cache;
+}
+
+function saveStore(next: AiChatStoreData): void {
+  cache = {
+    version: 1,
+    conversations: [...next.conversations].sort((a, b) => b.updatedAt - a.updatedAt),
+  };
+  fs.writeFileSync(getStorePath(), JSON.stringify(cache, null, 2), 'utf8');
+}
+
+function mergeConversation(existing: AiChatConversationRecord | undefined, incoming: AiChatConversationRecord): AiChatConversationRecord {
+  if (!existing) return incoming;
+  if (incoming.updatedAt > existing.updatedAt) return incoming;
+  if (incoming.updatedAt < existing.updatedAt) return existing;
+  if (incoming.messages.length > existing.messages.length) return incoming;
+  return existing;
+}
+
+export function getAiChatSnapshot(): AiChatStoreData {
+  const store = loadStore();
+  return {
+    version: 1,
+    conversations: store.conversations.map((conversation) => ({
+      ...conversation,
+      messages: conversation.messages.map((message) => ({ ...message })),
+      ...(conversation.metadata ? { metadata: { ...conversation.metadata } } : {}),
+    })),
+  };
+}
+
+export function upsertAiChatConversation(conversation: unknown): AiChatConversationRecord | null {
+  const normalized = normalizeConversation(conversation);
+  if (!normalized) return null;
+  const store = loadStore();
+  const nextConversations = store.conversations.filter((entry) => entry.id !== normalized.id);
+  nextConversations.unshift(normalized);
+  saveStore({ version: 1, conversations: nextConversations });
+  return normalized;
+}
+
+export function deleteAiChatConversation(id: string): boolean {
+  const normalizedId = String(id || '').trim();
+  if (!normalizedId) return false;
+  const store = loadStore();
+  const nextConversations = store.conversations.filter((conversation) => conversation.id !== normalizedId);
+  if (nextConversations.length === store.conversations.length) return false;
+  saveStore({ version: 1, conversations: nextConversations });
+  return true;
+}
+
+export function mergeAiChatSnapshot(snapshot: Partial<AiChatStoreData>): AiChatStoreData {
+  const store = loadStore();
+  const incoming = normalizeStore(snapshot);
+  const mergedById = new Map<string, AiChatConversationRecord>();
+  for (const conversation of store.conversations) {
+    mergedById.set(conversation.id, conversation);
+  }
+  for (const conversation of incoming.conversations) {
+    mergedById.set(
+      conversation.id,
+      mergeConversation(mergedById.get(conversation.id), conversation)
+    );
+  }
+  const next = {
+    version: 1 as const,
+    conversations: [...mergedById.values()].sort((a, b) => b.updatedAt - a.updatedAt),
+  };
+  saveStore(next);
+  return getAiChatSnapshot();
+}

--- a/src/main/extension-preferences-store.ts
+++ b/src/main/extension-preferences-store.ts
@@ -1,0 +1,145 @@
+import { app } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type PreferenceMap = Record<string, any>;
+
+interface ExtensionPreferencesStoreData {
+  version: 1;
+  extensions: Record<string, PreferenceMap>;
+  commands: Record<string, PreferenceMap>;
+}
+
+const DEFAULT_STORE: ExtensionPreferencesStoreData = {
+  version: 1,
+  extensions: {},
+  commands: {},
+};
+
+let cache: ExtensionPreferencesStoreData | null = null;
+
+function getStorePath(): string {
+  return path.join(app.getPath('userData'), 'extension-preferences.json');
+}
+
+function normalizePreferenceMap(value: unknown): PreferenceMap {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return { ...(value as Record<string, any>) };
+}
+
+function normalizeStore(value: unknown): ExtensionPreferencesStoreData {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { ...DEFAULT_STORE, extensions: {}, commands: {} };
+  }
+  const parsed = value as Partial<ExtensionPreferencesStoreData>;
+  const extensions: Record<string, PreferenceMap> = {};
+  const commands: Record<string, PreferenceMap> = {};
+
+  for (const [key, entry] of Object.entries(parsed.extensions || {})) {
+    const normalizedKey = String(key || '').trim();
+    if (!normalizedKey) continue;
+    extensions[normalizedKey] = normalizePreferenceMap(entry);
+  }
+  for (const [key, entry] of Object.entries(parsed.commands || {})) {
+    const normalizedKey = String(key || '').trim();
+    if (!normalizedKey) continue;
+    commands[normalizedKey] = normalizePreferenceMap(entry);
+  }
+
+  return {
+    version: 1,
+    extensions,
+    commands,
+  };
+}
+
+function loadStore(): ExtensionPreferencesStoreData {
+  if (cache) return cache;
+  try {
+    const raw = fs.readFileSync(getStorePath(), 'utf8');
+    cache = normalizeStore(JSON.parse(raw));
+  } catch {
+    cache = normalizeStore(DEFAULT_STORE);
+  }
+  return cache;
+}
+
+function saveStore(next: ExtensionPreferencesStoreData): void {
+  cache = next;
+  fs.writeFileSync(getStorePath(), JSON.stringify(next, null, 2), 'utf8');
+}
+
+function getCommandKey(extName: string, cmdName: string): string {
+  return `${extName}/${cmdName}`;
+}
+
+export function getExtensionPreferencesSnapshot(): ExtensionPreferencesStoreData {
+  const store = loadStore();
+  return {
+    version: 1,
+    extensions: { ...store.extensions },
+    commands: { ...store.commands },
+  };
+}
+
+export function getExtensionPreferences(extName: string, cmdName?: string): PreferenceMap {
+  const store = loadStore();
+  const normalizedExtName = String(extName || '').trim();
+  if (!normalizedExtName) return {};
+  if (cmdName) {
+    const normalizedCmdName = String(cmdName || '').trim();
+    if (!normalizedCmdName) return {};
+    return { ...(store.commands[getCommandKey(normalizedExtName, normalizedCmdName)] || {}) };
+  }
+  return { ...(store.extensions[normalizedExtName] || {}) };
+}
+
+export function setExtensionPreferences(extName: string, values: PreferenceMap, cmdName?: string): PreferenceMap {
+  const store = loadStore();
+  const normalizedExtName = String(extName || '').trim();
+  if (!normalizedExtName) return {};
+  const normalizedValues = normalizePreferenceMap(values);
+
+  if (cmdName) {
+    const normalizedCmdName = String(cmdName || '').trim();
+    if (!normalizedCmdName) return {};
+    store.commands[getCommandKey(normalizedExtName, normalizedCmdName)] = normalizedValues;
+  } else {
+    store.extensions[normalizedExtName] = normalizedValues;
+  }
+
+  saveStore(store);
+  return { ...normalizedValues };
+}
+
+export function setExtensionPreferenceValue(
+  extName: string,
+  preferenceName: string,
+  value: any,
+  cmdName?: string
+): PreferenceMap {
+  const current = getExtensionPreferences(extName, cmdName);
+  current[String(preferenceName || '').trim()] = value;
+  return setExtensionPreferences(extName, current, cmdName);
+}
+
+export function mergeExtensionPreferencesSnapshot(snapshot: Partial<ExtensionPreferencesStoreData>): ExtensionPreferencesStoreData {
+  const store = loadStore();
+  const normalized = normalizeStore(snapshot);
+
+  for (const [extName, values] of Object.entries(normalized.extensions)) {
+    store.extensions[extName] = {
+      ...values,
+      ...(store.extensions[extName] || {}),
+    };
+  }
+  for (const [commandKey, values] of Object.entries(normalized.commands)) {
+    store.commands[commandKey] = {
+      ...values,
+      ...(store.commands[commandKey] || {}),
+    };
+  }
+
+  saveStore(store);
+  return getExtensionPreferencesSnapshot();
+}

--- a/src/main/extension-registry.ts
+++ b/src/main/extension-registry.ts
@@ -1027,7 +1027,10 @@ export function getInstalledExtensionNames(): string[] {
  */
 export async function installExtension(
   name: string,
-  options?: { skipBundle?: boolean },
+  options?: {
+    skipBundle?: boolean;
+    onProgress?: (payload: { message: string; downloadedBytes?: number; totalBytes?: number }) => void;
+  },
 ): Promise<boolean> {
   if (!/^[A-Za-z0-9._-]+$/.test(String(name || ''))) {
     console.error(`Invalid extension name: "${name}"`);
@@ -1040,7 +1043,7 @@ export async function installExtension(
   // download path on retry.
   if (!options?.skipBundle) {
     try {
-      const success = await installExtensionFromBundle(name);
+      const success = await installExtensionFromBundle(name, options?.onProgress);
       if (success) return true;
     } catch (bundleError: any) {
       console.warn(`Bundle install failed for "${name}":`, bundleError?.message || bundleError);
@@ -1073,7 +1076,10 @@ export async function installExtension(
  * The bundle contains package.json + assets/ + .sc-build/ (esbuild output).
  * No npm, no bun, no esbuild needed. ~2-3s total.
  */
-async function installExtensionFromBundle(name: string): Promise<boolean> {
+async function installExtensionFromBundle(
+  name: string,
+  onProgress?: (payload: { message: string; downloadedBytes?: number; totalBytes?: number }) => void
+): Promise<boolean> {
   const installPath = getInstalledPath(name);
   const hadExistingInstall = fs.existsSync(installPath);
   const backupPath = hadExistingInstall
@@ -1087,9 +1093,17 @@ async function installExtensionFromBundle(name: string): Promise<boolean> {
     // Get pre-signed S3 URL from backend
     const { url } = await getExtensionBundleUrl(name);
     console.log(`Downloading pre-built bundle for "${name}"…`);
+    onProgress?.({ message: `Downloading ${name}…` });
 
     fs.mkdirSync(tmpDir, { recursive: true });
-    await downloadAndExtractTarball(url, tmpDir);
+    await downloadAndExtractTarball(url, tmpDir, ({ downloadedBytes, totalBytes }) => {
+      onProgress?.({
+        message: `Downloading ${name}…`,
+        downloadedBytes,
+        totalBytes,
+      });
+    });
+    onProgress?.({ message: `Extracting ${name}…` });
 
     // Find the extension in the extracted directory
     const nestedPath = path.join(tmpDir, name);
@@ -1374,7 +1388,11 @@ async function installExtensionViaGit(name: string): Promise<boolean> {
  * Download a .tar.gz from a URL and extract to destDir.
  * Uses Node.js built-in https + zlib + tar-stream parsing — no npm deps.
  */
-async function downloadAndExtractTarball(url: string, destDir: string): Promise<void> {
+async function downloadAndExtractTarball(
+  url: string,
+  destDir: string,
+  onProgress?: (payload: { downloadedBytes: number; totalBytes?: number }) => void
+): Promise<void> {
   return new Promise((resolve, reject) => {
     const makeRequest = (requestUrl: string, redirectCount = 0) => {
       if (redirectCount > 5) {
@@ -1399,7 +1417,14 @@ async function downloadAndExtractTarball(url: string, destDir: string): Promise<
         }
 
         const chunks: Buffer[] = [];
-        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        const totalBytesHeader = Number.parseInt(String(res.headers?.['content-length'] || ''), 10);
+        const totalBytes = Number.isFinite(totalBytesHeader) && totalBytesHeader > 0 ? totalBytesHeader : undefined;
+        let downloadedBytes = 0;
+        res.on('data', (chunk: Buffer) => {
+          chunks.push(chunk);
+          downloadedBytes += chunk.length;
+          onProgress?.({ downloadedBytes, ...(totalBytes !== undefined ? { totalBytes } : {}) });
+        });
         res.on('error', reject);
         res.on('end', () => {
           try {

--- a/src/main/extension-runner.ts
+++ b/src/main/extension-runner.ts
@@ -21,6 +21,7 @@ import {
   isCommandPlatformCompatible,
   isManifestPlatformCompatible,
 } from './extension-platform';
+import { getExtensionPreferences } from './extension-preferences-store';
 import { loadSettings } from './settings-store';
 
 /**
@@ -1257,8 +1258,10 @@ export async function getExtensionBundle(
     owner = typeof rawOwner === 'object' ? (rawOwner as any).name || '' : rawOwner;
 
     const { extensionPrefs, commandPrefs, definitions } = parsePreferences(pkg, cmdName);
-    preferences = extensionPrefs;
-    commandPreferences = commandPrefs;
+    const storedExtensionPrefs = getExtensionPreferences(normalizedExtName);
+    const storedCommandPrefs = getExtensionPreferences(normalizedExtName, cmdName);
+    preferences = { ...extensionPrefs, ...storedExtensionPrefs };
+    commandPreferences = { ...commandPrefs, ...storedCommandPrefs };
     preferenceDefinitions = definitions;
     commandArgumentDefinitions = Array.isArray(cmd?.arguments)
       ? cmd.arguments

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12962,6 +12962,9 @@ app.whenReady().then(async () => {
         invalidateScriptCommandsCache();
         invalidateCache();
         broadcastCommandsUpdated();
+        for (const extensionName of result.importedExtensionPreferenceExtensions || []) {
+          broadcastExtensionPreferencesUpdated(extensionName);
+        }
         const latestSettings = loadSettings();
         const windowsToNotify = [mainWindow, settingsWindow, extensionStoreWindow, promptWindow]
           .filter(Boolean) as Array<InstanceType<typeof BrowserWindow>>;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -36,6 +36,13 @@ import {
   uninstallExtension,
 } from './extension-registry';
 import {
+  getExtensionPreferences,
+  getExtensionPreferencesSnapshot,
+  mergeExtensionPreferencesSnapshot,
+  setExtensionPreferenceValue,
+  setExtensionPreferences,
+} from './extension-preferences-store';
+import {
   searchExtensions,
   getPopularExtensions,
   getExtensionDetails,
@@ -141,6 +148,7 @@ import {
   isCanvasLibInstalled,
   getCanvasLibDir,
 } from './canvas-store';
+import { importRaycastConfigFromFile } from './raycast-config-import';
 
 import { initialize as initAptabase, trackEvent } from "@aptabase/electron/main";
 
@@ -11562,6 +11570,17 @@ function broadcastCommandsUpdated(): void {
   }
 }
 
+function broadcastExtensionPreferencesUpdated(extensionName: string): void {
+  const normalized = String(extensionName || '').trim();
+  if (!normalized) return;
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window || window.isDestroyed()) continue;
+    try {
+      window.webContents.send('extension-preferences-updated', { extensionName: normalized });
+    } catch {}
+  }
+}
+
 function broadcastBrowserSearchHistoryChanged(): void {
   for (const window of BrowserWindow.getAllWindows()) {
     if (window.isDestroyed()) continue;
@@ -12873,6 +12892,11 @@ app.whenReady().then(async () => {
           console.error('Failed to rebuild extensions after updating custom folders:', error);
         }
       }
+      if (patch.scriptCommandFolders !== undefined) {
+        invalidateScriptCommandsCache();
+        invalidateCache();
+        broadcastCommandsUpdated();
+      }
       if (
         patch.emojiPickerEnabled !== undefined ||
         patch.emojiPickerTriggerPrefix !== undefined ||
@@ -12929,6 +12953,68 @@ app.whenReady().then(async () => {
       return result;
     }
   );
+
+  ipcMain.handle('rayconfig-import', async (event: any) => {
+    suppressBlurHide = true;
+    try {
+      const result = await importRaycastConfigFromFile(getDialogParentWindow(event));
+      if (!result.canceled) {
+        invalidateScriptCommandsCache();
+        invalidateCache();
+        broadcastCommandsUpdated();
+        const latestSettings = loadSettings();
+        const windowsToNotify = [mainWindow, settingsWindow, extensionStoreWindow, promptWindow]
+          .filter(Boolean) as Array<InstanceType<typeof BrowserWindow>>;
+        for (const win of windowsToNotify) {
+          if (win.isDestroyed()) continue;
+          try {
+            win.webContents.send('settings-updated', latestSettings);
+          } catch {}
+        }
+      }
+      return result;
+    } finally {
+      suppressBlurHide = false;
+    }
+  });
+
+  ipcMain.handle('get-extension-preferences-snapshot', () => {
+    return getExtensionPreferencesSnapshot();
+  });
+
+  ipcMain.handle('get-extension-preferences', (_event: any, extName: string, cmdName?: string) => {
+    return getExtensionPreferences(extName, cmdName);
+  });
+
+  ipcMain.handle(
+    'set-extension-preference',
+    (_event: any, extName: string, preferenceName: string, value: any, cmdName?: string) => {
+      const result = setExtensionPreferenceValue(extName, preferenceName, value, cmdName);
+      broadcastExtensionPreferencesUpdated(extName);
+      return result;
+    }
+  );
+
+  ipcMain.handle(
+    'set-extension-preferences',
+    (_event: any, extName: string, values: Record<string, any>, cmdName?: string) => {
+      const result = setExtensionPreferences(extName, values, cmdName);
+      broadcastExtensionPreferencesUpdated(extName);
+      return result;
+    }
+  );
+
+  ipcMain.handle('merge-extension-preferences-snapshot', (_event: any, snapshot: any) => {
+    const result = mergeExtensionPreferencesSnapshot(snapshot);
+    for (const extensionName of Object.keys(snapshot?.extensions || {})) {
+      broadcastExtensionPreferencesUpdated(extensionName);
+    }
+    for (const commandKey of Object.keys(snapshot?.commands || {})) {
+      const extensionName = String(commandKey || '').split('/')[0] || '';
+      if (extensionName) broadcastExtensionPreferencesUpdated(extensionName);
+    }
+    return result;
+  });
 
   ipcMain.handle('get-all-commands', async () => {
     // Return ALL commands (ignoring disabled filter) for the settings page

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -154,7 +154,12 @@ import {
   isCanvasLibInstalled,
   getCanvasLibDir,
 } from './canvas-store';
-import { importRaycastConfigFromFile } from './raycast-config-import';
+import {
+  type RaycastImportProgress,
+  executeRaycastConfigImport,
+  importRaycastConfigFromFile,
+  previewRaycastConfigImport,
+} from './raycast-config-import';
 
 import { initialize as initAptabase, trackEvent } from "@aptabase/electron/main";
 
@@ -12980,7 +12985,7 @@ app.whenReady().then(async () => {
         for (const extensionName of result.importedExtensionPreferenceExtensions || []) {
           broadcastExtensionPreferencesUpdated(extensionName);
         }
-        if (result.aiChats.imported > 0) {
+        if (result.aiChats.found > 0) {
           broadcastAiChatsUpdated();
         }
         const latestSettings = loadSettings();
@@ -12997,6 +13002,51 @@ app.whenReady().then(async () => {
     } finally {
       suppressBlurHide = false;
     }
+  });
+
+  ipcMain.handle('rayconfig-preview', async (event: any) => {
+    suppressBlurHide = true;
+    try {
+      return await previewRaycastConfigImport(getDialogParentWindow(event));
+    } finally {
+      suppressBlurHide = false;
+    }
+  });
+
+  ipcMain.handle('rayconfig-import-apply', async (_event: any, options: any) => {
+    const sender = _event.sender;
+    const reportProgress = (payload: RaycastImportProgress) => {
+      try {
+        sender.send('rayconfig-import-progress', payload);
+      } catch {}
+    };
+    const result = await executeRaycastConfigImport(options, (payload) => {
+      reportProgress({
+        sessionId: String(options?.sessionId || ''),
+        ...payload,
+      });
+    });
+    if (!result.canceled) {
+      invalidateScriptCommandsCache();
+      invalidateCache();
+      broadcastCommandsUpdated();
+      for (const extensionName of result.importedExtensionPreferenceExtensions || []) {
+        broadcastExtensionPreferencesUpdated(extensionName);
+      }
+      if (result.aiChats.found > 0) {
+        broadcastAiChatsUpdated();
+      }
+      const latestSettings = loadSettings();
+      const windowsToNotify = [mainWindow, settingsWindow, extensionStoreWindow, promptWindow]
+        .filter(Boolean) as Array<InstanceType<typeof BrowserWindow>>;
+      for (const win of windowsToNotify) {
+        if (win.isDestroyed()) continue;
+        try {
+          win.webContents.send('settings-updated', latestSettings);
+        } catch {}
+      }
+    }
+    return result;
   });
 
   ipcMain.handle('get-extension-preferences-snapshot', () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -36,6 +36,12 @@ import {
   uninstallExtension,
 } from './extension-registry';
 import {
+  deleteAiChatConversation,
+  getAiChatSnapshot,
+  mergeAiChatSnapshot,
+  upsertAiChatConversation,
+} from './ai-chat-store';
+import {
   getExtensionPreferences,
   getExtensionPreferencesSnapshot,
   mergeExtensionPreferencesSnapshot,
@@ -11581,6 +11587,15 @@ function broadcastExtensionPreferencesUpdated(extensionName: string): void {
   }
 }
 
+function broadcastAiChatsUpdated(): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window || window.isDestroyed()) continue;
+    try {
+      window.webContents.send('ai-chats-updated');
+    } catch {}
+  }
+}
+
 function broadcastBrowserSearchHistoryChanged(): void {
   for (const window of BrowserWindow.getAllWindows()) {
     if (window.isDestroyed()) continue;
@@ -12965,6 +12980,9 @@ app.whenReady().then(async () => {
         for (const extensionName of result.importedExtensionPreferenceExtensions || []) {
           broadcastExtensionPreferencesUpdated(extensionName);
         }
+        if (result.aiChats.imported > 0) {
+          broadcastAiChatsUpdated();
+        }
         const latestSettings = loadSettings();
         const windowsToNotify = [mainWindow, settingsWindow, extensionStoreWindow, promptWindow]
           .filter(Boolean) as Array<InstanceType<typeof BrowserWindow>>;
@@ -12983,6 +13001,32 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('get-extension-preferences-snapshot', () => {
     return getExtensionPreferencesSnapshot();
+  });
+
+  ipcMain.handle('get-ai-chat-snapshot', () => {
+    return getAiChatSnapshot();
+  });
+
+  ipcMain.handle('upsert-ai-chat-conversation', (_event: any, conversation: any) => {
+    const result = upsertAiChatConversation(conversation);
+    if (result) {
+      broadcastAiChatsUpdated();
+    }
+    return result;
+  });
+
+  ipcMain.handle('delete-ai-chat-conversation', (_event: any, id: string) => {
+    const removed = deleteAiChatConversation(id);
+    if (removed) {
+      broadcastAiChatsUpdated();
+    }
+    return removed;
+  });
+
+  ipcMain.handle('merge-ai-chat-snapshot', (_event: any, snapshot: any) => {
+    const result = mergeAiChatSnapshot(snapshot);
+    broadcastAiChatsUpdated();
+    return result;
   });
 
   ipcMain.handle('get-extension-preferences', (_event: any, extName: string, cmdName?: string) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -276,8 +276,19 @@ const electronAPI = {
   },
   saveSettings: (patch: any): Promise<any> =>
     ipcRenderer.invoke('save-settings', patch),
+  previewRaycastConfigImport: (): Promise<any> =>
+    ipcRenderer.invoke('rayconfig-preview'),
+  applyRaycastConfigImport: (options: any): Promise<any> =>
+    ipcRenderer.invoke('rayconfig-import-apply', options),
   importRaycastConfig: (): Promise<any> =>
     ipcRenderer.invoke('rayconfig-import'),
+  onRaycastImportProgress: (callback: (payload: any) => void) => {
+    const listener = (_event: any, payload: any) => callback(payload);
+    ipcRenderer.on('rayconfig-import-progress', listener);
+    return () => {
+      ipcRenderer.removeListener('rayconfig-import-progress', listener);
+    };
+  },
   getAiChatSnapshot: (): Promise<any> =>
     ipcRenderer.invoke('get-ai-chat-snapshot'),
   upsertAiChatConversation: (conversation: any): Promise<any> =>

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -269,6 +269,18 @@ const electronAPI = {
   },
   saveSettings: (patch: any): Promise<any> =>
     ipcRenderer.invoke('save-settings', patch),
+  importRaycastConfig: (): Promise<any> =>
+    ipcRenderer.invoke('rayconfig-import'),
+  getExtensionPreferencesSnapshot: (): Promise<any> =>
+    ipcRenderer.invoke('get-extension-preferences-snapshot'),
+  getExtensionPreferences: (extName: string, cmdName?: string): Promise<Record<string, any>> =>
+    ipcRenderer.invoke('get-extension-preferences', extName, cmdName),
+  setExtensionPreference: (extName: string, preferenceName: string, value: any, cmdName?: string): Promise<Record<string, any>> =>
+    ipcRenderer.invoke('set-extension-preference', extName, preferenceName, value, cmdName),
+  setExtensionPreferences: (extName: string, values: Record<string, any>, cmdName?: string): Promise<Record<string, any>> =>
+    ipcRenderer.invoke('set-extension-preferences', extName, values, cmdName),
+  mergeExtensionPreferencesSnapshot: (snapshot: any): Promise<any> =>
+    ipcRenderer.invoke('merge-extension-preferences-snapshot', snapshot),
   getAllCommands: (): Promise<any[]> =>
     ipcRenderer.invoke('get-all-commands'),
   updateGlobalShortcut: (shortcut: string): Promise<boolean> =>
@@ -322,6 +334,13 @@ const electronAPI = {
     ipcRenderer.on('settings-updated', listener);
     return () => {
       ipcRenderer.removeListener('settings-updated', listener);
+    };
+  },
+  onExtensionPreferencesUpdated: (callback: (payload: { extensionName: string }) => void) => {
+    const listener = (_event: any, payload: { extensionName: string }) => callback(payload);
+    ipcRenderer.on('extension-preferences-updated', listener);
+    return () => {
+      ipcRenderer.removeListener('extension-preferences-updated', listener);
     };
   },
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -99,6 +99,13 @@ const electronAPI = {
       ipcRenderer.removeListener('commands-updated', listener);
     };
   },
+  onAiChatsUpdated: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('ai-chats-updated', listener);
+    return () => {
+      ipcRenderer.removeListener('ai-chats-updated', listener);
+    };
+  },
   onRunSystemCommand: (callback: (commandId: string) => void) => {
     const listener = (_event: any, commandId: string) => callback(commandId);
     ipcRenderer.on('run-system-command', listener);
@@ -271,6 +278,14 @@ const electronAPI = {
     ipcRenderer.invoke('save-settings', patch),
   importRaycastConfig: (): Promise<any> =>
     ipcRenderer.invoke('rayconfig-import'),
+  getAiChatSnapshot: (): Promise<any> =>
+    ipcRenderer.invoke('get-ai-chat-snapshot'),
+  upsertAiChatConversation: (conversation: any): Promise<any> =>
+    ipcRenderer.invoke('upsert-ai-chat-conversation', conversation),
+  deleteAiChatConversation: (id: string): Promise<boolean> =>
+    ipcRenderer.invoke('delete-ai-chat-conversation', id),
+  mergeAiChatSnapshot: (snapshot: any): Promise<any> =>
+    ipcRenderer.invoke('merge-ai-chat-snapshot', snapshot),
   getExtensionPreferencesSnapshot: (): Promise<any> =>
     ipcRenderer.invoke('get-extension-preferences-snapshot'),
   getExtensionPreferences: (extName: string, cmdName?: string): Promise<Record<string, any>> =>

--- a/src/main/raycast-config-import.ts
+++ b/src/main/raycast-config-import.ts
@@ -132,6 +132,7 @@ export interface RaycastImportResult {
   snippets: RaycastImportBucketResult;
   notes: RaycastImportBucketResult;
   extensions: RaycastImportBucketResult;
+  importedExtensionPreferenceExtensions: string[];
   unsupported: string[];
   warnings: string[];
 }
@@ -888,7 +889,8 @@ async function importExtensions(data: RaycastBackup, warnings: string[]): Promis
   return result;
 }
 
-function importExtensionPreferences(data: RaycastBackup): void {
+function importExtensionPreferences(data: RaycastBackup): string[] {
+  const importedExtensionNames = new Set<string>();
   for (const extension of data.builtin_package_raycastExtensions?.extensions || []) {
     const extensionName = String(extension?.name || '').trim();
     if (!extensionName || !Array.isArray(extension.prefs) || extension.prefs.length === 0) continue;
@@ -904,7 +906,9 @@ function importExtensionPreferences(data: RaycastBackup): void {
       ...getExtensionPreferences(extensionName),
       ...nextValues,
     });
+    importedExtensionNames.add(extensionName);
   }
+  return [...importedExtensionNames];
 }
 
 export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow): Promise<RaycastImportResult> {
@@ -933,6 +937,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
       snippets: createBucketResult(),
       notes: createBucketResult(),
       extensions: createBucketResult(),
+      importedExtensionPreferenceExtensions: [],
       unsupported: [],
       warnings: [],
     };
@@ -967,6 +972,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
             snippets: createBucketResult(),
             notes: createBucketResult(),
             extensions: createBucketResult(),
+            importedExtensionPreferenceExtensions: [],
             unsupported: [],
             warnings: [],
           };
@@ -1019,6 +1025,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
       snippets: createBucketResult(),
       notes: createBucketResult(),
       extensions: createBucketResult(),
+      importedExtensionPreferenceExtensions: [],
       unsupported: collectUnsupportedCategories(backup),
       warnings: [],
     };
@@ -1030,7 +1037,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
   const snippets = importSnippets(backup);
   const notes = importNotes(backup);
   const extensions = await importExtensions(backup, warnings);
-  importExtensionPreferences(backup);
+  const importedExtensionPreferenceExtensions = importExtensionPreferences(backup);
   const {
     commandHotkeysImported,
     commandAliasesImported,
@@ -1051,6 +1058,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
     snippets,
     notes,
     extensions,
+    importedExtensionPreferenceExtensions,
     unsupported: collectUnsupportedCategories(backup),
     warnings,
   };

--- a/src/main/raycast-config-import.ts
+++ b/src/main/raycast-config-import.ts
@@ -1,0 +1,1054 @@
+import { dialog, type BrowserWindow } from 'electron';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as zlib from 'zlib';
+import { getAvailableCommands, invalidateCache, type CommandInfo } from './commands';
+import { setExtensionPreferences } from './extension-preferences-store';
+import { getInstalledExtensionNames, installExtension } from './extension-registry';
+import { createNote, getAllNotes, updateNote } from './notes-store';
+import { createQuickLink, getAllQuickLinks } from './quicklink-store';
+import { discoverScriptCommands, invalidateScriptCommandsCache } from './script-command-runner';
+import { loadSettings, saveSettings, type AppSettings } from './settings-store';
+import { createSnippet, getAllSnippets, updateSnippet } from './snippet-store';
+
+type RaycastQuicklinkRecord = {
+  uuid?: string;
+  name?: string;
+  url?: string;
+  isEnabled?: boolean;
+};
+
+type RaycastSnippetRecord = {
+  name?: string;
+  text?: string;
+  keyword?: string;
+  pinned?: boolean;
+};
+
+type RaycastNoteRecord = {
+  title?: string;
+  text?: string;
+  pinned?: boolean;
+};
+
+type RaycastExtensionCommandRecord = {
+  name?: string;
+  enabled?: boolean;
+};
+
+type RaycastExtensionRecord = {
+  name?: string;
+  owner?: string;
+  title?: string;
+  commands?: RaycastExtensionCommandRecord[];
+  prefs?: Array<{ name?: string; type?: string; value?: unknown }>;
+};
+
+type RaycastPreferencesPayload = {
+  preferencesGeneral?: {
+    raycastGlobalHotkey?: string;
+  };
+  preferencesAppearance?: {
+    raycastPreferredWindowMode?: string;
+  };
+  preferencesAdvanced?: {
+    navigationCommandStyleIdentifierKey?: string;
+    popToRootTimeout?: number;
+  };
+};
+
+type RaycastRootSearchRecord = {
+  key?: string;
+  type?: string;
+  path?: string;
+  hotkey?: string;
+  searchTerms?: string;
+};
+
+type RaycastPinnedMenuItem = {
+  key?: string;
+  id?: string;
+  title?: string;
+  path?: string;
+  type?: string;
+};
+
+type RaycastBackup = {
+  raycast_version?: string;
+  builtin_package_quicklinks?: {
+    quicklinks?: RaycastQuicklinkRecord[];
+  };
+  builtin_package_snippets?: {
+    snippets?: RaycastSnippetRecord[];
+  };
+  builtin_package_raycastNotes?: {
+    notes?: RaycastNoteRecord[];
+  };
+  builtin_package_raycastExtensions?: {
+    extensions?: RaycastExtensionRecord[];
+  };
+  builtin_package_raycastPreferences?: RaycastPreferencesPayload;
+  builtin_package_rootSearch?: {
+    rootSearch?: RaycastRootSearchRecord[];
+  };
+  builtin_package_navigation?: {
+    pinnedMenuItems?: Array<string | RaycastPinnedMenuItem>;
+  };
+  'builtin_package_open-ai'?: {
+    aiChats?: unknown[];
+  };
+  builtin_package_clipboardHistory?: {
+    clipboardHistoryRecords?: unknown[];
+  };
+  builtin_package_scriptCommands?: {
+    scriptCommandsDirectories?: string[];
+    disabledCommands?: string[];
+  };
+  builtin_package_mcp?: {
+    mcpServers?: unknown[];
+  };
+};
+
+export interface RaycastImportBucketResult {
+  found: number;
+  imported: number;
+  skipped: number;
+  failed: number;
+}
+
+export interface RaycastImportResult {
+  canceled: boolean;
+  filePath?: string;
+  raycastVersion?: string;
+  settingsImported: boolean;
+  disabledCommandsImported: number;
+  scriptCommandFoldersImported: number;
+  commandHotkeysImported: number;
+  commandAliasesImported: number;
+  pinnedCommandsImported: number;
+  quicklinks: RaycastImportBucketResult;
+  snippets: RaycastImportBucketResult;
+  notes: RaycastImportBucketResult;
+  extensions: RaycastImportBucketResult;
+  unsupported: string[];
+  warnings: string[];
+}
+
+const PASSWORD_PROMPT_TITLE = 'Import Raycast Backup';
+const PASSWORD_PROMPT_MESSAGE = 'Enter the password for the Raycast backup.';
+const PASSWORD_RETRY_MESSAGE = 'Password was not valid. Try again.';
+const RAYCAST_ROOT_SEARCH_PREFIX = 'extension_';
+const RAYCAST_SCRIPT_COMMAND_PREFIX = 'raycastScript_';
+
+const RAYCAST_BUILTIN_COMMAND_ID_MAP: Record<string, string> = {
+  builtin_command_clipboardHistory: 'system-clipboard-manager',
+  builtin_command_createScriptCommand: 'system-create-script-command',
+  builtin_command_developer_manageExtensions: 'system-open-extensions-settings',
+  builtin_command_extensionStore: 'system-open-extension-store',
+  builtin_command_lockScreen: 'system-lock-screen',
+  builtin_command_openCamera: 'system-camera',
+  builtin_command_raycastNotes_ask: 'system-search-notes',
+  builtin_command_searchEmoji: 'system-emoji-picker',
+};
+
+const RAYCAST_KEYCODE_TO_KEY: Record<number, string> = {
+  0: 'A',
+  1: 'S',
+  2: 'D',
+  3: 'F',
+  4: 'H',
+  5: 'G',
+  6: 'Z',
+  7: 'X',
+  8: 'C',
+  9: 'V',
+  11: 'B',
+  12: 'Q',
+  13: 'W',
+  14: 'E',
+  15: 'R',
+  16: 'Y',
+  17: 'T',
+  18: '1',
+  19: '2',
+  20: '3',
+  21: '4',
+  22: '6',
+  23: '5',
+  24: '=',
+  25: '9',
+  26: '7',
+  27: '-',
+  28: '8',
+  29: '0',
+  30: ']',
+  31: 'O',
+  32: 'U',
+  33: '[',
+  34: 'I',
+  35: 'P',
+  36: 'Return',
+  37: 'L',
+  38: 'J',
+  39: "'",
+  40: 'K',
+  41: ';',
+  42: '\\',
+  43: ',',
+  44: '/',
+  45: 'N',
+  46: 'M',
+  47: '.',
+  48: 'Tab',
+  49: 'Space',
+  50: '`',
+  51: 'Backspace',
+  53: 'Escape',
+  71: 'Clear',
+  76: 'Enter',
+  96: 'F5',
+  97: 'F6',
+  98: 'F7',
+  99: 'F3',
+  100: 'F8',
+  101: 'F9',
+  103: 'F11',
+  105: 'F13',
+  106: 'F16',
+  107: 'F14',
+  109: 'F10',
+  111: 'F12',
+  113: 'F15',
+  114: 'Insert',
+  115: 'Home',
+  116: 'PageUp',
+  117: 'Delete',
+  118: 'F4',
+  119: 'End',
+  120: 'F2',
+  121: 'PageDown',
+  122: 'F1',
+  123: 'Left',
+  124: 'Right',
+  125: 'Down',
+  126: 'Up',
+};
+
+function promptForPassword(message: string): string | null {
+  try {
+    const response = execFileSync(
+      '/usr/bin/osascript',
+      [
+        '-e',
+        `set userInput to text returned of (display dialog "${message}" with title "${PASSWORD_PROMPT_TITLE}" default answer "" with hidden answer buttons {"Cancel", "Import"} default button "Import")`,
+        '-e',
+        'return userInput',
+      ],
+      { encoding: 'utf8' }
+    );
+    const password = String(response || '').trim();
+    return password || null;
+  } catch (error: any) {
+    const messageText = `${String(error?.message || '')}\n${String(error?.stderr || '')}`.toLowerCase();
+    if (messageText.includes('user canceled') || messageText.includes('(-128)')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function parseMaybePlainJson(raw: Buffer): RaycastBackup | null {
+  const trimmed = raw.toString('utf8').trim();
+  if (!trimmed.startsWith('{')) return null;
+  return JSON.parse(trimmed) as RaycastBackup;
+}
+
+function findGzipOffset(buffer: Buffer): number {
+  for (let index = 0; index < Math.min(buffer.length - 2, 64); index += 1) {
+    if (buffer[index] === 0x1f && buffer[index + 1] === 0x8b && buffer[index + 2] === 0x08) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function decryptRaycastBuffer(raw: Buffer, password: string): Buffer {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'supercmd-rayconfig-'));
+  const inputPath = path.join(tempDir, 'backup.rayconfig');
+  try {
+    fs.writeFileSync(inputPath, raw);
+    const decrypted = execFileSync(
+      'openssl',
+      ['enc', '-d', '-aes-256-cbc', '-nosalt', '-in', inputPath, '-k', password],
+      { encoding: null, stdio: ['ignore', 'pipe', 'pipe'] }
+    ) as Buffer;
+    const gzipOffset = findGzipOffset(decrypted);
+    if (gzipOffset < 0) {
+      throw new Error('Failed to read import data; password is not valid.');
+    }
+    return zlib.gunzipSync(decrypted.subarray(gzipOffset));
+  } catch (error: any) {
+    const message = `${String(error?.message || error || '')}\n${String(error?.stderr || '')}`;
+    if (
+      message.includes('bad decrypt') ||
+      message.includes('BAD_DECRYPT') ||
+      message.includes('error:1C800064') ||
+      message.includes('error:1e000065')
+    ) {
+      throw new Error('Failed to read import data; password is not valid.');
+    }
+    throw error;
+  } finally {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+function loadRaycastBackupFromFile(filePath: string, password: string | null): RaycastBackup {
+  const raw = fs.readFileSync(filePath);
+  const plain = parseMaybePlainJson(raw);
+  if (plain) return plain;
+  if (!password) {
+    throw new Error('A password is required to import this Raycast backup.');
+  }
+  const jsonBuffer = decryptRaycastBuffer(raw, password);
+  return JSON.parse(jsonBuffer.toString('utf8')) as RaycastBackup;
+}
+
+function normalizeNavigationStyle(value: unknown): AppSettings['navigationStyle'] | null {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (normalized === 'macos') return 'macos';
+  if (normalized === 'vim') return 'vim';
+  return null;
+}
+
+function normalizeLauncherViewMode(value: unknown): AppSettings['launcherViewMode'] | null {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (normalized === 'compact') return 'compact';
+  if (normalized === 'default' || normalized === 'expanded') return 'expanded';
+  return null;
+}
+
+function decodeRaycastHotkey(value: unknown): string | null {
+  const raw = String(value || '').trim();
+  if (!raw) return null;
+  const parts = raw.split('-').map((part) => String(part || '').trim()).filter(Boolean);
+  if (parts.length === 0) return null;
+  const keyCode = Number(parts[parts.length - 1]);
+  if (!Number.isFinite(keyCode)) return null;
+  const key = RAYCAST_KEYCODE_TO_KEY[keyCode];
+  if (!key) return null;
+
+  const modifiers: string[] = [];
+  for (const modifier of parts.slice(0, -1)) {
+    const normalized = modifier.toLowerCase();
+    if (normalized === 'command' || normalized === 'cmd') {
+      modifiers.push('Command');
+      continue;
+    }
+    if (normalized === 'control' || normalized === 'ctrl') {
+      modifiers.push('Control');
+      continue;
+    }
+    if (normalized === 'option' || normalized === 'alt') {
+      modifiers.push('Alt');
+      continue;
+    }
+    if (normalized === 'shift') {
+      modifiers.push('Shift');
+      continue;
+    }
+    if (normalized === 'fn' || normalized === 'function') {
+      modifiers.push('Fn');
+      continue;
+    }
+  }
+
+  return [...modifiers, key].join('+');
+}
+
+function normalizeAliasCandidate(searchTerms: unknown): string | null {
+  const raw = String(searchTerms || '').trim().toLowerCase();
+  if (!raw) return null;
+  const tokens = raw
+    .split(',')
+    .map((token) => token.trim())
+    .filter((token) => /^[a-z0-9][a-z0-9 -]*$/.test(token));
+  if (tokens.length === 0) return null;
+
+  const counts = new Map<string, number>();
+  for (const token of tokens) {
+    counts.set(token, (counts.get(token) || 0) + 1);
+  }
+
+  const ranked = [...counts.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    if (b[0].length !== a[0].length) return b[0].length - a[0].length;
+    return a[0].localeCompare(b[0]);
+  });
+  const [candidate, count] = ranked[0] || [];
+  if (!candidate) return null;
+  if (candidate.length >= 4) return candidate;
+  if (candidate.length >= 3 && count >= 2) return candidate;
+  return null;
+}
+
+function normalizeRaycastPath(rawPath: string): string {
+  const trimmed = String(rawPath || '').trim();
+  if (!trimmed) return '';
+  if (trimmed.startsWith('~/')) {
+    return path.resolve(path.join(os.homedir(), trimmed.slice(2)));
+  }
+  return path.resolve(trimmed);
+}
+
+function parseRaycastExtensionCommandKey(key: string): { extensionName: string; commandName: string } | null {
+  if (!key.startsWith(RAYCAST_ROOT_SEARCH_PREFIX)) return null;
+  const body = key.slice(RAYCAST_ROOT_SEARCH_PREFIX.length);
+  const separatorIndex = body.indexOf('.');
+  if (separatorIndex <= 0) return null;
+  const suffixIndex = body.indexOf('__', separatorIndex + 1);
+  const extensionName = body.slice(0, separatorIndex).trim();
+  const commandName = (suffixIndex >= 0 ? body.slice(separatorIndex + 1, suffixIndex) : body.slice(separatorIndex + 1)).trim();
+  if (!extensionName || !commandName) return null;
+  return { extensionName, commandName };
+}
+
+function resolveRaycastCommandId(
+  item: RaycastRootSearchRecord | RaycastPinnedMenuItem,
+  appCommandIdByPath: Map<string, string>,
+  scriptCommandIdByPath: Map<string, string>
+): string | null {
+  const fallbackId = 'id' in item ? String(item.id || '') : '';
+  const key = String(item?.key || fallbackId).trim();
+  if (key) {
+    const builtinId = RAYCAST_BUILTIN_COMMAND_ID_MAP[key];
+    if (builtinId) return builtinId;
+
+    const extensionCommand = parseRaycastExtensionCommandKey(key);
+    if (extensionCommand) {
+      return `ext-${extensionCommand.extensionName}-${extensionCommand.commandName}`;
+    }
+
+    if (key.startsWith(RAYCAST_SCRIPT_COMMAND_PREFIX)) {
+      const scriptPath = normalizeRaycastPath(key.slice(RAYCAST_SCRIPT_COMMAND_PREFIX.length));
+      if (scriptPath) {
+        const scriptId = scriptCommandIdByPath.get(scriptPath);
+        if (scriptId) return scriptId;
+      }
+    }
+  }
+
+  const itemPath = normalizeRaycastPath(String(item?.path || ''));
+  if (itemPath) {
+    const appId = appCommandIdByPath.get(itemPath);
+    if (appId) return appId;
+    const scriptId = scriptCommandIdByPath.get(itemPath);
+    if (scriptId) return scriptId;
+  }
+
+  return null;
+}
+
+function buildImportPreview(data: RaycastBackup): string {
+  const quicklinks = Array.isArray(data.builtin_package_quicklinks?.quicklinks)
+    ? data.builtin_package_quicklinks?.quicklinks?.length || 0
+    : 0;
+  const snippets = Array.isArray(data.builtin_package_snippets?.snippets)
+    ? data.builtin_package_snippets?.snippets?.length || 0
+    : 0;
+  const notes = Array.isArray(data.builtin_package_raycastNotes?.notes)
+    ? data.builtin_package_raycastNotes?.notes?.length || 0
+    : 0;
+  const extensions = Array.isArray(data.builtin_package_raycastExtensions?.extensions)
+    ? data.builtin_package_raycastExtensions?.extensions?.length || 0
+    : 0;
+  const lines = [
+    `Raycast version: ${String(data.raycast_version || 'unknown')}`,
+    `Quicklinks: ${quicklinks}`,
+    `Snippets: ${snippets}`,
+    `Notes: ${notes}`,
+    `Extensions: ${extensions}`,
+    '',
+    'This import will only bring over categories that SuperCmd can map cleanly today.',
+    'It will skip Raycast AI chats, clipboard history, and MCP server config.',
+  ];
+  return lines.join('\n');
+}
+
+function collectUnsupportedCategories(data: RaycastBackup): string[] {
+  const unsupported: string[] = [];
+  if ((data['builtin_package_open-ai']?.aiChats?.length || 0) > 0) unsupported.push('AI chats');
+  if ((data.builtin_package_clipboardHistory?.clipboardHistoryRecords?.length || 0) > 0) unsupported.push('clipboard history');
+  if ((data.builtin_package_mcp?.mcpServers?.length || 0) > 0) unsupported.push('MCP servers');
+  return unsupported;
+}
+
+function createBucketResult(found = 0): RaycastImportBucketResult {
+  return { found, imported: 0, skipped: 0, failed: 0 };
+}
+
+function firstMeaningfulLine(text: string): string {
+  const line = String(text || '')
+    .split('\n')
+    .map((entry) => entry.trim())
+    .find(Boolean);
+  return line || 'Untitled';
+}
+
+function applySettingsFromBackup(data: RaycastBackup): {
+  settingsImported: boolean;
+  disabledCommandsImported: number;
+  scriptCommandFoldersImported: number;
+} {
+  const patch: Partial<AppSettings> = {};
+  const currentSettings = loadSettings();
+  const preferences = data.builtin_package_raycastPreferences;
+  const globalShortcut = decodeRaycastHotkey(preferences?.preferencesGeneral?.raycastGlobalHotkey);
+  if (globalShortcut) patch.globalShortcut = globalShortcut;
+
+  const navigationStyle = normalizeNavigationStyle(
+    preferences?.preferencesAdvanced?.navigationCommandStyleIdentifierKey
+  );
+  if (navigationStyle) patch.navigationStyle = navigationStyle;
+
+  const launcherViewMode = normalizeLauncherViewMode(
+    preferences?.preferencesAppearance?.raycastPreferredWindowMode
+  );
+  if (launcherViewMode) patch.launcherViewMode = launcherViewMode;
+
+  const popToRootTimeout = Number(preferences?.preferencesAdvanced?.popToRootTimeout);
+  if (Number.isFinite(popToRootTimeout) && popToRootTimeout >= 0) {
+    patch.popToRootSearchTimeoutSeconds = popToRootTimeout;
+  }
+
+  let disabledCommandsImported = 0;
+  const disabledCommandIds = new Set<string>();
+  for (const extension of data.builtin_package_raycastExtensions?.extensions || []) {
+    const extensionName = String(extension?.name || '').trim();
+    if (!extensionName) continue;
+    for (const command of extension.commands || []) {
+      if (!command?.name || command.enabled !== false) continue;
+      disabledCommandIds.add(`ext-${extensionName}-${command.name}`);
+    }
+  }
+
+  const importedScriptCommandFolders = Array.isArray(data.builtin_package_scriptCommands?.scriptCommandsDirectories)
+    ? data.builtin_package_scriptCommands?.scriptCommandsDirectories
+        ?.map((entry) => String(entry || '').trim())
+        .filter(Boolean)
+        .map((entry) => entry.startsWith('~/') ? path.join(os.homedir(), entry.slice(2)) : entry) || []
+    : [];
+  if (importedScriptCommandFolders.length > 0) {
+    const merged = new Set([
+      ...(currentSettings.scriptCommandFolders || []),
+      ...importedScriptCommandFolders,
+    ]);
+    patch.scriptCommandFolders = [...merged];
+  }
+
+  if (patch.scriptCommandFolders) {
+    saveSettings(patch);
+  }
+
+  const disabledScriptCommands = Array.isArray(data.builtin_package_scriptCommands?.disabledCommands)
+    ? data.builtin_package_scriptCommands?.disabledCommands || []
+    : [];
+  if (disabledScriptCommands.length > 0) {
+    invalidateScriptCommandsCache();
+    const scriptCommandsByPath = new Map(
+      discoverScriptCommands().map((command) => [path.resolve(command.scriptPath), command.id] as const)
+    );
+    for (const rawCommand of disabledScriptCommands) {
+      const rawValue = String(rawCommand || '').trim();
+      const scriptPath = rawValue.startsWith(RAYCAST_SCRIPT_COMMAND_PREFIX)
+        ? normalizeRaycastPath(rawValue.slice(RAYCAST_SCRIPT_COMMAND_PREFIX.length))
+        : '';
+      if (!scriptPath) continue;
+      const commandId = scriptCommandsByPath.get(scriptPath);
+      if (!commandId) continue;
+      disabledCommandIds.add(commandId);
+    }
+  }
+
+  if (disabledCommandIds.size > 0) {
+    const existing = new Set(loadSettings().disabledCommands || []);
+    const beforeSize = existing.size;
+    for (const commandId of disabledCommandIds) {
+      existing.add(commandId);
+    }
+    patch.disabledCommands = [...existing];
+    disabledCommandsImported = existing.size - beforeSize;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return {
+      settingsImported: false,
+      disabledCommandsImported,
+      scriptCommandFoldersImported: importedScriptCommandFolders.length,
+    };
+  }
+
+  saveSettings(patch);
+  return {
+    settingsImported: true,
+    disabledCommandsImported,
+    scriptCommandFoldersImported: importedScriptCommandFolders.length,
+  };
+}
+
+async function importCommandCustomizations(
+  data: RaycastBackup,
+  warnings: string[]
+): Promise<{
+  commandHotkeysImported: number;
+  commandAliasesImported: number;
+  pinnedCommandsImported: number;
+}> {
+  const rootSearchItems = Array.isArray(data.builtin_package_rootSearch?.rootSearch)
+    ? data.builtin_package_rootSearch?.rootSearch || []
+    : [];
+  const pinnedMenuItems = Array.isArray(data.builtin_package_navigation?.pinnedMenuItems)
+    ? data.builtin_package_navigation?.pinnedMenuItems || []
+    : [];
+  if (rootSearchItems.length === 0 && pinnedMenuItems.length === 0) {
+    return {
+      commandHotkeysImported: 0,
+      commandAliasesImported: 0,
+      pinnedCommandsImported: 0,
+    };
+  }
+
+  invalidateScriptCommandsCache();
+  invalidateCache();
+
+  const [availableCommands, scriptCommands] = await Promise.all([
+    getAvailableCommands(),
+    Promise.resolve(discoverScriptCommands()),
+  ]);
+  const appCommandIdByPath = new Map<string, string>();
+  const commandById = new Map<string, CommandInfo>();
+  for (const command of availableCommands) {
+    commandById.set(command.id, command);
+    if (command.category === 'app' && command.path) {
+      appCommandIdByPath.set(path.resolve(command.path), command.id);
+    }
+  }
+  const scriptCommandIdByPath = new Map<string, string>();
+  for (const command of scriptCommands) {
+    scriptCommandIdByPath.set(path.resolve(command.scriptPath), command.id);
+  }
+
+  const settings = loadSettings();
+  const nextHotkeys = { ...(settings.commandHotkeys || {}) };
+  const nextAliases = { ...(settings.commandAliases || {}) };
+  const nextPinnedCommands = new Set((settings.pinnedCommands || []).map((entry) => String(entry || '').trim()).filter(Boolean));
+
+  let commandHotkeysImported = 0;
+  let commandAliasesImported = 0;
+  let pinnedCommandsImported = 0;
+  let hotkeyConflictCount = 0;
+  let hotkeyUnmappedCount = 0;
+  let aliasConflictCount = 0;
+  let aliasUnmappedCount = 0;
+  let favoriteUnmappedCount = 0;
+
+  for (const item of rootSearchItems) {
+    const hasHotkey = Boolean(String(item?.hotkey || '').trim());
+    const hasSearchTerms = Boolean(String(item?.searchTerms || '').trim());
+    if (!hasHotkey && !hasSearchTerms) continue;
+
+    const commandId = resolveRaycastCommandId(item, appCommandIdByPath, scriptCommandIdByPath);
+    if (!commandId) {
+      if (hasHotkey) hotkeyUnmappedCount += 1;
+      if (hasSearchTerms) aliasUnmappedCount += 1;
+      continue;
+    }
+
+    if (hasHotkey) {
+      const decodedHotkey = decodeRaycastHotkey(item.hotkey);
+      if (decodedHotkey) {
+        const existingHotkey = String(nextHotkeys[commandId] || '').trim();
+        if (!existingHotkey) {
+          nextHotkeys[commandId] = decodedHotkey;
+          commandHotkeysImported += 1;
+        } else if (existingHotkey !== decodedHotkey) {
+          hotkeyConflictCount += 1;
+        }
+      }
+    }
+
+    if (hasSearchTerms) {
+      const aliasCandidate = normalizeAliasCandidate(item.searchTerms);
+      if (!aliasCandidate) continue;
+      const existingAlias = String(nextAliases[commandId] || '').trim();
+      if (!existingAlias) {
+        nextAliases[commandId] = aliasCandidate;
+        commandAliasesImported += 1;
+      } else if (existingAlias !== aliasCandidate) {
+        aliasConflictCount += 1;
+      }
+    }
+  }
+
+  for (const rawPinnedItem of pinnedMenuItems) {
+    const pinnedItem = typeof rawPinnedItem === 'string'
+      ? { key: rawPinnedItem }
+      : rawPinnedItem;
+    const commandId = resolveRaycastCommandId(pinnedItem, appCommandIdByPath, scriptCommandIdByPath);
+    if (!commandId) {
+      favoriteUnmappedCount += 1;
+      continue;
+    }
+    if (!commandById.has(commandId)) {
+      favoriteUnmappedCount += 1;
+      continue;
+    }
+    if (!nextPinnedCommands.has(commandId)) {
+      nextPinnedCommands.add(commandId);
+      pinnedCommandsImported += 1;
+    }
+  }
+
+  const patch: Partial<AppSettings> = {};
+  if (commandHotkeysImported > 0) {
+    patch.commandHotkeys = nextHotkeys;
+  }
+  if (commandAliasesImported > 0) {
+    patch.commandAliases = nextAliases;
+  }
+  if (pinnedCommandsImported > 0) {
+    patch.pinnedCommands = [...nextPinnedCommands];
+  }
+  if (Object.keys(patch).length > 0) {
+    saveSettings(patch);
+  }
+
+  if (hotkeyConflictCount > 0) {
+    warnings.push(`Skipped ${hotkeyConflictCount} Raycast command hotkey${hotkeyConflictCount === 1 ? '' : 's'} because SuperCmd already has a different shortcut.`);
+  }
+  if (hotkeyUnmappedCount > 0) {
+    warnings.push(`Skipped ${hotkeyUnmappedCount} Raycast command hotkey${hotkeyUnmappedCount === 1 ? '' : 's'} that could not be mapped to a SuperCmd command.`);
+  }
+  if (aliasConflictCount > 0) {
+    warnings.push(`Skipped ${aliasConflictCount} Raycast alias candidate${aliasConflictCount === 1 ? '' : 's'} because SuperCmd already has a different alias.`);
+  }
+  if (aliasUnmappedCount > 0) {
+    warnings.push(`Skipped ${aliasUnmappedCount} Raycast search alias candidate${aliasUnmappedCount === 1 ? '' : 's'} that could not be mapped to a SuperCmd command.`);
+  }
+  if (favoriteUnmappedCount > 0) {
+    warnings.push(`Skipped ${favoriteUnmappedCount} Raycast favorite${favoriteUnmappedCount === 1 ? '' : 's'} that could not be mapped to a SuperCmd command.`);
+  }
+
+  return {
+    commandHotkeysImported,
+    commandAliasesImported,
+    pinnedCommandsImported,
+  };
+}
+
+function importQuicklinks(data: RaycastBackup): RaycastImportBucketResult {
+  const source = Array.isArray(data.builtin_package_quicklinks?.quicklinks)
+    ? data.builtin_package_quicklinks?.quicklinks || []
+    : [];
+  const result = createBucketResult(source.length);
+  const existing = getAllQuickLinks();
+  const existingKeys = new Set(
+    existing.map((item) => `${item.name.trim().toLowerCase()}::${item.urlTemplate.trim().toLowerCase()}`)
+  );
+
+  for (const quicklink of source) {
+    const name = String(quicklink?.name || '').trim();
+    const url = String(quicklink?.url || '').trim();
+    if (!name || !url) {
+      result.failed += 1;
+      continue;
+    }
+    const dedupeKey = `${name.toLowerCase()}::${url.toLowerCase()}`;
+    if (existingKeys.has(dedupeKey)) {
+      result.skipped += 1;
+      continue;
+    }
+    createQuickLink({
+      name,
+      urlTemplate: url,
+      icon: url.includes('{argument}') ? 'Search' : 'Globe',
+    });
+    existingKeys.add(dedupeKey);
+    result.imported += 1;
+  }
+
+  return result;
+}
+
+function importSnippets(data: RaycastBackup): RaycastImportBucketResult {
+  const source = Array.isArray(data.builtin_package_snippets?.snippets)
+    ? data.builtin_package_snippets?.snippets || []
+    : [];
+  const result = createBucketResult(source.length);
+  const existing = getAllSnippets();
+
+  for (const snippet of source) {
+    const name = String(snippet?.name || '').trim();
+    const content = String(snippet?.text || '').trim();
+    const keyword = typeof snippet?.keyword === 'string' ? snippet.keyword.trim() : undefined;
+    if (!name || !content) {
+      result.failed += 1;
+      continue;
+    }
+    const duplicate = existing.find(
+      (item) =>
+        item.name.trim().toLowerCase() === name.toLowerCase() ||
+        (keyword && item.keyword && item.keyword.trim().toLowerCase() === keyword.toLowerCase())
+    );
+    if (duplicate) {
+      result.skipped += 1;
+      continue;
+    }
+    const created = createSnippet({ name, content, keyword });
+    if (snippet?.pinned) {
+      updateSnippet(created.id, { pinned: true });
+    }
+    existing.push({ ...created, pinned: Boolean(snippet?.pinned) });
+    result.imported += 1;
+  }
+
+  return result;
+}
+
+function importNotes(data: RaycastBackup): RaycastImportBucketResult {
+  const source = Array.isArray(data.builtin_package_raycastNotes?.notes)
+    ? data.builtin_package_raycastNotes?.notes || []
+    : [];
+  const result = createBucketResult(source.length);
+  const existing = getAllNotes();
+
+  for (const note of source) {
+    const content = String(note?.text || '').trim();
+    const title = String(note?.title || '').trim() || firstMeaningfulLine(content);
+    if (!title && !content) {
+      result.failed += 1;
+      continue;
+    }
+    const duplicate = existing.find(
+      (item) =>
+        item.title.trim().toLowerCase() === title.toLowerCase() &&
+        item.content.trim() === content
+    );
+    if (duplicate) {
+      result.skipped += 1;
+      continue;
+    }
+    const created = createNote({ title, content });
+    if (note?.pinned) {
+      updateNote(created.id, { pinned: true });
+    }
+    existing.push({ ...created, content, title, pinned: Boolean(note?.pinned) });
+    result.imported += 1;
+  }
+
+  return result;
+}
+
+async function importExtensions(data: RaycastBackup, warnings: string[]): Promise<RaycastImportBucketResult> {
+  const source = Array.isArray(data.builtin_package_raycastExtensions?.extensions)
+    ? data.builtin_package_raycastExtensions?.extensions || []
+    : [];
+  const result = createBucketResult(source.length);
+  const installed = new Set((await getInstalledExtensionNames()).map((entry) => String(entry || '').trim()));
+
+  for (const extension of source) {
+    const extensionName = String(extension?.name || '').trim();
+    if (!extensionName) {
+      result.failed += 1;
+      continue;
+    }
+    if (installed.has(extensionName)) {
+      result.skipped += 1;
+      continue;
+    }
+    try {
+      const success = await installExtension(extensionName);
+      if (!success) {
+        result.failed += 1;
+        warnings.push(`Failed to install extension "${extensionName}".`);
+        continue;
+      }
+      installed.add(extensionName);
+      result.imported += 1;
+    } catch (error: any) {
+      result.failed += 1;
+      warnings.push(`Failed to install extension "${extensionName}": ${String(error?.message || error || 'unknown error')}`);
+    }
+  }
+
+  return result;
+}
+
+function importExtensionPreferences(data: RaycastBackup): void {
+  for (const extension of data.builtin_package_raycastExtensions?.extensions || []) {
+    const extensionName = String(extension?.name || '').trim();
+    if (!extensionName || !Array.isArray(extension.prefs) || extension.prefs.length === 0) continue;
+    const nextValues: Record<string, any> = {};
+    for (const pref of extension.prefs) {
+      const prefName = String(pref?.name || '').trim();
+      if (!prefName) continue;
+      if (!Object.prototype.hasOwnProperty.call(pref || {}, 'value')) continue;
+      nextValues[prefName] = (pref as any).value;
+    }
+    if (Object.keys(nextValues).length === 0) continue;
+    setExtensionPreferences(extensionName, nextValues);
+  }
+}
+
+export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow): Promise<RaycastImportResult> {
+  const dialogOptions = {
+    title: 'Import Raycast Backup',
+    filters: [
+      { name: 'Raycast Backup', extensions: ['rayconfig', 'json'] },
+    ],
+    properties: ['openFile'] as Array<'openFile'>,
+  };
+
+  const selection = parentWindow
+    ? await dialog.showOpenDialog(parentWindow, dialogOptions)
+    : await dialog.showOpenDialog(dialogOptions);
+
+  if (selection.canceled || selection.filePaths.length === 0) {
+    return {
+      canceled: true,
+      settingsImported: false,
+      disabledCommandsImported: 0,
+      scriptCommandFoldersImported: 0,
+      commandHotkeysImported: 0,
+      commandAliasesImported: 0,
+      pinnedCommandsImported: 0,
+      quicklinks: createBucketResult(),
+      snippets: createBucketResult(),
+      notes: createBucketResult(),
+      extensions: createBucketResult(),
+      unsupported: [],
+      warnings: [],
+    };
+  }
+
+  const filePath = path.resolve(selection.filePaths[0]);
+  let backup: RaycastBackup | null = null;
+  let password: string | null = null;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      backup = loadRaycastBackupFromFile(filePath, password);
+      break;
+    } catch (error: any) {
+      const message = String(error?.message || error || '');
+      if (
+        message.includes('password is not valid') ||
+        message.includes('password is required')
+      ) {
+        const promptedPassword = promptForPassword(attempt === 0 ? PASSWORD_PROMPT_MESSAGE : PASSWORD_RETRY_MESSAGE);
+        if (!promptedPassword) {
+          return {
+            canceled: true,
+            filePath,
+            settingsImported: false,
+            disabledCommandsImported: 0,
+            scriptCommandFoldersImported: 0,
+            commandHotkeysImported: 0,
+            commandAliasesImported: 0,
+            pinnedCommandsImported: 0,
+            quicklinks: createBucketResult(),
+            snippets: createBucketResult(),
+            notes: createBucketResult(),
+            extensions: createBucketResult(),
+            unsupported: [],
+            warnings: [],
+          };
+        }
+        password = promptedPassword;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  if (!backup) {
+    throw new Error('Failed to read import data; password is not valid.');
+  }
+
+  const confirm = parentWindow
+    ? await dialog.showMessageBox(parentWindow, {
+        type: 'question',
+        buttons: ['Cancel', 'Import'],
+        defaultId: 1,
+        cancelId: 0,
+        noLink: true,
+        title: 'Import Raycast Backup',
+        message: 'Review the Raycast backup before importing.',
+        detail: buildImportPreview(backup),
+      })
+    : await dialog.showMessageBox({
+        type: 'question',
+        buttons: ['Cancel', 'Import'],
+        defaultId: 1,
+        cancelId: 0,
+        noLink: true,
+        title: 'Import Raycast Backup',
+        message: 'Review the Raycast backup before importing.',
+        detail: buildImportPreview(backup),
+      });
+
+  if (confirm.response !== 1) {
+    return {
+      canceled: true,
+      filePath,
+      raycastVersion: backup.raycast_version,
+      settingsImported: false,
+      disabledCommandsImported: 0,
+      scriptCommandFoldersImported: 0,
+      commandHotkeysImported: 0,
+      commandAliasesImported: 0,
+      pinnedCommandsImported: 0,
+      quicklinks: createBucketResult(),
+      snippets: createBucketResult(),
+      notes: createBucketResult(),
+      extensions: createBucketResult(),
+      unsupported: collectUnsupportedCategories(backup),
+      warnings: [],
+    };
+  }
+
+  const warnings: string[] = [];
+  const { settingsImported, disabledCommandsImported, scriptCommandFoldersImported } = applySettingsFromBackup(backup);
+  const quicklinks = importQuicklinks(backup);
+  const snippets = importSnippets(backup);
+  const notes = importNotes(backup);
+  const extensions = await importExtensions(backup, warnings);
+  importExtensionPreferences(backup);
+  const {
+    commandHotkeysImported,
+    commandAliasesImported,
+    pinnedCommandsImported,
+  } = await importCommandCustomizations(backup, warnings);
+
+  return {
+    canceled: false,
+    filePath,
+    raycastVersion: backup.raycast_version,
+    settingsImported,
+    disabledCommandsImported,
+    scriptCommandFoldersImported,
+    commandHotkeysImported,
+    commandAliasesImported,
+    pinnedCommandsImported,
+    quicklinks,
+    snippets,
+    notes,
+    extensions,
+    unsupported: collectUnsupportedCategories(backup),
+    warnings,
+  };
+}

--- a/src/main/raycast-config-import.ts
+++ b/src/main/raycast-config-import.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as zlib from 'zlib';
+import { getAiChatSnapshot, mergeAiChatSnapshot } from './ai-chat-store';
 import { getAvailableCommands, invalidateCache, type CommandInfo } from './commands';
 import { getExtensionPreferences, setExtensionPreferences } from './extension-preferences-store';
 import { getInstalledExtensionNames, installExtension } from './extension-registry';
@@ -128,6 +129,7 @@ export interface RaycastImportResult {
   commandHotkeysImported: number;
   commandAliasesImported: number;
   pinnedCommandsImported: number;
+  aiChats: RaycastImportBucketResult;
   quicklinks: RaycastImportBucketResult;
   snippets: RaycastImportBucketResult;
   notes: RaycastImportBucketResult;
@@ -455,6 +457,9 @@ function resolveRaycastCommandId(
 }
 
 function buildImportPreview(data: RaycastBackup): string {
+  const aiChats = Array.isArray(data['builtin_package_open-ai']?.aiChats)
+    ? data['builtin_package_open-ai']?.aiChats?.length || 0
+    : 0;
   const quicklinks = Array.isArray(data.builtin_package_quicklinks?.quicklinks)
     ? data.builtin_package_quicklinks?.quicklinks?.length || 0
     : 0;
@@ -469,20 +474,20 @@ function buildImportPreview(data: RaycastBackup): string {
     : 0;
   const lines = [
     `Raycast version: ${String(data.raycast_version || 'unknown')}`,
+    `AI chats: ${aiChats}`,
     `Quicklinks: ${quicklinks}`,
     `Snippets: ${snippets}`,
     `Notes: ${notes}`,
     `Extensions: ${extensions}`,
     '',
     'This import will only bring over categories that SuperCmd can map cleanly today.',
-    'It will skip Raycast AI chats, clipboard history, and MCP server config.',
+    'It will skip clipboard history and MCP server config.',
   ];
   return lines.join('\n');
 }
 
 function collectUnsupportedCategories(data: RaycastBackup): string[] {
   const unsupported: string[] = [];
-  if ((data['builtin_package_open-ai']?.aiChats?.length || 0) > 0) unsupported.push('AI chats');
   if ((data.builtin_package_clipboardHistory?.clipboardHistoryRecords?.length || 0) > 0) unsupported.push('clipboard history');
   if ((data.builtin_package_mcp?.mcpServers?.length || 0) > 0) unsupported.push('MCP servers');
   return unsupported;
@@ -490,6 +495,267 @@ function collectUnsupportedCategories(data: RaycastBackup): string[] {
 
 function createBucketResult(found = 0): RaycastImportBucketResult {
   return { found, imported: 0, skipped: 0, failed: 0 };
+}
+
+function asRecord(value: unknown): Record<string, any> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, any>;
+}
+
+function parseTimestamp(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value > 1e11) return Math.round(value);
+    if (value > 1e9) return Math.round(value * 1000);
+    if (value > 5e8) return Math.round((value + 978307200) * 1000);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) {
+      const asNumber = Number(trimmed);
+      if (Number.isFinite(asNumber)) return parseTimestamp(asNumber, fallback);
+      const asDate = Date.parse(trimmed);
+      if (Number.isFinite(asDate)) return asDate;
+    }
+  }
+  return fallback;
+}
+
+function extractTextChunks(value: unknown, depth = 0): string[] {
+  if (depth > 4 || value == null) return [];
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return [String(value)];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => extractTextChunks(entry, depth + 1));
+  }
+  const record = asRecord(value);
+  if (!record) return [];
+
+  const directKeys = [
+    'content',
+    'text',
+    'body',
+    'message',
+    'prompt',
+    'response',
+    'answer',
+    'question',
+    'markdown',
+    'output',
+    'summary',
+    'transcript',
+    'completion',
+    'value',
+  ];
+  const chunks: string[] = [];
+  for (const key of directKeys) {
+    if (Object.prototype.hasOwnProperty.call(record, key)) {
+      chunks.push(...extractTextChunks(record[key], depth + 1));
+    }
+  }
+
+  if (chunks.length > 0) return chunks;
+
+  for (const [key, child] of Object.entries(record)) {
+    if (/^(id|uuid|title|name|createdAt|updatedAt|timestamp|date|role|type|model|metadata)$/i.test(key)) {
+      continue;
+    }
+    chunks.push(...extractTextChunks(child, depth + 1));
+  }
+
+  return chunks;
+}
+
+function uniqueText(chunks: string[]): string {
+  const seen = new Set<string>();
+  const next: string[] = [];
+  for (const chunk of chunks) {
+    const normalized = chunk.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    next.push(normalized);
+  }
+  return next.join('\n\n').trim();
+}
+
+function normalizeImportedRole(value: unknown): 'user' | 'assistant' {
+  const raw = String(value || '').trim().toLowerCase();
+  if (
+    raw === 'user' ||
+    raw === 'human' ||
+    raw === 'prompt' ||
+    raw === 'question' ||
+    raw === 'input'
+  ) {
+    return 'user';
+  }
+  return 'assistant';
+}
+
+function extractConversationArray(record: Record<string, any>): unknown[] {
+  const directKeys = [
+    'messages',
+    'turns',
+    'entries',
+    'items',
+    'chatMessages',
+    'conversationMessages',
+    'conversation',
+    'history',
+    'nodes',
+  ];
+  for (const key of directKeys) {
+    if (Array.isArray(record[key])) return record[key];
+  }
+  for (const value of Object.values(record)) {
+    if (!Array.isArray(value)) continue;
+    if (value.some((entry) => asRecord(entry))) return value;
+  }
+  return [];
+}
+
+function extractMessagesFromRaycastEntry(entry: unknown, index: number): Array<{
+  role: 'user' | 'assistant';
+  content: string;
+  createdAt: number;
+}> {
+  const fallbackTs = Date.now() + index;
+  if (typeof entry === 'string') {
+    const trimmed = entry.trim();
+    return trimmed ? [{ role: 'assistant', content: trimmed, createdAt: fallbackTs }] : [];
+  }
+  const record = asRecord(entry);
+  if (!record) return [];
+
+  const pairedFields: Array<[keyof typeof record, keyof typeof record]> = [
+    ['prompt', 'response'],
+    ['question', 'answer'],
+    ['input', 'output'],
+    ['userMessage', 'assistantMessage'],
+    ['request', 'response'],
+  ];
+  for (const [userKey, assistantKey] of pairedFields) {
+    const userText = uniqueText(extractTextChunks(record[userKey]));
+    const assistantText = uniqueText(extractTextChunks(record[assistantKey]));
+    if (!userText && !assistantText) continue;
+    const createdAt = parseTimestamp(
+      record.createdAt ?? record.timestamp ?? record.date,
+      fallbackTs
+    );
+    const next: Array<{ role: 'user' | 'assistant'; content: string; createdAt: number }> = [];
+    if (userText) next.push({ role: 'user', content: userText, createdAt });
+    if (assistantText) next.push({ role: 'assistant', content: assistantText, createdAt: createdAt + 1 });
+    return next;
+  }
+
+  const content = uniqueText(extractTextChunks(record));
+  if (!content) return [];
+  const role = normalizeImportedRole(
+    record.role ?? record.type ?? record.authorRole ?? record.senderRole ?? record.author?.role ?? record.sender?.role
+  );
+  const createdAt = parseTimestamp(
+    record.createdAt ?? record.updatedAt ?? record.timestamp ?? record.date,
+    fallbackTs
+  );
+  return [{ role, content, createdAt }];
+}
+
+function normalizeRaycastConversation(chat: unknown, index: number): Record<string, any> | null {
+  const record = asRecord(chat);
+  if (!record) return null;
+  const rawMessages = extractConversationArray(record);
+  const messages = rawMessages.flatMap((entry, messageIndex) => extractMessagesFromRaycastEntry(entry, messageIndex));
+  if (messages.length === 0) {
+    const fallbackContent = uniqueText(extractTextChunks(record.preview ?? record.lastMessage ?? record.summary));
+    if (fallbackContent) {
+      messages.push({
+        role: 'assistant',
+        content: fallbackContent,
+        createdAt: parseTimestamp(record.updatedAt ?? record.createdAt, Date.now() + index),
+      });
+    }
+  }
+  if (messages.length === 0) return null;
+
+  const firstUserMessage = messages.find((message) => message.role === 'user')?.content || '';
+  const title = String(record.title || record.name || '').trim() || firstMeaningfulLine(firstUserMessage) || 'Imported Chat';
+  const sourceConversationId = String(
+    record.id ??
+    record.uuid ??
+    record.chatId ??
+    record.conversationId ??
+    record.identifier ??
+    ''
+  ).trim();
+  const createdAt = parseTimestamp(
+    record.createdAt ?? record.timestamp ?? messages[0]?.createdAt,
+    messages[0]?.createdAt || Date.now() + index
+  );
+  const updatedAt = parseTimestamp(
+    record.updatedAt ?? record.lastUpdatedAt ?? record.modifiedAt ?? messages[messages.length - 1]?.createdAt,
+    messages[messages.length - 1]?.createdAt || createdAt
+  );
+
+  const metadata: Record<string, any> = {};
+  for (const key of ['model', 'modelName', 'provider', 'temperature']) {
+    if (record[key] !== undefined) {
+      metadata[key] = record[key];
+    }
+  }
+
+  return {
+    id: sourceConversationId ? `raycast-${sourceConversationId}` : undefined,
+    title,
+    createdAt,
+    updatedAt,
+    source: 'raycast',
+    ...(sourceConversationId ? { sourceConversationId } : {}),
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+    messages: messages.map((message, messageIndex) => ({
+      id: `${sourceConversationId || `chat-${index}`}-msg-${messageIndex}`,
+      role: message.role,
+      content: message.content,
+      createdAt: message.createdAt,
+    })),
+  };
+}
+
+function importAiChats(data: RaycastBackup, warnings: string[]): RaycastImportBucketResult {
+  const source = Array.isArray(data['builtin_package_open-ai']?.aiChats)
+    ? data['builtin_package_open-ai']?.aiChats || []
+    : [];
+  const result = createBucketResult(source.length);
+  if (source.length === 0) return result;
+
+  const normalizedConversations = source
+    .map((chat, index) => normalizeRaycastConversation(chat, index))
+    .filter((conversation): conversation is Record<string, any> => Boolean(conversation));
+
+  result.failed = source.length - normalizedConversations.length;
+  if (result.failed > 0) {
+    warnings.push(`Skipped ${result.failed} Raycast AI chat${result.failed === 1 ? '' : 's'} that could not be mapped cleanly.`);
+  }
+  if (normalizedConversations.length === 0) return result;
+
+  const existingIds = new Set(getAiChatSnapshot().conversations.map((conversation) => conversation.id));
+  for (const conversation of normalizedConversations) {
+    const conversationId = String(conversation.id || '').trim();
+    if (conversationId && existingIds.has(conversationId)) {
+      result.skipped += 1;
+      continue;
+    }
+    result.imported += 1;
+  }
+
+  mergeAiChatSnapshot({
+    version: 1,
+    conversations: normalizedConversations as any,
+  });
+  return result;
 }
 
 function firstMeaningfulLine(text: string): string {
@@ -933,6 +1199,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
       commandHotkeysImported: 0,
       commandAliasesImported: 0,
       pinnedCommandsImported: 0,
+      aiChats: createBucketResult(),
       quicklinks: createBucketResult(),
       snippets: createBucketResult(),
       notes: createBucketResult(),
@@ -968,6 +1235,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
             commandHotkeysImported: 0,
             commandAliasesImported: 0,
             pinnedCommandsImported: 0,
+            aiChats: createBucketResult(),
             quicklinks: createBucketResult(),
             snippets: createBucketResult(),
             notes: createBucketResult(),
@@ -1021,6 +1289,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
       commandHotkeysImported: 0,
       commandAliasesImported: 0,
       pinnedCommandsImported: 0,
+      aiChats: createBucketResult(),
       quicklinks: createBucketResult(),
       snippets: createBucketResult(),
       notes: createBucketResult(),
@@ -1033,6 +1302,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
 
   const warnings: string[] = [];
   const { settingsImported, disabledCommandsImported, scriptCommandFoldersImported } = applySettingsFromBackup(backup);
+  const aiChats = importAiChats(backup, warnings);
   const quicklinks = importQuicklinks(backup);
   const snippets = importSnippets(backup);
   const notes = importNotes(backup);
@@ -1054,6 +1324,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
     commandHotkeysImported,
     commandAliasesImported,
     pinnedCommandsImported,
+    aiChats,
     quicklinks,
     snippets,
     notes,

--- a/src/main/raycast-config-import.ts
+++ b/src/main/raycast-config-import.ts
@@ -139,11 +139,71 @@ export interface RaycastImportResult {
   warnings: string[];
 }
 
+export interface RaycastImportSelections {
+  settings: boolean;
+  disabledCommands: boolean;
+  scriptCommandFolders: boolean;
+  commandHotkeys: boolean;
+  commandAliases: boolean;
+  pinnedCommands: boolean;
+  aiChats: boolean;
+  quicklinks: boolean;
+  snippets: boolean;
+  notes: boolean;
+  extensions: boolean;
+  extensionPreferences: boolean;
+}
+
+export interface RaycastImportOptions {
+  sessionId: string;
+  conflictMode: 'skip' | 'overwrite';
+  selections: RaycastImportSelections;
+}
+
+export interface RaycastImportPreview {
+  canceled: boolean;
+  sessionId?: string;
+  filePath?: string;
+  raycastVersion?: string;
+  selections: RaycastImportSelections;
+  counts: {
+    settings: number;
+    disabledCommands: number;
+    scriptCommandFolders: number;
+    commandHotkeys: number;
+    commandAliases: number;
+    pinnedCommands: number;
+    aiChats: number;
+    quicklinks: number;
+    snippets: number;
+    notes: number;
+    extensions: number;
+    extensionPreferences: number;
+  };
+  unsupported: string[];
+  warnings: string[];
+}
+
+export interface RaycastImportProgress {
+  sessionId: string;
+  stage: 'starting' | 'category' | 'extension' | 'done';
+  category?: keyof RaycastImportSelections;
+  message: string;
+  completedSteps: number;
+  totalSteps: number;
+  currentItem?: number;
+  totalItems?: number;
+  extensionName?: string;
+  downloadedBytes?: number;
+  totalBytes?: number;
+}
+
 const PASSWORD_PROMPT_TITLE = 'Import Raycast Backup';
 const PASSWORD_PROMPT_MESSAGE = 'Enter the password for the Raycast backup.';
 const PASSWORD_RETRY_MESSAGE = 'Password was not valid. Try again.';
 const RAYCAST_ROOT_SEARCH_PREFIX = 'extension_';
 const RAYCAST_SCRIPT_COMMAND_PREFIX = 'raycastScript_';
+const importSessions = new Map<string, { filePath: string; backup: RaycastBackup }>();
 
 const RAYCAST_BUILTIN_COMMAND_ID_MAP: Record<string, string> = {
   builtin_command_clipboardHistory: 'system-clipboard-manager',
@@ -155,6 +215,27 @@ const RAYCAST_BUILTIN_COMMAND_ID_MAP: Record<string, string> = {
   builtin_command_raycastNotes_ask: 'system-search-notes',
   builtin_command_searchEmoji: 'system-emoji-picker',
 };
+
+function createImportSessionId(): string {
+  return `ray-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function createDefaultSelections(): RaycastImportSelections {
+  return {
+    settings: true,
+    disabledCommands: true,
+    scriptCommandFolders: true,
+    commandHotkeys: true,
+    commandAliases: true,
+    pinnedCommands: true,
+    aiChats: true,
+    quicklinks: true,
+    snippets: true,
+    notes: true,
+    extensions: true,
+    extensionPreferences: true,
+  };
+}
 
 const RAYCAST_KEYCODE_TO_KEY: Record<number, string> = {
   0: 'A',
@@ -486,6 +567,38 @@ function buildImportPreview(data: RaycastBackup): string {
   return lines.join('\n');
 }
 
+function countPreviewStats(data: RaycastBackup): RaycastImportPreview['counts'] {
+  const rootSearchItems = Array.isArray(data.builtin_package_rootSearch?.rootSearch)
+    ? data.builtin_package_rootSearch?.rootSearch || []
+    : [];
+  const settingsCount =
+    Number(Boolean(decodeRaycastHotkey(data.builtin_package_raycastPreferences?.preferencesGeneral?.raycastGlobalHotkey))) +
+    Number(Boolean(normalizeNavigationStyle(data.builtin_package_raycastPreferences?.preferencesAdvanced?.navigationCommandStyleIdentifierKey))) +
+    Number(Boolean(normalizeLauncherViewMode(data.builtin_package_raycastPreferences?.preferencesAppearance?.raycastPreferredWindowMode))) +
+    Number(Number.isFinite(Number(data.builtin_package_raycastPreferences?.preferencesAdvanced?.popToRootTimeout)));
+
+  return {
+    settings: settingsCount,
+    disabledCommands:
+      (data.builtin_package_scriptCommands?.disabledCommands?.length || 0) +
+      (data.builtin_package_raycastExtensions?.extensions || []).reduce((count, extension) => (
+        count + (extension.commands || []).filter((command) => command?.enabled === false).length
+      ), 0),
+    scriptCommandFolders: data.builtin_package_scriptCommands?.scriptCommandsDirectories?.length || 0,
+    commandHotkeys: rootSearchItems.filter((item) => Boolean(String(item?.hotkey || '').trim())).length,
+    commandAliases: rootSearchItems.filter((item) => Boolean(normalizeAliasCandidate(item?.searchTerms))).length,
+    pinnedCommands: data.builtin_package_navigation?.pinnedMenuItems?.length || 0,
+    aiChats: data['builtin_package_open-ai']?.aiChats?.length || 0,
+    quicklinks: data.builtin_package_quicklinks?.quicklinks?.length || 0,
+    snippets: data.builtin_package_snippets?.snippets?.length || 0,
+    notes: data.builtin_package_raycastNotes?.notes?.length || 0,
+    extensions: data.builtin_package_raycastExtensions?.extensions?.length || 0,
+    extensionPreferences: (data.builtin_package_raycastExtensions?.extensions || []).filter((extension) => (
+      Array.isArray(extension.prefs) && extension.prefs.length > 0
+    )).length,
+  };
+}
+
 function collectUnsupportedCategories(data: RaycastBackup): string[] {
   const unsupported: string[] = [];
   if ((data.builtin_package_clipboardHistory?.clipboardHistoryRecords?.length || 0) > 0) unsupported.push('clipboard history');
@@ -766,7 +879,10 @@ function firstMeaningfulLine(text: string): string {
   return line || 'Untitled';
 }
 
-function applySettingsFromBackup(data: RaycastBackup): {
+function applySettingsFromBackup(
+  data: RaycastBackup,
+  options: { includeSettings: boolean; includeDisabledCommands: boolean; includeScriptCommandFolders: boolean }
+): {
   settingsImported: boolean;
   disabledCommandsImported: number;
   scriptCommandFoldersImported: number;
@@ -774,32 +890,36 @@ function applySettingsFromBackup(data: RaycastBackup): {
   const patch: Partial<AppSettings> = {};
   const currentSettings = loadSettings();
   const preferences = data.builtin_package_raycastPreferences;
-  const globalShortcut = decodeRaycastHotkey(preferences?.preferencesGeneral?.raycastGlobalHotkey);
-  if (globalShortcut) patch.globalShortcut = globalShortcut;
+  if (options.includeSettings) {
+    const globalShortcut = decodeRaycastHotkey(preferences?.preferencesGeneral?.raycastGlobalHotkey);
+    if (globalShortcut) patch.globalShortcut = globalShortcut;
 
-  const navigationStyle = normalizeNavigationStyle(
-    preferences?.preferencesAdvanced?.navigationCommandStyleIdentifierKey
-  );
-  if (navigationStyle) patch.navigationStyle = navigationStyle;
+    const navigationStyle = normalizeNavigationStyle(
+      preferences?.preferencesAdvanced?.navigationCommandStyleIdentifierKey
+    );
+    if (navigationStyle) patch.navigationStyle = navigationStyle;
 
-  const launcherViewMode = normalizeLauncherViewMode(
-    preferences?.preferencesAppearance?.raycastPreferredWindowMode
-  );
-  if (launcherViewMode) patch.launcherViewMode = launcherViewMode;
+    const launcherViewMode = normalizeLauncherViewMode(
+      preferences?.preferencesAppearance?.raycastPreferredWindowMode
+    );
+    if (launcherViewMode) patch.launcherViewMode = launcherViewMode;
 
-  const popToRootTimeout = Number(preferences?.preferencesAdvanced?.popToRootTimeout);
-  if (Number.isFinite(popToRootTimeout) && popToRootTimeout >= 0) {
-    patch.popToRootSearchTimeoutSeconds = popToRootTimeout;
+    const popToRootTimeout = Number(preferences?.preferencesAdvanced?.popToRootTimeout);
+    if (Number.isFinite(popToRootTimeout) && popToRootTimeout >= 0) {
+      patch.popToRootSearchTimeoutSeconds = popToRootTimeout;
+    }
   }
 
   let disabledCommandsImported = 0;
   const disabledCommandIds = new Set<string>();
-  for (const extension of data.builtin_package_raycastExtensions?.extensions || []) {
-    const extensionName = String(extension?.name || '').trim();
-    if (!extensionName) continue;
-    for (const command of extension.commands || []) {
-      if (!command?.name || command.enabled !== false) continue;
-      disabledCommandIds.add(`ext-${extensionName}-${command.name}`);
+  if (options.includeDisabledCommands) {
+    for (const extension of data.builtin_package_raycastExtensions?.extensions || []) {
+      const extensionName = String(extension?.name || '').trim();
+      if (!extensionName) continue;
+      for (const command of extension.commands || []) {
+        if (!command?.name || command.enabled !== false) continue;
+        disabledCommandIds.add(`ext-${extensionName}-${command.name}`);
+      }
     }
   }
 
@@ -809,7 +929,7 @@ function applySettingsFromBackup(data: RaycastBackup): {
         .filter(Boolean)
         .map((entry) => entry.startsWith('~/') ? path.join(os.homedir(), entry.slice(2)) : entry) || []
     : [];
-  if (importedScriptCommandFolders.length > 0) {
+  if (options.includeScriptCommandFolders && importedScriptCommandFolders.length > 0) {
     const merged = new Set([
       ...(currentSettings.scriptCommandFolders || []),
       ...importedScriptCommandFolders,
@@ -821,7 +941,7 @@ function applySettingsFromBackup(data: RaycastBackup): {
     saveSettings(patch);
   }
 
-  const disabledScriptCommands = Array.isArray(data.builtin_package_scriptCommands?.disabledCommands)
+  const disabledScriptCommands = options.includeDisabledCommands && Array.isArray(data.builtin_package_scriptCommands?.disabledCommands)
     ? data.builtin_package_scriptCommands?.disabledCommands || []
     : [];
   if (disabledScriptCommands.length > 0) {
@@ -869,7 +989,13 @@ function applySettingsFromBackup(data: RaycastBackup): {
 
 async function importCommandCustomizations(
   data: RaycastBackup,
-  warnings: string[]
+  warnings: string[],
+  options: {
+    includeHotkeys: boolean;
+    includeAliases: boolean;
+    includePinnedCommands: boolean;
+    conflictMode: 'skip' | 'overwrite';
+  }
 ): Promise<{
   commandHotkeysImported: number;
   commandAliasesImported: number;
@@ -924,8 +1050,8 @@ async function importCommandCustomizations(
   let favoriteUnmappedCount = 0;
 
   for (const item of rootSearchItems) {
-    const hasHotkey = Boolean(String(item?.hotkey || '').trim());
-    const hasSearchTerms = Boolean(String(item?.searchTerms || '').trim());
+    const hasHotkey = options.includeHotkeys && Boolean(String(item?.hotkey || '').trim());
+    const hasSearchTerms = options.includeAliases && Boolean(String(item?.searchTerms || '').trim());
     if (!hasHotkey && !hasSearchTerms) continue;
 
     const commandId = resolveRaycastCommandId(item, appCommandIdByPath, scriptCommandIdByPath);
@@ -942,6 +1068,9 @@ async function importCommandCustomizations(
         if (!existingHotkey) {
           nextHotkeys[commandId] = decodedHotkey;
           commandHotkeysImported += 1;
+        } else if (existingHotkey !== decodedHotkey && options.conflictMode === 'overwrite') {
+          nextHotkeys[commandId] = decodedHotkey;
+          commandHotkeysImported += 1;
         } else if (existingHotkey !== decodedHotkey) {
           hotkeyConflictCount += 1;
         }
@@ -955,13 +1084,16 @@ async function importCommandCustomizations(
       if (!existingAlias) {
         nextAliases[commandId] = aliasCandidate;
         commandAliasesImported += 1;
+      } else if (existingAlias !== aliasCandidate && options.conflictMode === 'overwrite') {
+        nextAliases[commandId] = aliasCandidate;
+        commandAliasesImported += 1;
       } else if (existingAlias !== aliasCandidate) {
         aliasConflictCount += 1;
       }
     }
   }
 
-  for (const rawPinnedItem of pinnedMenuItems) {
+  for (const rawPinnedItem of options.includePinnedCommands ? pinnedMenuItems : []) {
     const pinnedItem = typeof rawPinnedItem === 'string'
       ? { key: rawPinnedItem }
       : rawPinnedItem;
@@ -1017,7 +1149,7 @@ async function importCommandCustomizations(
   };
 }
 
-function importQuicklinks(data: RaycastBackup): RaycastImportBucketResult {
+function importQuicklinks(data: RaycastBackup, conflictMode: 'skip' | 'overwrite'): RaycastImportBucketResult {
   const source = Array.isArray(data.builtin_package_quicklinks?.quicklinks)
     ? data.builtin_package_quicklinks?.quicklinks || []
     : [];
@@ -1035,9 +1167,16 @@ function importQuicklinks(data: RaycastBackup): RaycastImportBucketResult {
       continue;
     }
     const dedupeKey = `${name.toLowerCase()}::${url.toLowerCase()}`;
-    if (existingKeys.has(dedupeKey)) {
+    if (existingKeys.has(dedupeKey) && conflictMode !== 'overwrite') {
       result.skipped += 1;
       continue;
+    }
+    if (existingKeys.has(dedupeKey) && conflictMode === 'overwrite') {
+      const duplicate = existing.find((item) => `${item.name.trim().toLowerCase()}::${item.urlTemplate.trim().toLowerCase()}` === dedupeKey);
+      if (duplicate) {
+        result.skipped += 1;
+        continue;
+      }
     }
     createQuickLink({
       name,
@@ -1051,7 +1190,7 @@ function importQuicklinks(data: RaycastBackup): RaycastImportBucketResult {
   return result;
 }
 
-function importSnippets(data: RaycastBackup): RaycastImportBucketResult {
+function importSnippets(data: RaycastBackup, conflictMode: 'skip' | 'overwrite'): RaycastImportBucketResult {
   const source = Array.isArray(data.builtin_package_snippets?.snippets)
     ? data.builtin_package_snippets?.snippets || []
     : [];
@@ -1072,6 +1211,11 @@ function importSnippets(data: RaycastBackup): RaycastImportBucketResult {
         (keyword && item.keyword && item.keyword.trim().toLowerCase() === keyword.toLowerCase())
     );
     if (duplicate) {
+      if (conflictMode === 'overwrite') {
+        updateSnippet(duplicate.id, { name, content, keyword, pinned: Boolean(snippet?.pinned) });
+        result.imported += 1;
+        continue;
+      }
       result.skipped += 1;
       continue;
     }
@@ -1086,7 +1230,7 @@ function importSnippets(data: RaycastBackup): RaycastImportBucketResult {
   return result;
 }
 
-function importNotes(data: RaycastBackup): RaycastImportBucketResult {
+function importNotes(data: RaycastBackup, conflictMode: 'skip' | 'overwrite'): RaycastImportBucketResult {
   const source = Array.isArray(data.builtin_package_raycastNotes?.notes)
     ? data.builtin_package_raycastNotes?.notes || []
     : [];
@@ -1106,6 +1250,11 @@ function importNotes(data: RaycastBackup): RaycastImportBucketResult {
         item.content.trim() === content
     );
     if (duplicate) {
+      if (conflictMode === 'overwrite') {
+        updateNote(duplicate.id, { title, content, pinned: Boolean(note?.pinned) });
+        result.imported += 1;
+        continue;
+      }
       result.skipped += 1;
       continue;
     }
@@ -1120,42 +1269,103 @@ function importNotes(data: RaycastBackup): RaycastImportBucketResult {
   return result;
 }
 
-async function importExtensions(data: RaycastBackup, warnings: string[]): Promise<RaycastImportBucketResult> {
+async function importExtensions(
+  data: RaycastBackup,
+  warnings: string[],
+  onProgress?: (payload: {
+    message: string;
+    currentItem: number;
+    totalItems: number;
+    extensionName?: string;
+    downloadedBytes?: number;
+    totalBytes?: number;
+  }) => void
+): Promise<RaycastImportBucketResult> {
   const source = Array.isArray(data.builtin_package_raycastExtensions?.extensions)
     ? data.builtin_package_raycastExtensions?.extensions || []
     : [];
   const result = createBucketResult(source.length);
   const installed = new Set((await getInstalledExtensionNames()).map((entry) => String(entry || '').trim()));
 
-  for (const extension of source) {
+  for (let index = 0; index < source.length; index += 1) {
+    const extension = source[index];
     const extensionName = String(extension?.name || '').trim();
+    onProgress?.({
+      message: extensionName ? `Preparing extension ${extensionName}` : 'Preparing extension',
+      currentItem: index + 1,
+      totalItems: source.length,
+      extensionName: extensionName || undefined,
+    });
     if (!extensionName) {
       result.failed += 1;
       continue;
     }
     if (installed.has(extensionName)) {
+      onProgress?.({
+        message: `${extensionName} already installed`,
+        currentItem: index + 1,
+        totalItems: source.length,
+        extensionName,
+      });
       result.skipped += 1;
       continue;
     }
     try {
-      const success = await installExtension(extensionName);
+      onProgress?.({
+        message: `Installing ${extensionName}…`,
+        currentItem: index + 1,
+        totalItems: source.length,
+        extensionName,
+      });
+      const success = await installExtension(extensionName, {
+        onProgress: (payload) => {
+          onProgress?.({
+            message: payload.message,
+            currentItem: index + 1,
+            totalItems: source.length,
+            extensionName,
+            downloadedBytes: payload.downloadedBytes,
+            totalBytes: payload.totalBytes,
+          });
+        },
+      });
       if (!success) {
         result.failed += 1;
         warnings.push(`Failed to install extension "${extensionName}".`);
+        onProgress?.({
+          message: `Failed to install ${extensionName}`,
+          currentItem: index + 1,
+          totalItems: source.length,
+          extensionName,
+        });
         continue;
       }
       installed.add(extensionName);
       result.imported += 1;
+      onProgress?.({
+        message: `Installed ${extensionName}`,
+        currentItem: index + 1,
+        totalItems: source.length,
+        extensionName,
+      });
     } catch (error: any) {
       result.failed += 1;
       warnings.push(`Failed to install extension "${extensionName}": ${String(error?.message || error || 'unknown error')}`);
+      onProgress?.({
+        message: `Failed to install ${extensionName}`,
+        currentItem: index + 1,
+        totalItems: source.length,
+        extensionName,
+      });
     }
   }
 
   return result;
 }
 
-function importExtensionPreferences(data: RaycastBackup): string[] {
+type ImportProgressReporter = (payload: Omit<RaycastImportProgress, 'sessionId'>) => void;
+
+function importExtensionPreferences(data: RaycastBackup, conflictMode: 'skip' | 'overwrite'): string[] {
   const importedExtensionNames = new Set<string>();
   for (const extension of data.builtin_package_raycastExtensions?.extensions || []) {
     const extensionName = String(extension?.name || '').trim();
@@ -1168,8 +1378,17 @@ function importExtensionPreferences(data: RaycastBackup): string[] {
       nextValues[prefName] = (pref as any).value;
     }
     if (Object.keys(nextValues).length === 0) continue;
+    const currentValues = getExtensionPreferences(extensionName);
+    if (conflictMode === 'skip') {
+      for (const prefName of Object.keys(nextValues)) {
+        if (currentValues[prefName] !== undefined) {
+          delete nextValues[prefName];
+        }
+      }
+      if (Object.keys(nextValues).length === 0) continue;
+    }
     setExtensionPreferences(extensionName, {
-      ...getExtensionPreferences(extensionName),
+      ...currentValues,
       ...nextValues,
     });
     importedExtensionNames.add(extensionName);
@@ -1177,7 +1396,56 @@ function importExtensionPreferences(data: RaycastBackup): string[] {
   return [...importedExtensionNames];
 }
 
-export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow): Promise<RaycastImportResult> {
+function createEmptyImportResult(partial?: Partial<RaycastImportResult>): RaycastImportResult {
+  return {
+    canceled: false,
+    settingsImported: false,
+    disabledCommandsImported: 0,
+    scriptCommandFoldersImported: 0,
+    commandHotkeysImported: 0,
+    commandAliasesImported: 0,
+    pinnedCommandsImported: 0,
+    aiChats: createBucketResult(),
+    quicklinks: createBucketResult(),
+    snippets: createBucketResult(),
+    notes: createBucketResult(),
+    extensions: createBucketResult(),
+    importedExtensionPreferenceExtensions: [],
+    unsupported: [],
+    warnings: [],
+    ...partial,
+  };
+}
+
+function createEmptyPreview(partial?: Partial<RaycastImportPreview>): RaycastImportPreview {
+  return {
+    canceled: false,
+    selections: createDefaultSelections(),
+    counts: {
+      settings: 0,
+      disabledCommands: 0,
+      scriptCommandFolders: 0,
+      commandHotkeys: 0,
+      commandAliases: 0,
+      pinnedCommands: 0,
+      aiChats: 0,
+      quicklinks: 0,
+      snippets: 0,
+      notes: 0,
+      extensions: 0,
+      extensionPreferences: 0,
+    },
+    unsupported: [],
+    warnings: [],
+    ...partial,
+  };
+}
+
+async function selectAndLoadRaycastBackup(parentWindow?: BrowserWindow): Promise<{
+  canceled: boolean;
+  filePath?: string;
+  backup?: RaycastBackup;
+}> {
   const dialogOptions = {
     title: 'Import Raycast Backup',
     filters: [
@@ -1191,23 +1459,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
     : await dialog.showOpenDialog(dialogOptions);
 
   if (selection.canceled || selection.filePaths.length === 0) {
-    return {
-      canceled: true,
-      settingsImported: false,
-      disabledCommandsImported: 0,
-      scriptCommandFoldersImported: 0,
-      commandHotkeysImported: 0,
-      commandAliasesImported: 0,
-      pinnedCommandsImported: 0,
-      aiChats: createBucketResult(),
-      quicklinks: createBucketResult(),
-      snippets: createBucketResult(),
-      notes: createBucketResult(),
-      extensions: createBucketResult(),
-      importedExtensionPreferenceExtensions: [],
-      unsupported: [],
-      warnings: [],
-    };
+    return { canceled: true };
   }
 
   const filePath = path.resolve(selection.filePaths[0]);
@@ -1226,24 +1478,7 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
       ) {
         const promptedPassword = promptForPassword(attempt === 0 ? PASSWORD_PROMPT_MESSAGE : PASSWORD_RETRY_MESSAGE);
         if (!promptedPassword) {
-          return {
-            canceled: true,
-            filePath,
-            settingsImported: false,
-            disabledCommandsImported: 0,
-            scriptCommandFoldersImported: 0,
-            commandHotkeysImported: 0,
-            commandAliasesImported: 0,
-            pinnedCommandsImported: 0,
-            aiChats: createBucketResult(),
-            quicklinks: createBucketResult(),
-            snippets: createBucketResult(),
-            notes: createBucketResult(),
-            extensions: createBucketResult(),
-            importedExtensionPreferenceExtensions: [],
-            unsupported: [],
-            warnings: [],
-          };
+          return { canceled: true, filePath };
         }
         password = promptedPassword;
         continue;
@@ -1256,65 +1491,188 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
     throw new Error('Failed to read import data; password is not valid.');
   }
 
-  const confirm = parentWindow
-    ? await dialog.showMessageBox(parentWindow, {
-        type: 'question',
-        buttons: ['Cancel', 'Import'],
-        defaultId: 1,
-        cancelId: 0,
-        noLink: true,
-        title: 'Import Raycast Backup',
-        message: 'Review the Raycast backup before importing.',
-        detail: buildImportPreview(backup),
-      })
-    : await dialog.showMessageBox({
-        type: 'question',
-        buttons: ['Cancel', 'Import'],
-        defaultId: 1,
-        cancelId: 0,
-        noLink: true,
-        title: 'Import Raycast Backup',
-        message: 'Review the Raycast backup before importing.',
-        detail: buildImportPreview(backup),
-      });
+  return {
+    canceled: false,
+    filePath,
+    backup,
+  };
+}
 
-  if (confirm.response !== 1) {
-    return {
+export async function previewRaycastConfigImport(parentWindow?: BrowserWindow): Promise<RaycastImportPreview> {
+  const loaded = await selectAndLoadRaycastBackup(parentWindow);
+  if (loaded.canceled || !loaded.backup || !loaded.filePath) {
+    return createEmptyPreview({
       canceled: true,
-      filePath,
-      raycastVersion: backup.raycast_version,
-      settingsImported: false,
-      disabledCommandsImported: 0,
-      scriptCommandFoldersImported: 0,
-      commandHotkeysImported: 0,
-      commandAliasesImported: 0,
-      pinnedCommandsImported: 0,
-      aiChats: createBucketResult(),
-      quicklinks: createBucketResult(),
-      snippets: createBucketResult(),
-      notes: createBucketResult(),
-      extensions: createBucketResult(),
-      importedExtensionPreferenceExtensions: [],
-      unsupported: collectUnsupportedCategories(backup),
-      warnings: [],
-    };
+      filePath: loaded.filePath,
+    });
   }
 
+  const sessionId = createImportSessionId();
+  importSessions.set(sessionId, {
+    filePath: loaded.filePath,
+    backup: loaded.backup,
+  });
+
+  return createEmptyPreview({
+    canceled: false,
+    sessionId,
+    filePath: loaded.filePath,
+    raycastVersion: loaded.backup.raycast_version,
+    counts: countPreviewStats(loaded.backup),
+    unsupported: collectUnsupportedCategories(loaded.backup),
+  });
+}
+
+export async function executeRaycastConfigImport(
+  options: RaycastImportOptions,
+  reportProgress?: ImportProgressReporter
+): Promise<RaycastImportResult> {
+  const session = importSessions.get(String(options.sessionId || '').trim());
+  if (!session) {
+    throw new Error('Raycast import session expired. Choose the backup again.');
+  }
+
+  const backup = session.backup;
+  const filePath = session.filePath;
   const warnings: string[] = [];
-  const { settingsImported, disabledCommandsImported, scriptCommandFoldersImported } = applySettingsFromBackup(backup);
-  const aiChats = importAiChats(backup, warnings);
-  const quicklinks = importQuicklinks(backup);
-  const snippets = importSnippets(backup);
-  const notes = importNotes(backup);
-  const extensions = await importExtensions(backup, warnings);
-  const importedExtensionPreferenceExtensions = importExtensionPreferences(backup);
+  const previewCounts = countPreviewStats(backup);
+  const totalSteps = Math.max(
+    1,
+    Number(Boolean(options.selections.settings || options.selections.disabledCommands || options.selections.scriptCommandFolders)) +
+      Number(Boolean(options.selections.aiChats)) +
+      Number(Boolean(options.selections.quicklinks)) +
+      Number(Boolean(options.selections.snippets)) +
+      Number(Boolean(options.selections.notes)) +
+      Number(Boolean(options.selections.extensions)) +
+      Number(Boolean(options.selections.extensionPreferences)) +
+      Number(Boolean(options.selections.commandHotkeys)) +
+      Number(Boolean(options.selections.commandAliases)) +
+      Number(Boolean(options.selections.pinnedCommands))
+  );
+  let completedSteps = 0;
+  const emitCategoryProgress = (
+    category: keyof RaycastImportSelections,
+    message: string,
+    currentItem?: number,
+    totalItems?: number,
+    extensionName?: string,
+    downloadedBytes?: number,
+    totalBytes?: number,
+    stage: RaycastImportProgress['stage'] = extensionName ? 'extension' : 'category'
+  ) => {
+    reportProgress?.({
+      stage,
+      category,
+      message,
+      completedSteps,
+      totalSteps,
+      ...(currentItem !== undefined ? { currentItem } : {}),
+      ...(totalItems !== undefined ? { totalItems } : {}),
+      ...(extensionName ? { extensionName } : {}),
+      ...(downloadedBytes !== undefined ? { downloadedBytes } : {}),
+      ...(totalBytes !== undefined ? { totalBytes } : {}),
+    });
+  };
+  reportProgress?.({
+    stage: 'starting',
+    message: 'Starting Raycast import…',
+    completedSteps,
+    totalSteps,
+  });
+
+  const { settingsImported, disabledCommandsImported, scriptCommandFoldersImported } = applySettingsFromBackup(backup, {
+    includeSettings: options.selections.settings,
+    includeDisabledCommands: options.selections.disabledCommands,
+    includeScriptCommandFolders: options.selections.scriptCommandFolders,
+  });
+  if (options.selections.settings || options.selections.disabledCommands || options.selections.scriptCommandFolders) {
+    completedSteps += 1;
+    emitCategoryProgress('settings', 'Applied mapped settings and command state');
+  }
+
+  const aiChats = options.selections.aiChats ? importAiChats(backup, warnings) : createBucketResult(previewCounts.aiChats);
+  if (options.selections.aiChats) {
+    completedSteps += 1;
+    emitCategoryProgress('aiChats', `Imported ${aiChats.imported} AI chats`);
+  }
+
+  const quicklinks = options.selections.quicklinks ? importQuicklinks(backup, options.conflictMode) : createBucketResult(previewCounts.quicklinks);
+  if (options.selections.quicklinks) {
+    completedSteps += 1;
+    emitCategoryProgress('quicklinks', `Imported ${quicklinks.imported} quicklinks`);
+  }
+
+  const snippets = options.selections.snippets ? importSnippets(backup, options.conflictMode) : createBucketResult(previewCounts.snippets);
+  if (options.selections.snippets) {
+    completedSteps += 1;
+    emitCategoryProgress('snippets', `Imported ${snippets.imported} snippets`);
+  }
+
+  const notes = options.selections.notes ? importNotes(backup, options.conflictMode) : createBucketResult(previewCounts.notes);
+  if (options.selections.notes) {
+    completedSteps += 1;
+    emitCategoryProgress('notes', `Imported ${notes.imported} notes`);
+  }
+
+  const extensions = options.selections.extensions
+    ? await importExtensions(backup, warnings, (payload) => {
+        emitCategoryProgress(
+          'extensions',
+          payload.message,
+          payload.currentItem,
+          payload.totalItems,
+          payload.extensionName,
+          payload.downloadedBytes,
+          payload.totalBytes,
+          'extension'
+        );
+      })
+    : createBucketResult(previewCounts.extensions);
+  if (options.selections.extensions) {
+    completedSteps += 1;
+    emitCategoryProgress('extensions', `Processed ${extensions.found} extensions`);
+  }
+
+  const importedExtensionPreferenceExtensions = options.selections.extensionPreferences
+    ? importExtensionPreferences(backup, options.conflictMode)
+    : [];
+  if (options.selections.extensionPreferences) {
+    completedSteps += 1;
+    emitCategoryProgress('extensionPreferences', `Imported prefs for ${importedExtensionPreferenceExtensions.length} extensions`);
+  }
+
   const {
     commandHotkeysImported,
     commandAliasesImported,
     pinnedCommandsImported,
-  } = await importCommandCustomizations(backup, warnings);
+  } = await importCommandCustomizations(backup, warnings, {
+    includeHotkeys: options.selections.commandHotkeys,
+    includeAliases: options.selections.commandAliases,
+    includePinnedCommands: options.selections.pinnedCommands,
+    conflictMode: options.conflictMode,
+  });
+  if (options.selections.commandHotkeys) {
+    completedSteps += 1;
+    emitCategoryProgress('commandHotkeys', `Imported ${commandHotkeysImported} command hotkeys`);
+  }
+  if (options.selections.commandAliases) {
+    completedSteps += 1;
+    emitCategoryProgress('commandAliases', `Imported ${commandAliasesImported} aliases`);
+  }
+  if (options.selections.pinnedCommands) {
+    completedSteps += 1;
+    emitCategoryProgress('pinnedCommands', `Imported ${pinnedCommandsImported} favorites`);
+  }
 
-  return {
+  importSessions.delete(options.sessionId);
+  reportProgress?.({
+    stage: 'done',
+    message: 'Raycast import complete',
+    completedSteps: totalSteps,
+    totalSteps,
+  });
+
+  return createEmptyImportResult({
     canceled: false,
     filePath,
     raycastVersion: backup.raycast_version,
@@ -1332,5 +1690,55 @@ export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow):
     importedExtensionPreferenceExtensions,
     unsupported: collectUnsupportedCategories(backup),
     warnings,
-  };
+  });
+}
+
+export async function importRaycastConfigFromFile(parentWindow?: BrowserWindow): Promise<RaycastImportResult> {
+  const preview = await previewRaycastConfigImport(parentWindow);
+  if (preview.canceled || !preview.sessionId) {
+    return createEmptyImportResult({
+      canceled: true,
+      filePath: preview.filePath,
+      raycastVersion: preview.raycastVersion,
+      unsupported: preview.unsupported,
+    });
+  }
+
+  const confirm = parentWindow
+    ? await dialog.showMessageBox(parentWindow, {
+        type: 'question',
+        buttons: ['Cancel', 'Import'],
+        defaultId: 1,
+        cancelId: 0,
+        noLink: true,
+        title: 'Import Raycast Backup',
+        message: 'Review the Raycast backup before importing.',
+        detail: buildImportPreview(importSessions.get(preview.sessionId)?.backup || { raycast_version: preview.raycastVersion }),
+      })
+    : await dialog.showMessageBox({
+        type: 'question',
+        buttons: ['Cancel', 'Import'],
+        defaultId: 1,
+        cancelId: 0,
+        noLink: true,
+        title: 'Import Raycast Backup',
+        message: 'Review the Raycast backup before importing.',
+        detail: buildImportPreview(importSessions.get(preview.sessionId)?.backup || { raycast_version: preview.raycastVersion }),
+      });
+
+  if (confirm.response !== 1) {
+    importSessions.delete(preview.sessionId);
+    return createEmptyImportResult({
+      canceled: true,
+      filePath: preview.filePath,
+      raycastVersion: preview.raycastVersion,
+      unsupported: preview.unsupported,
+    });
+  }
+
+  return executeRaycastConfigImport({
+    sessionId: preview.sessionId,
+    conflictMode: 'skip',
+    selections: preview.selections,
+  });
 }

--- a/src/main/raycast-config-import.ts
+++ b/src/main/raycast-config-import.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as zlib from 'zlib';
 import { getAvailableCommands, invalidateCache, type CommandInfo } from './commands';
-import { setExtensionPreferences } from './extension-preferences-store';
+import { getExtensionPreferences, setExtensionPreferences } from './extension-preferences-store';
 import { getInstalledExtensionNames, installExtension } from './extension-registry';
 import { createNote, getAllNotes, updateNote } from './notes-store';
 import { createQuickLink, getAllQuickLinks } from './quicklink-store';
@@ -793,9 +793,9 @@ function importSnippets(data: RaycastBackup): RaycastImportBucketResult {
 
   for (const snippet of source) {
     const name = String(snippet?.name || '').trim();
-    const content = String(snippet?.text || '').trim();
+    const content = typeof snippet?.text === 'string' ? snippet.text : '';
     const keyword = typeof snippet?.keyword === 'string' ? snippet.keyword.trim() : undefined;
-    if (!name || !content) {
+    if (!name || content.length === 0) {
       result.failed += 1;
       continue;
     }
@@ -900,7 +900,10 @@ function importExtensionPreferences(data: RaycastBackup): void {
       nextValues[prefName] = (pref as any).value;
     }
     if (Object.keys(nextValues).length === 0) continue;
-    setExtensionPreferences(extensionName, nextValues);
+    setExtensionPreferences(extensionName, {
+      ...getExtensionPreferences(extensionName),
+      ...nextValues,
+    });
   }
 }
 

--- a/src/main/script-command-runner.ts
+++ b/src/main/script-command-runner.ts
@@ -4,6 +4,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { loadSettings } from './settings-store';
 
 export type ScriptCommandMode = 'fullOutput' | 'compact' | 'silent' | 'inline';
 export type ScriptArgumentType = 'text' | 'password' | 'dropdown';
@@ -77,6 +78,9 @@ function getScriptCommandDirectories(): string[] {
     .split(path.delimiter)
     .map((v) => expandHome(v))
     .filter(Boolean);
+  const fromSettings = (loadSettings().scriptCommandFolders || [])
+    .map((v) => expandHome(v))
+    .filter(Boolean);
 
   const defaults = [
     getSuperCmdScriptsDir(),
@@ -87,7 +91,7 @@ function getScriptCommandDirectories(): string[] {
   ];
 
   const unique = new Set<string>();
-  for (const dir of [...defaults, ...fromEnv]) {
+  for (const dir of [...defaults, ...fromSettings, ...fromEnv]) {
     const normalized = path.resolve(expandHome(dir));
     unique.add(normalized);
   }

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -86,6 +86,7 @@ export interface AppSettings {
   disabledCommands: string[];
   enabledCommands: string[];
   customExtensionFolders: string[];
+  scriptCommandFolders: string[];
   commandHotkeys: Record<string, string>;
   commandAliases: Record<string, string>;
   pinnedCommands: string[];
@@ -170,6 +171,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   disabledCommands: [],
   enabledCommands: [],
   customExtensionFolders: [],
+  scriptCommandFolders: [],
   commandHotkeys: {
     'system-supercmd-whisper': 'Command+Shift+W',
     'system-supercmd-whisper-speak-toggle': 'Fn',
@@ -438,6 +440,11 @@ export function loadSettings(): AppSettings {
             .map((value: any) => String(value || '').trim())
             .filter(Boolean)
         : DEFAULT_SETTINGS.customExtensionFolders,
+      scriptCommandFolders: Array.isArray(parsed.scriptCommandFolders)
+        ? parsed.scriptCommandFolders
+            .map((value: any) => String(value || '').trim())
+            .filter(Boolean)
+        : DEFAULT_SETTINGS.scriptCommandFolders,
       commandHotkeys: {
         ...DEFAULT_SETTINGS.commandHotkeys,
         ...parsedHotkeys,
@@ -513,6 +520,16 @@ export function saveSettings(patch: Partial<AppSettings>): AppSettings {
   const updated = {
     ...current,
     ...patch,
+    customExtensionFolders: Array.isArray(patch.customExtensionFolders ?? current.customExtensionFolders)
+      ? (patch.customExtensionFolders ?? current.customExtensionFolders)
+          .map((value: any) => String(value || '').trim())
+          .filter(Boolean)
+      : [],
+    scriptCommandFolders: Array.isArray(patch.scriptCommandFolders ?? current.scriptCommandFolders)
+      ? (patch.scriptCommandFolders ?? current.scriptCommandFolders)
+          .map((value: any) => String(value || '').trim())
+          .filter(Boolean)
+      : [],
     appLanguage: normalizeAppLanguage(patch.appLanguage ?? current.appLanguage),
     launcherBackgroundImagePath: normalizeLauncherBackgroundImagePath(
       patch.launcherBackgroundImagePath ?? current.launcherBackgroundImagePath

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -57,6 +57,7 @@ import {
   getShortcutDisplayParts,
 } from './utils/command-helpers';
 import {
+  collectLegacyExtensionPreferencesSnapshot,
   readJsonObject, writeJsonObject,
   getCmdArgsKey,
   getScriptCmdArgsKey,
@@ -2794,6 +2795,17 @@ const App: React.FC = () => {
   // Signal main process that the renderer is mounted and IPC listeners are
   // registered.  Main waits for this before dispatching the initial
   // window-shown / run-system-command messages so they are never lost.
+  useEffect(() => {
+    const legacySnapshot = collectLegacyExtensionPreferencesSnapshot();
+    if (
+      Object.keys(legacySnapshot.extensions).length === 0 &&
+      Object.keys(legacySnapshot.commands).length === 0
+    ) {
+      return;
+    }
+    void window.electron.mergeExtensionPreferencesSnapshot(legacySnapshot);
+  }, []);
+
   useEffect(() => {
     window.electron.rendererReady();
   }, []);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -43,7 +43,7 @@ import { useSpeakManager } from './hooks/useSpeakManager';
 import { useWhisperManager } from './hooks/useWhisperManager';
 import { useInlineArgumentAnchor } from './hooks/useInlineArgumentAnchor';
 import { useBrowserSearch } from './hooks/useBrowserSearch';
-import { LAST_EXT_KEY, MAX_RECENT_COMMANDS } from './utils/constants';
+import { AI_CHAT_STORAGE_KEY, LAST_EXT_KEY, MAX_RECENT_COMMANDS } from './utils/constants';
 import { applyBaseColor } from './utils/base-color';
 import { resetAccessToken } from './raycast-api';
 import {
@@ -2804,6 +2804,22 @@ const App: React.FC = () => {
       return;
     }
     void window.electron.mergeExtensionPreferencesSnapshot(legacySnapshot);
+  }, []);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(AI_CHAT_STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed) || parsed.length === 0) return;
+      void window.electron.mergeAiChatSnapshot({
+        version: 1,
+        conversations: parsed.map((conversation: any) => ({
+          ...conversation,
+          source: conversation?.source === 'raycast' ? 'raycast' : 'local',
+        })),
+      });
+    } catch {}
   }, []);
 
   useEffect(() => {

--- a/src/renderer/src/SettingsApp.tsx
+++ b/src/renderer/src/SettingsApp.tsx
@@ -15,6 +15,7 @@ import { applyBaseColor } from './utils/base-color';
 import { applyUiStyle } from './utils/ui-style';
 import AdvancedTab from './settings/AdvancedTab';
 import { useI18n } from './i18n';
+import { collectLegacyExtensionPreferencesSnapshot } from './utils/extension-preferences';
 
 type Tab = 'general' | 'ai' | 'extensions' | 'advanced';
 type SettingsTarget = { extensionName?: string; commandName?: string };
@@ -99,6 +100,17 @@ const SettingsApp: React.FC = () => {
     { id: 'extensions', label: t('settings.tabs.extensions'), icon: tabDefinitions[2].icon },
     { id: 'advanced', label: t('settings.tabs.advanced'), icon: tabDefinitions[3].icon },
   ];
+
+  useEffect(() => {
+    const legacySnapshot = collectLegacyExtensionPreferencesSnapshot();
+    if (
+      Object.keys(legacySnapshot.extensions).length === 0 &&
+      Object.keys(legacySnapshot.commands).length === 0
+    ) {
+      return;
+    }
+    void window.electron.mergeExtensionPreferencesSnapshot(legacySnapshot);
+  }, []);
 
   useEffect(() => {
     (window as any).electron?.onSettingsTabChanged?.((rawPayload: any) => {

--- a/src/renderer/src/hooks/useAiChat.ts
+++ b/src/renderer/src/hooks/useAiChat.ts
@@ -93,6 +93,10 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
     const nextConversations = normalizeSnapshot(snapshot);
     setConversations(nextConversations);
 
+    if (aiStreamingRef.current) {
+      return;
+    }
+
     const activeId = activeConversationIdRef.current;
     if (!activeId) return;
 

--- a/src/renderer/src/hooks/useAiChat.ts
+++ b/src/renderer/src/hooks/useAiChat.ts
@@ -3,7 +3,7 @@
  *
  * Multi-turn AI chat state with conversation history.
  * - Owns `messages` array for the active conversation
- * - Persists conversation list + bodies in localStorage
+ * - Persists conversation list + bodies in the Electron main process
  * - Streams assistant responses into the last message
  * - startAiChat(query): enter AI mode; if query present, auto-send
  * - sendMessage(text): append user msg, stream assistant reply
@@ -15,24 +15,13 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
+import type {
+  AiChatConversation as AiConversation,
+  AiChatMessage as AiMessage,
+  AiChatSnapshot,
+} from '../../types/electron';
 
-// ─── Types ──────────────────────────────────────────────────────────
-
-export interface AiMessage {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  createdAt: number;
-  cancelled?: boolean;
-}
-
-export interface AiConversation {
-  id: string;
-  title: string;
-  messages: AiMessage[];
-  createdAt: number;
-  updatedAt: number;
-}
+export type { AiConversation, AiMessage };
 
 export interface UseAiChatOptions {
   onExitAiMode?: () => void;
@@ -40,7 +29,6 @@ export interface UseAiChatOptions {
 }
 
 export interface UseAiChatReturn {
-  // Active conversation
   messages: AiMessage[];
   aiStreaming: boolean;
   aiAvailable: boolean;
@@ -49,12 +37,8 @@ export interface UseAiChatReturn {
   aiInputRef: React.RefObject<HTMLInputElement>;
   aiResponseRef: React.RefObject<HTMLDivElement>;
   setAiAvailable: (value: boolean) => void;
-
-  // History
   conversations: AiConversation[];
   activeConversationId: string | null;
-
-  // Actions
   startAiChat: (searchQuery: string) => void;
   sendMessage: (text: string) => void;
   stopStreaming: () => void;
@@ -64,49 +48,25 @@ export interface UseAiChatReturn {
   exitAiMode: () => void;
 }
 
-// ─── Persistence ────────────────────────────────────────────────────
-
-const STORAGE_KEY = 'sc.aiChat.conversations';
 const MAX_CONVERSATIONS = 50;
-
-function loadConversations(): AiConversation[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(
-      (c) =>
-        c &&
-        typeof c.id === 'string' &&
-        Array.isArray(c.messages)
-    );
-  } catch {
-    return [];
-  }
-}
-
-function saveConversations(convs: AiConversation[]) {
-  try {
-    const trimmed = convs.slice(0, MAX_CONVERSATIONS);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
-  } catch {}
-}
 
 function makeTitle(text: string): string {
   const t = (text || '').trim().replace(/\s+/g, ' ');
   if (!t) return 'New Chat';
-  return t.length > 48 ? t.slice(0, 48) + '…' : t;
+  return t.length > 48 ? `${t.slice(0, 48)}…` : t;
 }
 
 function uid(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-// ─── Hook ───────────────────────────────────────────────────────────
+function normalizeSnapshot(snapshot: AiChatSnapshot | null | undefined): AiConversation[] {
+  if (!snapshot || !Array.isArray(snapshot.conversations)) return [];
+  return snapshot.conversations.slice(0, MAX_CONVERSATIONS);
+}
 
 export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiChatReturn {
-  const [conversations, setConversations] = useState<AiConversation[]>(() => loadConversations());
+  const [conversations, setConversations] = useState<AiConversation[]>([]);
   const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
   const [messages, setMessages] = useState<AiMessage[]>([]);
   const [aiStreaming, setAiStreaming] = useState(false);
@@ -117,49 +77,96 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
   const aiStreamingRef = useRef(false);
   const streamingMessageIdRef = useRef<string | null>(null);
   const activeConversationIdRef = useRef<string | null>(null);
+  const messagesRef = useRef<AiMessage[]>([]);
   const aiInputRef = useRef<HTMLInputElement>(null);
   const aiResponseRef = useRef<HTMLDivElement>(null);
 
-  // Keep ref in sync
   useEffect(() => {
     activeConversationIdRef.current = activeConversationId;
   }, [activeConversationId]);
 
-  // Persist conversations on change
   useEffect(() => {
-    saveConversations(conversations);
-  }, [conversations]);
+    messagesRef.current = messages;
+  }, [messages]);
 
-  // ── Streaming listeners ────────────────────────────────────────
+  const applySnapshot = useCallback((snapshot: AiChatSnapshot | null | undefined) => {
+    const nextConversations = normalizeSnapshot(snapshot);
+    setConversations(nextConversations);
+
+    const activeId = activeConversationIdRef.current;
+    if (!activeId) return;
+
+    const nextActive = nextConversations.find((conversation) => conversation.id === activeId);
+    if (nextActive) {
+      setMessages(nextActive.messages);
+      return;
+    }
+
+    if (messagesRef.current.length === 0) {
+      activeConversationIdRef.current = null;
+      setActiveConversationId(null);
+    }
+  }, []);
+
+  const refreshSnapshot = useCallback(() => {
+    void window.electron.getAiChatSnapshot()
+      .then((snapshot) => {
+        applySnapshot(snapshot);
+      })
+      .catch(() => {});
+  }, [applySnapshot]);
+
+  useEffect(() => {
+    refreshSnapshot();
+  }, [refreshSnapshot]);
+
+  useEffect(() => {
+    return window.electron.onAiChatsUpdated(() => {
+      refreshSnapshot();
+    });
+  }, [refreshSnapshot]);
+
+  const persistConversation = useCallback((conversation: AiConversation) => {
+    setConversations((prev) => [
+      conversation,
+      ...prev.filter((entry) => entry.id !== conversation.id),
+    ].slice(0, MAX_CONVERSATIONS));
+    void window.electron.upsertAiChatConversation(conversation);
+  }, []);
 
   useEffect(() => {
     const appendToStreamingMessage = (chunk: string) => {
       const msgId = streamingMessageIdRef.current;
       if (!msgId) return;
       setMessages((prev) =>
-        prev.map((m) => (m.id === msgId ? { ...m, content: m.content + chunk } : m))
+        prev.map((message) => (
+          message.id === msgId
+            ? { ...message, content: message.content + chunk }
+            : message
+        ))
       );
     };
 
     const finalizeConversation = () => {
-      const convId = activeConversationIdRef.current;
-      if (!convId) return;
+      const conversationId = activeConversationIdRef.current;
+      if (!conversationId) return;
+
       setMessages((current) => {
-        setConversations((convs) => {
-          const idx = convs.findIndex((c) => c.id === convId);
-          const updated: AiConversation = {
-            id: convId,
-            title:
-              convs[idx]?.title && convs[idx].title !== 'New Chat'
-                ? convs[idx].title
-                : makeTitle(current.find((m) => m.role === 'user')?.content || 'New Chat'),
-            messages: current,
-            createdAt: convs[idx]?.createdAt ?? Date.now(),
-            updatedAt: Date.now(),
-          };
-          const rest = convs.filter((c) => c.id !== convId);
-          return [updated, ...rest];
-        });
+        const existing = conversations.find((conversation) => conversation.id === conversationId);
+        const updatedConversation: AiConversation = {
+          id: conversationId,
+          title:
+            existing?.title && existing.title !== 'New Chat'
+              ? existing.title
+              : makeTitle(current.find((message) => message.role === 'user')?.content || 'New Chat'),
+          messages: current,
+          createdAt: existing?.createdAt ?? Date.now(),
+          updatedAt: Date.now(),
+          source: existing?.source || 'local',
+          ...(existing?.sourceConversationId ? { sourceConversationId: existing.sourceConversationId } : {}),
+          ...(existing?.metadata ? { metadata: existing.metadata } : {}),
+        };
+        persistConversation(updatedConversation);
         return current;
       });
     };
@@ -169,6 +176,7 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
         appendToStreamingMessage(data.chunk);
       }
     };
+
     const handleDone = (data: { requestId: string }) => {
       if (data.requestId === aiRequestIdRef.current) {
         aiStreamingRef.current = false;
@@ -177,16 +185,20 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
         finalizeConversation();
       }
     };
+
     const handleError = (data: { requestId: string; error: string }) => {
       if (data.requestId === aiRequestIdRef.current) {
         aiStreamingRef.current = false;
         const msgId = streamingMessageIdRef.current;
         if (msgId) {
           setMessages((prev) =>
-            prev.map((m) =>
-              m.id === msgId
-                ? { ...m, content: m.content + (m.content ? '\n\n' : '') + `Error: ${data.error}` }
-                : m
+            prev.map((message) =>
+              message.id === msgId
+                ? {
+                    ...message,
+                    content: message.content + (message.content ? '\n\n' : '') + `Error: ${data.error}`,
+                  }
+                : message
             )
           );
         }
@@ -205,9 +217,7 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
       removeDone?.();
       removeError?.();
     };
-  }, []);
-
-  // ── Auto-scroll on new content ─────────────────────────────────
+  }, [conversations, persistConversation]);
 
   useEffect(() => {
     if (aiResponseRef.current) {
@@ -215,16 +225,11 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
     }
   }, [messages]);
 
-  // ── Availability check ────────────────────────────────────────
-
   useEffect(() => {
     window.electron.aiIsAvailable().then(setAiAvailable);
   }, []);
 
-  // ── Internal: send a chat turn ────────────────────────────────
-
   const sendChatTurn = useCallback((allMessages: AiMessage[]) => {
-    // Cancel any in-flight
     if (aiRequestIdRef.current && aiStreamingRef.current) {
       window.electron.aiCancel(aiRequestIdRef.current);
     }
@@ -232,68 +237,63 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
     aiRequestIdRef.current = requestId;
     aiStreamingRef.current = true;
     setAiStreaming(true);
-    const payload = allMessages.map((m) => ({ role: m.role, content: m.content }));
+    const payload = allMessages.map((message) => ({ role: message.role, content: message.content }));
     window.electron.aiChat(requestId, payload);
   }, []);
-
-  // ── Actions ───────────────────────────────────────────────────
 
   const sendMessage = useCallback(
     (text: string) => {
       const trimmed = text.trim();
       if (!trimmed || !aiAvailable) return;
 
-      // Ensure we have an active conversation
-      let convId = activeConversationIdRef.current;
-      if (!convId) {
-        convId = uid('conv');
-        activeConversationIdRef.current = convId;
-        setActiveConversationId(convId);
-        const newConv: AiConversation = {
-          id: convId,
+      let conversationId = activeConversationIdRef.current;
+      if (!conversationId) {
+        conversationId = uid('conv');
+        activeConversationIdRef.current = conversationId;
+        setActiveConversationId(conversationId);
+        persistConversation({
+          id: conversationId,
           title: makeTitle(trimmed),
           messages: [],
           createdAt: Date.now(),
           updatedAt: Date.now(),
-        };
-        setConversations((prev) => [newConv, ...prev]);
+          source: 'local',
+        });
       }
 
-      const userMsg: AiMessage = {
+      const userMessage: AiMessage = {
         id: uid('msg'),
         role: 'user',
         content: trimmed,
         createdAt: Date.now(),
       };
-      const assistantMsg: AiMessage = {
+      const assistantMessage: AiMessage = {
         id: uid('msg'),
         role: 'assistant',
         content: '',
         createdAt: Date.now(),
       };
-      streamingMessageIdRef.current = assistantMsg.id;
+      streamingMessageIdRef.current = assistantMessage.id;
 
       setMessages((prev) => {
-        const next = [...prev, userMsg, assistantMsg];
-        sendChatTurn([...prev, userMsg]); // assistant is empty, send context up to user msg
+        const next = [...prev, userMessage, assistantMessage];
+        sendChatTurn([...prev, userMessage]);
         return next;
       });
       setAiQuery('');
     },
-    [aiAvailable, sendChatTurn]
+    [aiAvailable, persistConversation, sendChatTurn]
   );
 
   const startAiChat = useCallback(
     (searchQuery: string) => {
       if (!aiAvailable) return;
-      // Start a fresh conversation
       activeConversationIdRef.current = null;
       setActiveConversationId(null);
       setMessages([]);
       setAiMode(true);
       const trimmed = searchQuery.trim();
       if (trimmed) {
-        // Send immediately
         setTimeout(() => sendMessage(trimmed), 0);
       } else {
         setAiQuery('');
@@ -308,10 +308,10 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
     }
     aiStreamingRef.current = false;
     setAiStreaming(false);
-    const msgId = streamingMessageIdRef.current;
-    if (msgId) {
+    const messageId = streamingMessageIdRef.current;
+    if (messageId) {
       setMessages((prev) =>
-        prev.map((m) => (m.id === msgId ? { ...m, cancelled: true } : m))
+        prev.map((message) => (message.id === messageId ? { ...message, cancelled: true } : message))
       );
     }
     streamingMessageIdRef.current = null;
@@ -342,37 +342,35 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
     streamingMessageIdRef.current = null;
     setAiStreaming(false);
 
-    setConversations((convs) => {
-      const conv = convs.find((c) => c.id === id);
-      if (conv) {
+    setConversations((current) => {
+      const conversation = current.find((entry) => entry.id === id);
+      if (conversation) {
         activeConversationIdRef.current = id;
         setActiveConversationId(id);
-        setMessages(conv.messages);
+        setMessages(conversation.messages);
       }
-      return convs;
+      return current;
     });
     setAiQuery('');
     setTimeout(() => aiInputRef.current?.focus(), 0);
   }, []);
 
-  const deleteConversation = useCallback(
-    (id: string) => {
-      setConversations((prev) => prev.filter((c) => c.id !== id));
-      if (activeConversationIdRef.current === id) {
-        activeConversationIdRef.current = null;
-        setActiveConversationId(null);
-        setMessages([]);
-        if (aiRequestIdRef.current && aiStreamingRef.current) {
-          window.electron.aiCancel(aiRequestIdRef.current);
-        }
-        aiRequestIdRef.current = null;
-        aiStreamingRef.current = false;
-        streamingMessageIdRef.current = null;
-        setAiStreaming(false);
+  const deleteConversation = useCallback((id: string) => {
+    setConversations((prev) => prev.filter((conversation) => conversation.id !== id));
+    void window.electron.deleteAiChatConversation(id);
+    if (activeConversationIdRef.current === id) {
+      activeConversationIdRef.current = null;
+      setActiveConversationId(null);
+      setMessages([]);
+      if (aiRequestIdRef.current && aiStreamingRef.current) {
+        window.electron.aiCancel(aiRequestIdRef.current);
       }
-    },
-    []
-  );
+      aiRequestIdRef.current = null;
+      aiStreamingRef.current = false;
+      streamingMessageIdRef.current = null;
+      setAiStreaming(false);
+    }
+  }, []);
 
   const exitAiMode = useCallback(() => {
     if (aiRequestIdRef.current && aiStreamingRef.current) {
@@ -384,17 +382,14 @@ export function useAiChat({ onExitAiMode, setAiMode }: UseAiChatOptions): UseAiC
     setAiMode(false);
     setAiStreaming(false);
     setAiQuery('');
-    // Keep messages + activeConversationId so returning shows the same chat.
     onExitAiMode?.();
   }, [setAiMode, onExitAiMode]);
 
-  // ── Escape to exit AI mode (only while messages/query/streaming) ──
-
   useEffect(() => {
     if (messages.length === 0 && !aiQuery && !aiStreaming) return;
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
         exitAiMode();
       }
     };

--- a/src/renderer/src/hooks/useMenuBarExtensions.ts
+++ b/src/renderer/src/hooks/useMenuBarExtensions.ts
@@ -174,6 +174,14 @@ export function useMenuBarExtensions(): UseMenuBarExtensionsReturn {
     };
   }, [remountMenuBarExtensionsForExtension]);
 
+  useEffect(() => {
+    return window.electron.onExtensionPreferencesUpdated((payload) => {
+      const extensionName = String(payload?.extensionName || '').trim();
+      if (!extensionName) return;
+      remountMenuBarExtensionsForExtension(extensionName);
+    });
+  }, [remountMenuBarExtensionsForExtension]);
+
   return {
     menuBarExtensions,
     backgroundNoViewRuns,

--- a/src/renderer/src/settings/ExtensionsTab.tsx
+++ b/src/renderer/src/settings/ExtensionsTab.tsx
@@ -31,6 +31,7 @@ import type {
   AppSettings,
   CommandInfo,
   ExtensionCommandSettingsSchema,
+  ExtensionPreferencesSnapshot,
   ExtensionPreferenceSchema,
   InstalledExtensionSettingsSchema,
 } from '../../types/electron';
@@ -63,6 +64,13 @@ function readJsonObject(key: string): Record<string, any> {
 
 function writeJsonObject(key: string, value: Record<string, any>) {
   localStorage.setItem(key, JSON.stringify(value));
+}
+
+function mergePreferenceSources(
+  primary: Record<string, any>,
+  fallback: Record<string, any>
+): Record<string, any> {
+  return { ...fallback, ...primary };
 }
 
 function getDefaultValue(pref: ExtensionPreferenceSchema): any {
@@ -111,6 +119,11 @@ const ExtensionsTab: React.FC<{
   const [settings, setSettings] = useState<AppSettings | null>(null);
   const [schemas, setSchemas] = useState<InstalledExtensionSettingsSchema[]>([]);
   const [installedExtensionNames, setInstalledExtensionNames] = useState<Set<string>>(new Set());
+  const [extensionPreferencesSnapshot, setExtensionPreferencesSnapshot] = useState<ExtensionPreferencesSnapshot>({
+    version: 1,
+    extensions: {},
+    commands: {},
+  });
   const [search, setSearch] = useState('');
   const [activeScope, setActiveScope] = useState<'all' | 'commands'>('all');
   const [statusFilter, setStatusFilter] = useState<'all' | 'enabled' | 'disabled'>('all');
@@ -180,15 +193,17 @@ const ExtensionsTab: React.FC<{
   const loadData = useCallback(async () => {
     setIsLoading(true);
     try {
-      const [cmds, sett, extSchemas, installedNames] = await Promise.all([
+      const [cmds, sett, extSchemas, installedNames, preferenceSnapshot] = await Promise.all([
         window.electron.getAllCommands(),
         window.electron.getSettings(),
         window.electron.getInstalledExtensionsSettingsSchema(),
         window.electron.getInstalledExtensionNames(),
+        window.electron.getExtensionPreferencesSnapshot(),
       ]);
       setCommands(cmds);
       setSettings(sett);
       setSchemas(extSchemas);
+      setExtensionPreferencesSnapshot(preferenceSnapshot);
       setInstalledExtensionNames(
         new Set(
           (installedNames || [])
@@ -219,6 +234,13 @@ const ExtensionsTab: React.FC<{
       dispose?.();
     };
   }, [loadData]);
+
+  useEffect(() => {
+    return window.electron.onExtensionPreferencesUpdated(async () => {
+      const snapshot = await window.electron.getExtensionPreferencesSnapshot();
+      setExtensionPreferencesSnapshot(snapshot);
+    });
+  }, []);
 
   const commandBySchemaKey = useMemo(() => {
     const map = new Map<string, CommandInfo>();
@@ -658,8 +680,13 @@ const ExtensionsTab: React.FC<{
   );
 
   const getPreferenceValues = (extName: string, cmdName?: string): Record<string, any> => {
-    if (!cmdName) return readJsonObject(getExtPrefsKey(extName));
-    return readJsonObject(getCmdPrefsKey(extName, cmdName));
+    const primary = !cmdName
+      ? (extensionPreferencesSnapshot.extensions[extName] || {})
+      : (extensionPreferencesSnapshot.commands[`${extName}/${cmdName}`] || {});
+    const fallback = !cmdName
+      ? readJsonObject(getExtPrefsKey(extName))
+      : readJsonObject(getCmdPrefsKey(extName, cmdName));
+    return mergePreferenceSources(primary, fallback);
   };
 
   const setPreferenceValue = (extName: string, pref: ExtensionPreferenceSchema, value: any, cmdName?: string) => {
@@ -667,6 +694,32 @@ const ExtensionsTab: React.FC<{
     const current = readJsonObject(storageKey);
     current[pref.name] = value;
     writeJsonObject(storageKey, current);
+    setExtensionPreferencesSnapshot((prev) => {
+      if (cmdName) {
+        const commandKey = `${extName}/${cmdName}`;
+        return {
+          ...prev,
+          commands: {
+            ...prev.commands,
+            [commandKey]: {
+              ...(prev.commands[commandKey] || {}),
+              [pref.name]: value,
+            },
+          },
+        };
+      }
+      return {
+        ...prev,
+        extensions: {
+          ...prev.extensions,
+          [extName]: {
+            ...(prev.extensions[extName] || {}),
+            [pref.name]: value,
+          },
+        },
+      };
+    });
+    void window.electron.setExtensionPreference(extName, pref.name, value, cmdName);
     window.dispatchEvent(new CustomEvent('sc-extension-storage-changed', { detail: { extensionName: extName } }));
     // force rerender to reflect required/filled indicators
     setSelected((prev) => (prev ? { ...prev } : prev));

--- a/src/renderer/src/settings/GeneralTab.tsx
+++ b/src/renderer/src/settings/GeneralTab.tsx
@@ -7,7 +7,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Keyboard, Info, RefreshCw, Download, RotateCcw, Type, Sun, Moon, SunMoon, Sparkles, Image, Trash2, SlidersHorizontal, ChevronDown, ChevronUp, Power, PanelTop } from 'lucide-react';
 import HotkeyRecorder from './HotkeyRecorder';
-import type { AppSettings, AppUpdaterStatus } from '../../types/electron';
+import type { AppSettings, AppUpdaterStatus, RaycastImportResult } from '../../types/electron';
 import { applyAppFontSize, getDefaultAppFontSize } from '../utils/font-size';
 import {
   getThemePreference,
@@ -93,6 +93,8 @@ const GeneralTab: React.FC = () => {
   const [launcherViewMode, setLauncherViewMode] = useState<'expanded' | 'compact'>('expanded');
   const [launcherBackgroundBusy, setLauncherBackgroundBusy] = useState(false);
   const [launcherBackgroundControlsExpanded, setLauncherBackgroundControlsExpanded] = useState(false);
+  const [raycastImportBusy, setRaycastImportBusy] = useState(false);
+  const [raycastImportResult, setRaycastImportResult] = useState<RaycastImportResult | null>(null);
 
   useEffect(() => {
     window.electron.getSettings().then((nextSettings) => {
@@ -362,6 +364,33 @@ const GeneralTab: React.FC = () => {
       setSettings(nextSettings);
     } catch {
       setSettings((prev) => (prev ? { ...prev, [field]: previousValue } : prev));
+    }
+  };
+
+  const handleRaycastImport = async () => {
+    if (raycastImportBusy) return;
+    setRaycastImportBusy(true);
+    try {
+      const result = await window.electron.importRaycastConfig();
+      setRaycastImportResult(result);
+    } catch (error: any) {
+      setRaycastImportResult({
+        canceled: false,
+        settingsImported: false,
+        disabledCommandsImported: 0,
+        scriptCommandFoldersImported: 0,
+        commandHotkeysImported: 0,
+        commandAliasesImported: 0,
+        pinnedCommandsImported: 0,
+        quicklinks: { found: 0, imported: 0, skipped: 0, failed: 1 },
+        snippets: { found: 0, imported: 0, skipped: 0, failed: 0 },
+        notes: { found: 0, imported: 0, skipped: 0, failed: 0 },
+        extensions: { found: 0, imported: 0, skipped: 0, failed: 0 },
+        unsupported: [],
+        warnings: [String(error?.message || error || 'Raycast import failed.')],
+      });
+    } finally {
+      setRaycastImportBusy(false);
     }
   };
 
@@ -675,6 +704,86 @@ const GeneralTab: React.FC = () => {
               />
               {t('settings.general.background.useEverywhere')}
             </label>
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          icon={<Download className="w-4 h-4" />}
+          title="Import Raycast Backup"
+          description="Import settings and supported data from an encrypted Raycast .rayconfig backup."
+        >
+          <div className="w-full space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void handleRaycastImport()}
+                disabled={raycastImportBusy}
+                className="inline-flex items-center gap-1.5 px-3 py-2 rounded-md border border-[var(--ui-divider)] bg-[var(--ui-segment-bg)] text-[0.75rem] font-semibold text-[var(--text-primary)] hover:border-[var(--ui-segment-border)] hover:bg-[var(--ui-segment-hover-bg)] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+              >
+                <Download className={`w-3.5 h-3.5 ${raycastImportBusy ? 'animate-pulse' : ''}`} />
+                {raycastImportBusy ? 'Importing…' : 'Choose Backup'}
+              </button>
+              {raycastImportResult?.filePath ? (
+                <span className="text-[0.75rem] text-[var(--text-subtle)] truncate">
+                  {getFileName(raycastImportResult.filePath)}
+                </span>
+              ) : null}
+            </div>
+
+            {raycastImportResult?.canceled ? (
+              <p className="text-[0.75rem] text-[var(--text-subtle)]">
+                Import canceled.
+              </p>
+            ) : null}
+
+            {!raycastImportResult?.canceled && raycastImportResult ? (
+              <div className="space-y-1">
+                <p className="text-[0.75rem] text-[var(--text-secondary)]">
+                  {[
+                    raycastImportResult.settingsImported ? 'settings imported' : null,
+                    `${raycastImportResult.quicklinks.imported}/${raycastImportResult.quicklinks.found} quicklinks`,
+                    `${raycastImportResult.snippets.imported}/${raycastImportResult.snippets.found} snippets`,
+                    `${raycastImportResult.notes.imported}/${raycastImportResult.notes.found} notes`,
+                    `${raycastImportResult.extensions.imported}/${raycastImportResult.extensions.found} extensions`,
+                  ].filter(Boolean).join(' · ')}
+                </p>
+                {raycastImportResult.disabledCommandsImported > 0 ? (
+                  <p className="text-[0.75rem] text-[var(--text-subtle)]">
+                    Imported {raycastImportResult.disabledCommandsImported} disabled command mapping{raycastImportResult.disabledCommandsImported === 1 ? '' : 's'}.
+                  </p>
+                ) : null}
+                {raycastImportResult.commandHotkeysImported > 0 ? (
+                  <p className="text-[0.75rem] text-[var(--text-subtle)]">
+                    Imported {raycastImportResult.commandHotkeysImported} command hotkey{raycastImportResult.commandHotkeysImported === 1 ? '' : 's'}.
+                  </p>
+                ) : null}
+                {raycastImportResult.commandAliasesImported > 0 ? (
+                  <p className="text-[0.75rem] text-[var(--text-subtle)]">
+                    Imported {raycastImportResult.commandAliasesImported} alias{raycastImportResult.commandAliasesImported === 1 ? '' : 'es'}.
+                  </p>
+                ) : null}
+                {raycastImportResult.pinnedCommandsImported > 0 ? (
+                  <p className="text-[0.75rem] text-[var(--text-subtle)]">
+                    Imported {raycastImportResult.pinnedCommandsImported} favorite{raycastImportResult.pinnedCommandsImported === 1 ? '' : 's'} into pinned commands.
+                  </p>
+                ) : null}
+                {raycastImportResult.scriptCommandFoldersImported > 0 ? (
+                  <p className="text-[0.75rem] text-[var(--text-subtle)]">
+                    Imported {raycastImportResult.scriptCommandFoldersImported} script command folder path{raycastImportResult.scriptCommandFoldersImported === 1 ? '' : 's'}.
+                  </p>
+                ) : null}
+                {raycastImportResult.unsupported.length > 0 ? (
+                  <p className="text-[0.75rem] text-[var(--text-subtle)]">
+                    Skipped: {raycastImportResult.unsupported.join(', ')}.
+                  </p>
+                ) : null}
+                {raycastImportResult.warnings.length > 0 ? (
+                  <p className="text-[0.75rem] text-amber-300">
+                    {raycastImportResult.warnings[0]}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         </SettingsRow>
 

--- a/src/renderer/src/settings/GeneralTab.tsx
+++ b/src/renderer/src/settings/GeneralTab.tsx
@@ -382,6 +382,7 @@ const GeneralTab: React.FC = () => {
         commandHotkeysImported: 0,
         commandAliasesImported: 0,
         pinnedCommandsImported: 0,
+        aiChats: { found: 0, imported: 0, skipped: 0, failed: 0 },
         quicklinks: { found: 0, imported: 0, skipped: 0, failed: 1 },
         snippets: { found: 0, imported: 0, skipped: 0, failed: 0 },
         notes: { found: 0, imported: 0, skipped: 0, failed: 0 },
@@ -742,6 +743,7 @@ const GeneralTab: React.FC = () => {
                 <p className="text-[0.75rem] text-[var(--text-secondary)]">
                   {[
                     raycastImportResult.settingsImported ? 'settings imported' : null,
+                    `${raycastImportResult.aiChats.imported}/${raycastImportResult.aiChats.found} AI chats`,
                     `${raycastImportResult.quicklinks.imported}/${raycastImportResult.quicklinks.found} quicklinks`,
                     `${raycastImportResult.snippets.imported}/${raycastImportResult.snippets.found} snippets`,
                     `${raycastImportResult.notes.imported}/${raycastImportResult.notes.found} notes`,

--- a/src/renderer/src/settings/GeneralTab.tsx
+++ b/src/renderer/src/settings/GeneralTab.tsx
@@ -5,9 +5,9 @@
  */
 
 import React, { useState, useEffect, useMemo } from 'react';
-import { Keyboard, Info, RefreshCw, Download, RotateCcw, Type, Sun, Moon, SunMoon, Sparkles, Image, Trash2, SlidersHorizontal, ChevronDown, ChevronUp, Power, PanelTop } from 'lucide-react';
+import { Keyboard, Info, RefreshCw, Download, RotateCcw, Type, Sun, Moon, SunMoon, Sparkles, Image, Trash2, SlidersHorizontal, ChevronDown, ChevronUp, Power, PanelTop, X, ShieldAlert, Wand2, FileArchive, FolderTree, Command, Link2, StickyNote, Puzzle, BrainCircuit } from 'lucide-react';
 import HotkeyRecorder from './HotkeyRecorder';
-import type { AppSettings, AppUpdaterStatus, RaycastImportResult } from '../../types/electron';
+import type { AppSettings, AppUpdaterStatus, RaycastImportPreview, RaycastImportProgress, RaycastImportResult, RaycastImportSelections } from '../../types/electron';
 import { applyAppFontSize, getDefaultAppFontSize } from '../utils/font-size';
 import {
   getThemePreference,
@@ -82,6 +82,27 @@ const SettingsRow: React.FC<SettingsRowProps> = ({
   </div>
 );
 
+const IMPORT_CATEGORY_META: Array<{
+  key: keyof RaycastImportSelections;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  countKey: keyof RaycastImportPreview['counts'];
+}> = [
+  { key: 'settings', title: 'App settings', description: 'Launcher mode, global hotkey, navigation style, and core mapped preferences.', icon: <Wand2 className="w-4 h-4" />, countKey: 'settings' },
+  { key: 'disabledCommands', title: 'Disabled commands', description: 'Extension and script command disabled state.', icon: <ShieldAlert className="w-4 h-4" />, countKey: 'disabledCommands' },
+  { key: 'scriptCommandFolders', title: 'Script folders', description: 'Imported Raycast script-command directories.', icon: <FolderTree className="w-4 h-4" />, countKey: 'scriptCommandFolders' },
+  { key: 'commandHotkeys', title: 'Command hotkeys', description: 'Per-command hotkeys mapped onto SuperCmd commands.', icon: <Command className="w-4 h-4" />, countKey: 'commandHotkeys' },
+  { key: 'commandAliases', title: 'Aliases', description: 'Best-effort alias migration from exported search terms.', icon: <Command className="w-4 h-4" />, countKey: 'commandAliases' },
+  { key: 'pinnedCommands', title: 'Favorites', description: 'Pinned commands and favorites when Raycast exports them.', icon: <Sparkles className="w-4 h-4" />, countKey: 'pinnedCommands' },
+  { key: 'aiChats', title: 'AI chats', description: 'Conversation history mapped into the existing SuperCmd chat UI.', icon: <BrainCircuit className="w-4 h-4" />, countKey: 'aiChats' },
+  { key: 'quicklinks', title: 'Quicklinks', description: 'Saved links and templates.', icon: <Link2 className="w-4 h-4" />, countKey: 'quicklinks' },
+  { key: 'snippets', title: 'Snippets', description: 'Text expansions and snippet content.', icon: <Type className="w-4 h-4" />, countKey: 'snippets' },
+  { key: 'notes', title: 'Notes', description: 'Raycast notes imported into SuperCmd notes.', icon: <StickyNote className="w-4 h-4" />, countKey: 'notes' },
+  { key: 'extensions', title: 'Extensions', description: 'Install missing Raycast Store extensions.', icon: <Puzzle className="w-4 h-4" />, countKey: 'extensions' },
+  { key: 'extensionPreferences', title: 'Extension prefs', description: 'Mapped extension preference values for imported and installed extensions.', icon: <Puzzle className="w-4 h-4" />, countKey: 'extensionPreferences' },
+];
+
 const GeneralTab: React.FC = () => {
   const { t } = useI18n();
   const [settings, setSettings] = useState<AppSettings | null>(null);
@@ -94,6 +115,11 @@ const GeneralTab: React.FC = () => {
   const [launcherBackgroundBusy, setLauncherBackgroundBusy] = useState(false);
   const [launcherBackgroundControlsExpanded, setLauncherBackgroundControlsExpanded] = useState(false);
   const [raycastImportBusy, setRaycastImportBusy] = useState(false);
+  const [raycastImportPreview, setRaycastImportPreview] = useState<RaycastImportPreview | null>(null);
+  const [raycastImportSelections, setRaycastImportSelections] = useState<RaycastImportSelections | null>(null);
+  const [raycastImportConflictMode, setRaycastImportConflictMode] = useState<'skip' | 'overwrite'>('skip');
+  const [raycastImportProgress, setRaycastImportProgress] = useState<RaycastImportProgress | null>(null);
+  const [raycastImportLog, setRaycastImportLog] = useState<Array<RaycastImportProgress>>([]);
   const [raycastImportResult, setRaycastImportResult] = useState<RaycastImportResult | null>(null);
 
   useEffect(() => {
@@ -120,6 +146,13 @@ const GeneralTab: React.FC = () => {
       setLauncherViewMode(nextSettings.launcherViewMode || 'expanded');
     });
     return cleanup;
+  }, []);
+
+  useEffect(() => {
+    return window.electron.onRaycastImportProgress((payload) => {
+      setRaycastImportProgress(payload);
+      setRaycastImportLog((prev) => [...prev.slice(-11), payload]);
+    });
   }, []);
 
   useEffect(() => {
@@ -371,8 +404,50 @@ const GeneralTab: React.FC = () => {
     if (raycastImportBusy) return;
     setRaycastImportBusy(true);
     try {
-      const result = await window.electron.importRaycastConfig();
+      const preview = await window.electron.previewRaycastConfigImport();
+      setRaycastImportProgress(null);
+      setRaycastImportLog([]);
+      setRaycastImportPreview(preview);
+      setRaycastImportSelections(preview.canceled ? null : preview.selections);
+    } catch (error: any) {
+      setRaycastImportPreview(null);
+      setRaycastImportSelections(null);
+      setRaycastImportResult({
+        canceled: false,
+        settingsImported: false,
+        disabledCommandsImported: 0,
+        scriptCommandFoldersImported: 0,
+        commandHotkeysImported: 0,
+        commandAliasesImported: 0,
+        pinnedCommandsImported: 0,
+        aiChats: { found: 0, imported: 0, skipped: 0, failed: 0 },
+        quicklinks: { found: 0, imported: 0, skipped: 0, failed: 1 },
+        snippets: { found: 0, imported: 0, skipped: 0, failed: 0 },
+        notes: { found: 0, imported: 0, skipped: 0, failed: 0 },
+        extensions: { found: 0, imported: 0, skipped: 0, failed: 0 },
+        importedExtensionPreferenceExtensions: [],
+        unsupported: [],
+        warnings: [String(error?.message || error || 'Raycast import failed.')],
+      });
+    } finally {
+      setRaycastImportBusy(false);
+    }
+  };
+
+  const handleApplyRaycastImport = async () => {
+    if (raycastImportBusy || !raycastImportPreview?.sessionId || !raycastImportSelections) return;
+    setRaycastImportBusy(true);
+    try {
+      setRaycastImportProgress(null);
+      setRaycastImportLog([]);
+      const result = await window.electron.applyRaycastConfigImport({
+        sessionId: raycastImportPreview.sessionId,
+        conflictMode: raycastImportConflictMode,
+        selections: raycastImportSelections,
+      });
       setRaycastImportResult(result);
+      setRaycastImportPreview(null);
+      setRaycastImportSelections(null);
     } catch (error: any) {
       setRaycastImportResult({
         canceled: false,
@@ -410,8 +485,33 @@ const GeneralTab: React.FC = () => {
     settings.launcherBackgroundImageOpacityPercent,
     DEFAULT_LAUNCHER_BACKGROUND_OPACITY_PERCENT
   );
+  const selectedImportCategoryCount = raycastImportSelections
+    ? Object.values(raycastImportSelections).filter(Boolean).length
+    : 0;
+  const selectedImportItemCount = raycastImportSelections && raycastImportPreview
+    ? IMPORT_CATEGORY_META.reduce((count, category) => (
+        raycastImportSelections[category.key]
+          ? count + (raycastImportPreview.counts[category.countKey] || 0)
+          : count
+      ), 0)
+    : 0;
+  const raycastImportOverallPercent = raycastImportProgress
+    ? Math.max(
+        0,
+        Math.min(
+          100,
+          raycastImportProgress.totalSteps > 0
+            ? (raycastImportProgress.completedSteps / raycastImportProgress.totalSteps) * 100
+            : 0
+        )
+      )
+    : 0;
+  const raycastImportByteLabel = raycastImportProgress && raycastImportProgress.downloadedBytes !== undefined
+    ? `${formatBytes(raycastImportProgress.downloadedBytes)}${raycastImportProgress.totalBytes ? ` / ${formatBytes(raycastImportProgress.totalBytes)}` : ''}`
+    : '';
 
   return (
+    <>
     <div className="w-full max-w-[980px] mx-auto space-y-3">
       <h2 className="text-[0.9375rem] font-semibold text-[var(--text-primary)]">{t('settings.general.title')}</h2>
 
@@ -866,6 +966,250 @@ const GeneralTab: React.FC = () => {
         </SettingsRow>
       </div>
     </div>
+    {raycastImportPreview && !raycastImportPreview.canceled && raycastImportSelections ? (
+      <div className="fixed inset-0 z-[120] flex items-center justify-center px-5 py-8">
+        <button
+          type="button"
+          aria-label="Close import preview"
+          className="absolute inset-0 bg-[rgba(5,8,12,0.62)] backdrop-blur-md"
+          onClick={() => {
+            if (raycastImportBusy) return;
+            setRaycastImportPreview(null);
+            setRaycastImportSelections(null);
+          }}
+        />
+        <div className={`relative w-full overflow-hidden border shadow-[0_18px_60px_rgba(0,0,0,0.28)] ${
+          raycastImportBusy
+            ? 'max-w-[430px] rounded-[18px] border-[rgba(255,255,255,0.12)] bg-[linear-gradient(180deg,rgba(18,22,30,0.98),rgba(10,12,18,0.98))]'
+            : 'max-w-[460px] rounded-[18px] border-[var(--ui-panel-border)] bg-[var(--settings-panel-bg)]'
+        }`}>
+          {!raycastImportBusy ? (
+            <>
+              <div className="border-b border-[var(--ui-divider)] px-4 py-3.5">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <div className="inline-flex items-center gap-2 rounded-full border border-[var(--ui-divider)] bg-[var(--ui-segment-bg)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-secondary)]">
+                      <FileArchive className="w-3 h-3" />
+                      Raycast Import
+                    </div>
+                    <h3 className="mt-2.5 text-[0.95rem] font-semibold text-[var(--text-primary)]">Choose what to import</h3>
+                    <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[0.7rem] text-[var(--text-subtle)]">
+                      {raycastImportPreview.filePath ? <span>{getFileName(raycastImportPreview.filePath)}</span> : null}
+                      {raycastImportPreview.raycastVersion ? <span>Raycast {raycastImportPreview.raycastVersion}</span> : null}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setRaycastImportPreview(null);
+                      setRaycastImportSelections(null);
+                    }}
+                    className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[var(--ui-divider)] bg-[var(--ui-segment-bg)] text-[var(--text-secondary)] hover:bg-[var(--ui-segment-hover-bg)]"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              </div>
+
+              <div className="px-4 py-3.5">
+                <div className="max-h-[320px] space-y-2 overflow-y-auto pr-1">
+                  {IMPORT_CATEGORY_META.map((category) => {
+                    const count = raycastImportPreview.counts[category.countKey] || 0;
+                    const selected = raycastImportSelections[category.key];
+                    const disabled = count === 0;
+                    return (
+                      <button
+                        key={category.key}
+                        type="button"
+                        disabled={disabled}
+                        onClick={() => {
+                          if (disabled) return;
+                          setRaycastImportSelections((prev) => (
+                            prev ? { ...prev, [category.key]: !prev[category.key] } : prev
+                          ));
+                        }}
+                        className={`flex items-center gap-3 rounded-xl border px-3 py-2.5 text-left transition-colors ${
+                          disabled
+                            ? 'cursor-not-allowed border-[var(--ui-divider)] bg-[var(--ui-segment-bg)] opacity-45'
+                            : selected
+                              ? 'border-cyan-400/40 bg-cyan-400/10'
+                              : 'border-[var(--ui-divider)] bg-[var(--ui-segment-bg)] hover:border-[var(--ui-segment-border)] hover:bg-[var(--ui-segment-hover-bg)]'
+                        }`}
+                      >
+                        <div className={`inline-flex h-7 w-7 items-center justify-center rounded-lg ${
+                          selected ? 'bg-cyan-400/18 text-cyan-200' : 'bg-[var(--ui-segment-active-bg)] text-[var(--text-secondary)]'
+                        }`}>
+                          {category.icon}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-[0.77rem] font-medium text-[var(--text-primary)]">{category.title}</div>
+                          <div className="mt-0.5 text-[0.68rem] text-[var(--text-muted)]">{category.description}</div>
+                        </div>
+                        <div className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+                          selected ? 'bg-cyan-400/16 text-cyan-200' : 'bg-[var(--ui-segment-active-bg)] text-[var(--text-secondary)]'
+                        }`}>
+                          {count}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <div className="mt-3 rounded-xl border border-[var(--ui-divider)] bg-[var(--ui-segment-bg)] p-2">
+                  <div className="text-[0.7rem] font-medium text-[var(--text-primary)]">If something already exists</div>
+                  <div className="mt-2 inline-flex w-full rounded-lg border border-[var(--ui-divider)] bg-[var(--ui-segment-bg)] p-0.5">
+                    {([
+                      { id: 'skip' as const, label: 'Keep existing', description: 'Merge safely' },
+                      { id: 'overwrite' as const, label: 'Overwrite', description: 'Use backup values' },
+                    ]).map((option) => {
+                      const active = raycastImportConflictMode === option.id;
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() => setRaycastImportConflictMode(option.id)}
+                          className={`flex-1 rounded-md px-3 py-2 text-left transition-colors ${
+                            active
+                              ? 'bg-[var(--ui-segment-active-bg)] text-[var(--text-primary)]'
+                              : 'text-[var(--text-secondary)] hover:bg-[var(--ui-segment-hover-bg)]'
+                          }`}
+                        >
+                          <div className="text-[0.72rem] font-medium">{option.label}</div>
+                          <div className="text-[0.66rem] opacity-80">{option.description}</div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {raycastImportPreview.unsupported.length > 0 ? (
+                  <div className="mt-3 rounded-xl border border-amber-300/18 bg-amber-300/10 px-3 py-2.5">
+                    <div className="text-[0.68rem] font-medium text-amber-100">Not imported yet</div>
+                    <p className="mt-1 text-[0.69rem] leading-relaxed text-amber-100/85">
+                      {raycastImportPreview.unsupported.join(', ')}
+                    </p>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="flex items-center justify-between gap-3 border-t border-[var(--ui-divider)] px-4 py-3.5">
+                <div className="text-[0.72rem] text-[var(--text-muted)]">
+                  <span className="font-semibold text-[var(--text-primary)]">{selectedImportItemCount}</span> items across{' '}
+                  <span className="font-semibold text-[var(--text-primary)]">{selectedImportCategoryCount}</span> categories
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setRaycastImportPreview(null);
+                      setRaycastImportSelections(null);
+                    }}
+                    className="inline-flex items-center justify-center rounded-lg border border-[var(--ui-divider)] px-3 py-2 text-[0.73rem] font-medium text-[var(--text-secondary)] hover:bg-[var(--ui-segment-hover-bg)]"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleApplyRaycastImport()}
+                    disabled={selectedImportCategoryCount === 0}
+                    className="inline-flex items-center justify-center gap-2 rounded-lg bg-[var(--ui-segment-active-bg)] px-3 py-2 text-[0.73rem] font-medium text-[var(--text-primary)] shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <Download className="w-3.5 h-3.5" />
+                    Import
+                  </button>
+                </div>
+              </div>
+            </>
+          ) : (
+            <div className="px-4 py-4">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="inline-flex items-center gap-2 rounded-full border border-cyan-400/20 bg-cyan-400/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-cyan-200">
+                    <Download className="w-3 h-3" />
+                    Importing
+                  </div>
+                  <h3 className="mt-2.5 text-[0.96rem] font-semibold text-white">
+                    {raycastImportProgress?.extensionName || 'Bringing data over'}
+                  </h3>
+                  <p className="mt-1 text-[0.72rem] leading-relaxed text-[rgba(214,224,237,0.72)]">
+                    {raycastImportProgress?.message || 'Preparing import…'}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <div className="text-[0.65rem] uppercase tracking-[0.12em] text-[rgba(214,224,237,0.52)]">Progress</div>
+                  <div className="mt-1 text-[1.2rem] font-semibold text-white">{Math.round(raycastImportOverallPercent)}%</div>
+                </div>
+              </div>
+
+              <div className="mt-3 rounded-[16px] border border-[rgba(255,255,255,0.09)] bg-[rgba(255,255,255,0.04)] p-3">
+                <div className="flex items-center justify-between gap-3 text-[0.69rem] text-[rgba(214,224,237,0.74)]">
+                  <span>
+                    Step {Math.min(raycastImportProgress?.completedSteps || 0, raycastImportProgress?.totalSteps || 0)} / {raycastImportProgress?.totalSteps || 0}
+                  </span>
+                  {raycastImportProgress?.stage === 'extension' && raycastImportProgress?.extensionName ? (
+                    <span className="truncate text-right">{raycastImportProgress.extensionName}</span>
+                  ) : null}
+                </div>
+                <div className="mt-2.5 h-2 overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
+                  <div
+                    className="h-full rounded-full bg-[linear-gradient(90deg,#5edfff,#238bff)] transition-all"
+                    style={{ width: `${raycastImportOverallPercent}%` }}
+                  />
+                </div>
+                {raycastImportProgress?.stage === 'extension' ? (
+                  <div className="mt-3 rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(4,8,14,0.35)] px-3 py-2.5">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="truncate text-[0.73rem] font-medium text-white">
+                        {raycastImportProgress.extensionName || 'Extension'}
+                      </span>
+                      <span className="shrink-0 text-[0.7rem] text-cyan-200">
+                        {raycastImportByteLabel || 'Preparing…'}
+                      </span>
+                    </div>
+                    {raycastImportProgress.downloadedBytes !== undefined ? (
+                      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
+                        <div
+                          className="h-full rounded-full bg-[linear-gradient(90deg,#88e6ff,#33a8ff)] transition-all"
+                          style={{
+                            width: `${raycastImportProgress.totalBytes && raycastImportProgress.totalBytes > 0
+                              ? Math.max(2, Math.min(100, (raycastImportProgress.downloadedBytes / raycastImportProgress.totalBytes) * 100))
+                              : 18}%`,
+                          }}
+                        />
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+
+              {raycastImportLog.length > 0 ? (
+                <div className="mt-3 rounded-[16px] border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.03)] px-3 py-2.5">
+                  <div className="text-[0.66rem] font-semibold uppercase tracking-[0.12em] text-[rgba(214,224,237,0.55)]">Live activity</div>
+                  <div className="mt-2 max-h-[120px] space-y-1.5 overflow-y-auto">
+                    {raycastImportLog.slice().reverse().map((entry, index) => (
+                      <div key={`${entry.message}-${index}`} className="flex items-start justify-between gap-3 text-[0.69rem] leading-relaxed text-[rgba(214,224,237,0.76)]">
+                        <span className="min-w-0 flex-1">
+                          {entry.message}
+                          {entry.stage === 'extension' && entry.downloadedBytes !== undefined ? (
+                            <span className="text-[rgba(214,224,237,0.48)]">
+                              {` ${formatBytes(entry.downloadedBytes)}${entry.totalBytes ? ` / ${formatBytes(entry.totalBytes)}` : ''}`}
+                            </span>
+                          ) : null}
+                        </span>
+                        {entry.currentItem && entry.totalItems ? (
+                          <span className="shrink-0 text-[rgba(214,224,237,0.48)]">{entry.currentItem}/{entry.totalItems}</span>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </div>
+    ) : null}
+    </>
   );
 };
 

--- a/src/renderer/src/settings/GeneralTab.tsx
+++ b/src/renderer/src/settings/GeneralTab.tsx
@@ -386,6 +386,7 @@ const GeneralTab: React.FC = () => {
         snippets: { found: 0, imported: 0, skipped: 0, failed: 0 },
         notes: { found: 0, imported: 0, skipped: 0, failed: 0 },
         extensions: { found: 0, imported: 0, skipped: 0, failed: 0 },
+        importedExtensionPreferenceExtensions: [],
         unsupported: [],
         warnings: [String(error?.message || error || 'Raycast import failed.')],
       });

--- a/src/renderer/src/utils/constants.ts
+++ b/src/renderer/src/utils/constants.ts
@@ -9,6 +9,7 @@
  */
 
 export const LAST_EXT_KEY = 'sc-last-extension';
+export const AI_CHAT_STORAGE_KEY = 'sc.aiChat.conversations';
 export const EXT_PREFS_KEY_PREFIX = 'sc-ext-prefs:';
 export const CMD_PREFS_KEY_PREFIX = 'sc-ext-cmd-prefs:';
 export const CMD_ARGS_KEY_PREFIX = 'sc-ext-cmd-args:';

--- a/src/renderer/src/utils/extension-preferences.ts
+++ b/src/renderer/src/utils/extension-preferences.ts
@@ -13,7 +13,7 @@
  * Import these helpers instead of reading localStorage directly.
  */
 
-import type { ExtensionBundle, CommandInfo } from '../../types/electron';
+import type { ExtensionBundle, CommandInfo, ExtensionPreferencesSnapshot } from '../../types/electron';
 import {
   EXT_PREFS_KEY_PREFIX,
   CMD_PREFS_KEY_PREFIX,
@@ -39,6 +39,40 @@ export function readJsonObject(key: string): Record<string, any> {
 
 export function writeJsonObject(key: string, value: Record<string, any>) {
   localStorage.setItem(key, JSON.stringify(value));
+}
+
+export function collectLegacyExtensionPreferencesSnapshot(): ExtensionPreferencesSnapshot {
+  const snapshot: ExtensionPreferencesSnapshot = {
+    version: 1,
+    extensions: {},
+    commands: {},
+  };
+
+  try {
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index);
+      if (!key) continue;
+      if (key.startsWith(EXT_PREFS_KEY_PREFIX)) {
+        const extName = key.slice(EXT_PREFS_KEY_PREFIX.length).trim();
+        if (!extName) continue;
+        const value = readJsonObject(key);
+        if (Object.keys(value).length === 0) continue;
+        snapshot.extensions[extName] = value;
+        continue;
+      }
+      if (key.startsWith(CMD_PREFS_KEY_PREFIX)) {
+        const commandKey = key.slice(CMD_PREFS_KEY_PREFIX.length).trim();
+        if (!commandKey) continue;
+        const value = readJsonObject(key);
+        if (Object.keys(value).length === 0) continue;
+        snapshot.commands[commandKey] = value;
+      }
+    }
+  } catch {
+    // best-effort migration only
+  }
+
+  return snapshot;
 }
 
 export function getMenuBarCommandKey(extName: string, cmdName: string): string {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -333,6 +333,7 @@ export interface RaycastImportResult {
   snippets: RaycastImportBucketResult;
   notes: RaycastImportBucketResult;
   extensions: RaycastImportBucketResult;
+  importedExtensionPreferenceExtensions: string[];
   unsupported: string[];
   warnings: string[];
 }

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -363,6 +363,59 @@ export interface RaycastImportResult {
   warnings: string[];
 }
 
+export interface RaycastImportSelections {
+  settings: boolean;
+  disabledCommands: boolean;
+  scriptCommandFolders: boolean;
+  commandHotkeys: boolean;
+  commandAliases: boolean;
+  pinnedCommands: boolean;
+  aiChats: boolean;
+  quicklinks: boolean;
+  snippets: boolean;
+  notes: boolean;
+  extensions: boolean;
+  extensionPreferences: boolean;
+}
+
+export interface RaycastImportPreview {
+  canceled: boolean;
+  sessionId?: string;
+  filePath?: string;
+  raycastVersion?: string;
+  selections: RaycastImportSelections;
+  counts: {
+    settings: number;
+    disabledCommands: number;
+    scriptCommandFolders: number;
+    commandHotkeys: number;
+    commandAliases: number;
+    pinnedCommands: number;
+    aiChats: number;
+    quicklinks: number;
+    snippets: number;
+    notes: number;
+    extensions: number;
+    extensionPreferences: number;
+  };
+  unsupported: string[];
+  warnings: string[];
+}
+
+export interface RaycastImportProgress {
+  sessionId: string;
+  stage: 'starting' | 'category' | 'extension' | 'done';
+  category?: keyof RaycastImportSelections;
+  message: string;
+  completedSteps: number;
+  totalSteps: number;
+  currentItem?: number;
+  totalItems?: number;
+  extensionName?: string;
+  downloadedBytes?: number;
+  totalBytes?: number;
+}
+
 export interface ExtensionPreferencesSnapshot {
   version: 1;
   extensions: Record<string, Record<string, any>>;
@@ -638,7 +691,14 @@ export interface ElectronAPI {
   appUpdaterCheckAndInstall: () => Promise<{ success: boolean; error?: string; message?: string; state?: string }>;
   onAppUpdaterStatus: (callback: (status: AppUpdaterStatus) => void) => (() => void);
   saveSettings: (patch: Partial<AppSettings>) => Promise<AppSettings>;
+  previewRaycastConfigImport: () => Promise<RaycastImportPreview>;
+  applyRaycastConfigImport: (options: {
+    sessionId: string;
+    conflictMode: 'skip' | 'overwrite';
+    selections: RaycastImportSelections;
+  }) => Promise<RaycastImportResult>;
   importRaycastConfig: () => Promise<RaycastImportResult>;
+  onRaycastImportProgress: (callback: (payload: RaycastImportProgress) => void) => (() => void);
   getAiChatSnapshot: () => Promise<AiChatSnapshot>;
   upsertAiChatConversation: (conversation: AiChatConversation) => Promise<AiChatConversation | null>;
   deleteAiChatConversation: (id: string) => Promise<boolean>;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -319,6 +319,30 @@ export interface RaycastImportBucketResult {
   failed: number;
 }
 
+export interface AiChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  createdAt: number;
+  cancelled?: boolean;
+}
+
+export interface AiChatConversation {
+  id: string;
+  title: string;
+  messages: AiChatMessage[];
+  createdAt: number;
+  updatedAt: number;
+  source?: 'local' | 'raycast';
+  sourceConversationId?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface AiChatSnapshot {
+  version: 1;
+  conversations: AiChatConversation[];
+}
+
 export interface RaycastImportResult {
   canceled: boolean;
   filePath?: string;
@@ -329,6 +353,7 @@ export interface RaycastImportResult {
   commandHotkeysImported: number;
   commandAliasesImported: number;
   pinnedCommandsImported: number;
+  aiChats: RaycastImportBucketResult;
   quicklinks: RaycastImportBucketResult;
   snippets: RaycastImportBucketResult;
   notes: RaycastImportBucketResult;
@@ -614,6 +639,10 @@ export interface ElectronAPI {
   onAppUpdaterStatus: (callback: (status: AppUpdaterStatus) => void) => (() => void);
   saveSettings: (patch: Partial<AppSettings>) => Promise<AppSettings>;
   importRaycastConfig: () => Promise<RaycastImportResult>;
+  getAiChatSnapshot: () => Promise<AiChatSnapshot>;
+  upsertAiChatConversation: (conversation: AiChatConversation) => Promise<AiChatConversation | null>;
+  deleteAiChatConversation: (id: string) => Promise<boolean>;
+  mergeAiChatSnapshot: (snapshot: AiChatSnapshot) => Promise<AiChatSnapshot>;
   getExtensionPreferencesSnapshot: () => Promise<ExtensionPreferencesSnapshot>;
   getExtensionPreferences: (extName: string, cmdName?: string) => Promise<Record<string, any>>;
   setExtensionPreference: (extName: string, preferenceName: string, value: any, cmdName?: string) => Promise<Record<string, any>>;
@@ -665,6 +694,7 @@ export interface ElectronAPI {
   ) => void;
   onSettingsUpdated: (callback: (settings: AppSettings) => void) => (() => void);
   onExtensionPreferencesUpdated: (callback: (payload: { extensionName: string }) => void) => (() => void);
+  onAiChatsUpdated: (callback: () => void) => (() => void);
 
   // Extension Runner
   runExtension: (extName: string, cmdName: string) => Promise<ExtensionBundle | null>;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -312,12 +312,44 @@ export interface BrowserSearchImportResult {
   reason?: string;
 }
 
+export interface RaycastImportBucketResult {
+  found: number;
+  imported: number;
+  skipped: number;
+  failed: number;
+}
+
+export interface RaycastImportResult {
+  canceled: boolean;
+  filePath?: string;
+  raycastVersion?: string;
+  settingsImported: boolean;
+  disabledCommandsImported: number;
+  scriptCommandFoldersImported: number;
+  commandHotkeysImported: number;
+  commandAliasesImported: number;
+  pinnedCommandsImported: number;
+  quicklinks: RaycastImportBucketResult;
+  snippets: RaycastImportBucketResult;
+  notes: RaycastImportBucketResult;
+  extensions: RaycastImportBucketResult;
+  unsupported: string[];
+  warnings: string[];
+}
+
+export interface ExtensionPreferencesSnapshot {
+  version: 1;
+  extensions: Record<string, Record<string, any>>;
+  commands: Record<string, Record<string, any>>;
+}
+
 export interface AppSettings {
   globalShortcut: string;
   openAtLogin: boolean;
   disabledCommands: string[];
   enabledCommands: string[];
   customExtensionFolders: string[];
+  scriptCommandFolders: string[];
   commandHotkeys: Record<string, string>;
   commandAliases: Record<string, string>;
   pinnedCommands: string[];
@@ -580,6 +612,12 @@ export interface ElectronAPI {
   appUpdaterCheckAndInstall: () => Promise<{ success: boolean; error?: string; message?: string; state?: string }>;
   onAppUpdaterStatus: (callback: (status: AppUpdaterStatus) => void) => (() => void);
   saveSettings: (patch: Partial<AppSettings>) => Promise<AppSettings>;
+  importRaycastConfig: () => Promise<RaycastImportResult>;
+  getExtensionPreferencesSnapshot: () => Promise<ExtensionPreferencesSnapshot>;
+  getExtensionPreferences: (extName: string, cmdName?: string) => Promise<Record<string, any>>;
+  setExtensionPreference: (extName: string, preferenceName: string, value: any, cmdName?: string) => Promise<Record<string, any>>;
+  setExtensionPreferences: (extName: string, values: Record<string, any>, cmdName?: string) => Promise<Record<string, any>>;
+  mergeExtensionPreferencesSnapshot: (snapshot: ExtensionPreferencesSnapshot) => Promise<ExtensionPreferencesSnapshot>;
   getAllCommands: () => Promise<CommandInfo[]>;
   updateGlobalShortcut: (shortcut: string) => Promise<boolean>;
   setOpenAtLogin: (enabled: boolean) => Promise<boolean>;
@@ -625,6 +663,7 @@ export interface ElectronAPI {
     ) => void
   ) => void;
   onSettingsUpdated: (callback: (settings: AppSettings) => void) => (() => void);
+  onExtensionPreferencesUpdated: (callback: (payload: { extensionName: string }) => void) => (() => void);
 
   // Extension Runner
   runExtension: (extName: string, cmdName: string) => Promise<ExtensionBundle | null>;


### PR DESCRIPTION
fixes: #284 
## Summary

This PR adds first-class import support for Raycast backup files (`.rayconfig`) and fills in the storage gaps that were blocking a believable migration into SuperCmd.

The importer now runs in the Electron main process. It can open a Raycast backup, prompt for the backup password, decrypt it locally, preview what it found, and import the parts of the backup that SuperCmd can represent safely today.

## What imports now

- Raycast settings that have direct SuperCmd equivalents
- global launcher hotkey
- command hotkeys where a Raycast command, app, or script can be mapped onto a SuperCmd command
- disabled extension commands
- disabled script commands
- quicklinks
- snippets
- notes
- installed Raycast Store extensions
- extension preferences
- script command folder paths
- pinned or favorite commands when Raycast exports them in a usable form
- AI chat history

## AI chat handling

This PR now imports Raycast AI chats instead of skipping them.

The important part is that this does not require a large UX rewrite. SuperCmd already had a usable AI chat interface, but its history lived entirely in renderer `localStorage`. That made import awkward and brittle. This PR introduces a shared main-process AI chat store, migrates old local chat history into it on startup, and updates the existing AI chat UI to read and write through that shared store.

That means imported Raycast conversations simply appear inside the current SuperCmd AI chat history like normal conversations.

The importer maps Raycast chat data into SuperCmd's existing conversation model:

- conversation id
- title
- message list
- created and updated timestamps
- optional source metadata

To avoid unnecessary UI churn, Raycast-specific structures are flattened into the current `user` / `assistant` transcript model. So the chat history itself is preserved, but Raycast-only affordances such as richer tool-call rendering are not recreated in the UI.

## Storage refactor

This PR also continues the storage cleanup needed to make import reliable:

- extension preferences now live in a main-process store instead of renderer-only `localStorage`
- AI chats now live in a main-process store instead of renderer-only `localStorage`
- legacy extension prefs are merged forward on startup
- legacy `sc.aiChat.conversations` data is merged forward on startup

This keeps existing SuperCmd users' data intact while giving the importer a real place to write imported state.

## Script command import

Script command migration is more complete now:

- imported Raycast script-command folders are persisted in SuperCmd settings
- the script runner reads from those folders
- Raycast's disabled script-command entries are resolved from their path-based identifiers onto SuperCmd script command ids so disabled state survives import

## Aliases, favorites, and hotkeys

Raycast command hotkeys are imported when they can be mapped onto known SuperCmd commands.

Favorites are imported when Raycast exposes them through `pinnedMenuItems`. In backups where that array is empty, there is simply nothing to import.

Aliases remain best-effort. Raycast does not appear to expose a clean first-class alias model in this backup format, so alias import is derived conservatively from exported search-term data only when it looks intentional rather than noisy.

## MCPs

MCP server import is still intentionally out of scope.

Raycast can export MCP server data, but SuperCmd does not yet have a normalized persisted MCP configuration model that this importer can safely target. Importing MCPs now would mean either guessing at storage shape or pushing credential-adjacent config into an unstable format.

So the current behavior is deliberate:

- the importer detects exported MCP servers
- it reports them as skipped
- it does not silently drop them
- it does not import them into a guessed schema

To support MCP import properly, SuperCmd would first need:

1. a canonical persisted MCP server config model
2. explicit mapping from Raycast MCP fields onto that model
3. a policy for secrets and auth material
4. a decision on whether imported MCP servers should be disabled by default until reviewed

## Still out of scope

- clipboard history import
- MCP server import
- perfect one-to-one alias migration from Raycast
- full builtin-command parity for every Raycast builtin
- Raycast-specific AI metadata beyond what fits cleanly into SuperCmd's current conversation UI

## Verification

- `npm run build:main`
- `npm run build:renderer`
