### PR TITLE
Performance improvements: Cut latency on show + Enter; fire-and-forget all launch paths

### DIFF
--- a/src/main/browser-search-history.ts
+++ b/src/main/browser-search-history.ts
@@ -192,12 +192,11 @@ export async function openInDefaultBrowser(rawInput: string): Promise<{
 }> {
   const resolved = resolveInput(rawInput);
   if (!resolved) return { ok: false, resolved: null };
-  try {
-    await shell.openExternal(resolved.url);
-  } catch (e) {
+  // Fire-and-forget: don't await LaunchServices. The renderer's IPC await
+  // would otherwise hold the launcher visible for the full dispatch window.
+  void shell.openExternal(resolved.url).catch((e) => {
     console.error('Failed to open URL in default browser:', e);
-    return { ok: false, resolved };
-  }
+  });
   recordEntry(rawInput.trim(), resolved);
   return { ok: true, resolved };
 }

--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -1189,6 +1189,9 @@ async function openAppByPath(appPath: string): Promise<void> {
     detached: true,
     stdio: 'ignore',
   });
+  child.on('error', (err) => {
+    console.error(`Failed to open app: ${appPath}`, err);
+  });
   child.unref();
 }
 
@@ -1204,7 +1207,11 @@ async function openSettingsPane(identifier: string): Promise<void> {
   const url = identifier.startsWith('com.apple.')
     ? `x-apple.systempreferences:${identifier}`
     : `x-apple.systempreferences:com.apple.settings.${identifier}`;
-  spawn('/usr/bin/open', [url], { detached: true, stdio: 'ignore' }).unref();
+  const child = spawn('/usr/bin/open', [url], { detached: true, stdio: 'ignore' });
+  child.on('error', (err) => {
+    console.error(`Failed to open settings pane: ${url}`, err);
+  });
+  child.unref();
 }
 
 // ─── Public API ─────────────────────────────────────────────────────

--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -1179,12 +1179,10 @@ async function discoverSystemSettings(): Promise<CommandInfo[]> {
 // ─── Command Execution ──────────────────────────────────────────────
 
 async function openAppByPath(appPath: string): Promise<void> {
-  // open(1) on macOS dispatches the launch to LaunchServices and is supposed
-  // to return quickly, but it can block for 1-3 s on first launch (Gatekeeper
-  // signature checks, sealed-package validation, LaunchServices metadata
-  // rebuilds — Microsoft Office is a frequent offender). Awaiting it kept
-  // the launcher visible the whole time and made the launch feel slow even
-  // though the app's own startup is identical either way. Fire-and-forget.
+  // open(1) is supposed to return quickly after dispatching to
+  // LaunchServices, but can block 1-3s on first launch (Gatekeeper,
+  // sealed-package validation — Microsoft Office is a frequent offender).
+  // The launch is dispatched async either way, so fire-and-forget.
   const child = spawn('/usr/bin/open', [appPath], {
     detached: true,
     stdio: 'ignore',
@@ -1196,14 +1194,11 @@ async function openAppByPath(appPath: string): Promise<void> {
 }
 
 async function openSettingsPane(identifier: string): Promise<void> {
-  // Same fire-and-forget reasoning as openAppByPath: open(1) dispatches to
-  // LaunchServices but can occasionally block 1-3s, and the renderer was
-  // awaiting it — meaning the launcher hung visible while System Settings
-  // was already coming up. The previous sequential fallback chain made it
-  // worse: open(1) returns success (exit 0) for any well-formed URL even
-  // when macOS doesn't recognize it, so the chain rarely fell through.
-  // If macOS doesn't recognize the URL it opens System Settings to its
-  // default pane, which matches the previous bare-fallback behaviour.
+  // Fire-and-forget for the same reason as openAppByPath. The old
+  // sequential fallback chain was futile too: open(1) returns 0 for any
+  // well-formed x-apple.systempreferences URL, and macOS opens System
+  // Settings to its default pane on unknown URLs (matching the old
+  // bare fallback).
   const url = identifier.startsWith('com.apple.')
     ? `x-apple.systempreferences:${identifier}`
     : `x-apple.systempreferences:com.apple.settings.${identifier}`;

--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -11,7 +11,7 @@
  */
 
 import { app } from 'electron';
-import { exec, execFile } from 'child_process';
+import { exec, execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -1179,7 +1179,17 @@ async function discoverSystemSettings(): Promise<CommandInfo[]> {
 // ─── Command Execution ──────────────────────────────────────────────
 
 async function openAppByPath(appPath: string): Promise<void> {
-  await execAsync(`open "${appPath}"`);
+  // open(1) on macOS dispatches the launch to LaunchServices and is supposed
+  // to return quickly, but it can block for 1-3 s on first launch (Gatekeeper
+  // signature checks, sealed-package validation, LaunchServices metadata
+  // rebuilds — Microsoft Office is a frequent offender). Awaiting it kept
+  // the launcher visible the whole time and made the launch feel slow even
+  // though the app's own startup is identical either way. Fire-and-forget.
+  const child = spawn('/usr/bin/open', [appPath], {
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
 }
 
 async function openSettingsPane(identifier: string): Promise<void> {

--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -1193,36 +1193,18 @@ async function openAppByPath(appPath: string): Promise<void> {
 }
 
 async function openSettingsPane(identifier: string): Promise<void> {
-  if (identifier.startsWith('com.apple.')) {
-    try {
-      await execAsync(`open "x-apple.systempreferences:${identifier}"`);
-      return;
-    } catch { /* fall through */ }
-  }
-
-  try {
-    await execAsync(
-      `open "x-apple.systempreferences:com.apple.settings.${identifier}"`
-    );
-    return;
-  } catch { /* fall through */ }
-
-  try {
-    await execAsync(
-      `open "x-apple.systempreferences:com.apple.preference.${identifier.toLowerCase()}"`
-    );
-    return;
-  } catch { /* fall through */ }
-
-  try {
-    await execAsync('open -a "System Settings"');
-  } catch {
-    try {
-      await execAsync('open -a "System Preferences"');
-    } catch (e) {
-      console.error('Could not open System Settings:', e);
-    }
-  }
+  // Same fire-and-forget reasoning as openAppByPath: open(1) dispatches to
+  // LaunchServices but can occasionally block 1-3s, and the renderer was
+  // awaiting it — meaning the launcher hung visible while System Settings
+  // was already coming up. The previous sequential fallback chain made it
+  // worse: open(1) returns success (exit 0) for any well-formed URL even
+  // when macOS doesn't recognize it, so the chain rarely fell through.
+  // If macOS doesn't recognize the URL it opens System Settings to its
+  // default pane, which matches the previous bare-fallback behaviour.
+  const url = identifier.startsWith('com.apple.')
+    ? `x-apple.systempreferences:${identifier}`
+    : `x-apple.systempreferences:com.apple.settings.${identifier}`;
+  spawn('/usr/bin/open', [url], { detached: true, stdio: 'ignore' }).unref();
 }
 
 // ─── Public API ─────────────────────────────────────────────────────

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7040,10 +7040,9 @@ async function openTargetWithApplication(target: string, application?: string): 
   const appName = String(application || '').trim();
   const { normalizedTarget, launchTarget, externalTarget } = normalizeOpenTarget(rawTarget);
 
-  // All three branches dispatch fire-and-forget. Awaiting LaunchServices for
-  // a quicklink kept the launcher visible for the duration of the dispatch
-  // (commonly 1-3 s on macOS), which is exactly the bug we already fixed for
-  // openAppByPath / openSettingsPane. Errors are logged but no longer block.
+  // All three branches fire-and-forget — same reason as openAppByPath /
+  // openSettingsPane. Awaiting LaunchServices held the launcher visible
+  // for the dispatch window (1-3s on macOS).
 
   if (appName) {
     const { spawn } = require('child_process');
@@ -7226,9 +7225,8 @@ function createWindow(): void {
       nodeIntegration: true,
       contextIsolation: false,
       sandbox: false,
-      // Keep the renderer running at full speed even while the launcher is
-      // hidden. Otherwise Chromium throttles paint of hidden windows, so the
-      // first frame after show() is catch-up and feels sluggish.
+      // Without this, Chromium throttles paint of the hidden launcher,
+      // so the first frame after show() is catch-up and feels sluggish.
       backgroundThrottling: false,
       preload: path.join(__dirname, 'preload.js'),
     },
@@ -8239,12 +8237,9 @@ async function showWindow(options?: { systemCommandId?: string }): Promise<void>
     selectedTextSnapshot: initialSelectionSnapshot,
   };
 
-  // Show the window FIRST, then notify the renderer. The renderer's
-  // window-shown handler does non-trivial work (state resets, focus calls,
-  // optional fetch), and doing it before show() means the user perceives
-  // the window appearing only after that work completes. With show() first,
-  // the OS paints the visible window and the renderer's reconciliation cost
-  // happens on a window the user is already looking at.
+  // Show first, notify second. The window-shown handler does non-trivial
+  // work (state resets, focus, optional fetch); running it before show()
+  // makes the user wait for that work before seeing the window.
   if (shouldActivateLauncherWindow) {
     try {
       app.focus({ steal: true });
@@ -10210,12 +10205,9 @@ async function runCommandById(commandId: string, source: 'launcher' | 'hotkey' |
     }
   }
 
-  // Hide the launcher up-front rather than waiting on executeCommand to
-  // resolve. With openAppByPath now fire-and-forget, executeCommand returns
-  // ~instantly for app/settings, but if any future code path adds a slow
-  // await, this reorder keeps the launcher feeling instantaneous. The
-  // command was selected from the list, so a "command not found" failure
-  // here is a logic error, not a normal user path.
+  // Hide up-front rather than awaiting executeCommand. App/settings paths
+  // are already fire-and-forget so this is mostly defense in depth — if a
+  // future path adds a slow await, the launcher still feels instant.
   if (source === 'launcher') {
     setTimeout(() => hideWindow(), 50);
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7242,6 +7242,10 @@ function createWindow(): void {
       nodeIntegration: true,
       contextIsolation: false,
       sandbox: false,
+      // Keep the renderer running at full speed even while the launcher is
+      // hidden. Otherwise Chromium throttles paint of hidden windows, so the
+      // first frame after show() is catch-up and feels sluggish.
+      backgroundThrottling: false,
       preload: path.join(__dirname, 'preload.js'),
     },
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8251,20 +8251,12 @@ async function showWindow(options?: { systemCommandId?: string }): Promise<void>
     selectedTextSnapshot: initialSelectionSnapshot,
   };
 
-  // Notify renderer before showing the window so it can finalize view state
-  // (including contextual command list) before first paint.
-  mainWindow.webContents.send('window-shown', windowShownPayload);
-
-  if (selectionSnapshotPromise) {
-    void selectionSnapshotPromise.then((snapshot) => {
-      if (!mainWindow || mainWindow.isDestroyed()) return;
-      const nextSnapshot = String(snapshot || '').trim();
-      const prevSnapshot = String(initialSelectionSnapshot || '').trim();
-      if (nextSnapshot === prevSnapshot) return;
-      mainWindow.webContents.send('selection-snapshot-updated', { selectedTextSnapshot: nextSnapshot });
-    });
-  }
-
+  // Show the window FIRST, then notify the renderer. The renderer's
+  // window-shown handler does non-trivial work (state resets, focus calls,
+  // optional fetch), and doing it before show() means the user perceives
+  // the window appearing only after that work completes. With show() first,
+  // the OS paints the visible window and the renderer's reconciliation cost
+  // happens on a window the user is already looking at.
   if (shouldActivateLauncherWindow) {
     try {
       app.focus({ steal: true });
@@ -8287,6 +8279,18 @@ async function showWindow(options?: { systemCommandId?: string }): Promise<void>
   }
   mainWindow.moveTop();
   isVisible = true;
+
+  mainWindow.webContents.send('window-shown', windowShownPayload);
+
+  if (selectionSnapshotPromise) {
+    void selectionSnapshotPromise.then((snapshot) => {
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      const nextSnapshot = String(snapshot || '').trim();
+      const prevSnapshot = String(initialSelectionSnapshot || '').trim();
+      if (nextSnapshot === prevSnapshot) return;
+      mainWindow.webContents.send('selection-snapshot-updated', { selectedTextSnapshot: nextSnapshot });
+    });
+  }
 
   // Now that the window is visible on the current Space, confine it here
   // and re-sync AeroSpace (the pre-show move may have been a no-op for

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8123,6 +8123,10 @@ function resolveLauncherEntryTargetWindowId(): string | null {
   return fallback || null;
 }
 
+function resolveLauncherEntryTargetWorkArea(): { x: number; y: number; width: number; height: number } | null {
+  return cloneWorkArea(launcherEntryWindowManagementTargetWorkArea ?? windowManagementTargetWorkArea);
+}
+
 function captureFrontmostAppContext(): void {
   if (process.platform !== 'darwin') return;
   try {
@@ -9340,7 +9344,7 @@ async function openLauncherAndRunSystemCommand(
 
   if (isWindowManagementSystemCommand(commandId)) {
     const launcherTargetWindowId = resolveLauncherEntryTargetWindowId();
-    const launcherTargetWorkArea = cloneWorkArea(launcherEntryWindowManagementTargetWorkArea);
+    const launcherTargetWorkArea = resolveLauncherEntryTargetWorkArea();
     if (isVisible && (launcherTargetWindowId || launcherTargetWorkArea)) {
       windowManagementTargetWindowId = launcherTargetWindowId;
       windowManagementTargetWorkArea = launcherTargetWorkArea;
@@ -9957,7 +9961,7 @@ async function runCommandById(commandId: string, source: 'launcher' | 'hotkey' |
       ? resolveLauncherEntryTargetWindowId()
       : (String(windowManagementTargetWindowId || '').trim() || null);
     const preferredTargetWorkArea = source === 'launcher' && isVisible
-      ? cloneWorkArea(launcherEntryWindowManagementTargetWorkArea)
+      ? resolveLauncherEntryTargetWorkArea()
       : cloneWorkArea(windowManagementTargetWorkArea);
     if (source === 'launcher' && isVisible) {
       windowManagementTargetWindowId = preferredTargetWindowId;
@@ -10011,7 +10015,7 @@ async function runCommandById(commandId: string, source: 'launcher' | 'hotkey' |
       ? resolveLauncherEntryTargetWindowId()
       : (String(windowManagementTargetWindowId || '').trim() || null);
     const preferredTargetWorkArea = source === 'launcher' && isVisible
-      ? cloneWorkArea(launcherEntryWindowManagementTargetWorkArea)
+      ? resolveLauncherEntryTargetWorkArea()
       : cloneWorkArea(windowManagementTargetWorkArea);
     if (source === 'launcher' && isVisible) {
       windowManagementTargetWindowId = preferredTargetWindowId;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7040,64 +7040,48 @@ async function openTargetWithApplication(target: string, application?: string): 
   const appName = String(application || '').trim();
   const { normalizedTarget, launchTarget, externalTarget } = normalizeOpenTarget(rawTarget);
 
+  // All three branches dispatch fire-and-forget. Awaiting LaunchServices for
+  // a quicklink kept the launcher visible for the duration of the dispatch
+  // (commonly 1-3 s on macOS), which is exactly the bug we already fixed for
+  // openAppByPath / openSettingsPane. Errors are logged but no longer block.
+
   if (appName) {
-    try {
-      const { spawn } = require('child_process');
-      const exitCode = await new Promise<number>((resolve) => {
-        const proc = spawn('open', ['-a', appName, launchTarget], { shell: false });
-        let stderr = '';
-
-        proc.stderr?.on('data', (data: Buffer) => {
-          stderr += data.toString();
-        });
-
-        proc.on('close', (code: number | null) => {
-          const resolved = code ?? 1;
-          if (resolved !== 0) {
-            console.error(`Failed to open target with ${appName}: ${launchTarget}`, stderr.trim() || `exit code ${resolved}`);
-          }
-          resolve(resolved);
-        });
-
-        proc.on('error', (err: Error) => {
-          console.error(`Failed to open target with ${appName}: ${launchTarget}`, err);
-          resolve(1);
-        });
-      });
-      return exitCode === 0;
-    } catch (error) {
-      console.error(`Failed to open target with ${appName}: ${launchTarget}`, error);
-      return false;
-    }
+    const { spawn } = require('child_process');
+    const proc = spawn('/usr/bin/open', ['-a', appName, launchTarget], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    proc.on('error', (err: Error) => {
+      console.error(`Failed to open target with ${appName}: ${launchTarget}`, err);
+    });
+    proc.unref();
+    return true;
   }
 
   if (path.isAbsolute(normalizedTarget)) {
-    try {
-      const openPathError = await shell.openPath(normalizedTarget);
-      if (openPathError) {
-        console.error(`Failed to open path: ${normalizedTarget}`, openPathError);
-        return false;
-      }
-      return true;
-    } catch (error) {
-      console.error(`Failed to open path: ${normalizedTarget}`, error);
-      return false;
-    }
+    void shell
+      .openPath(normalizedTarget)
+      .then((openPathError: string) => {
+        if (openPathError) {
+          console.error(`Failed to open path: ${normalizedTarget}`, openPathError);
+        }
+      })
+      .catch((error: unknown) => {
+        console.error(`Failed to open path: ${normalizedTarget}`, error);
+      });
+    return true;
   }
 
-  try {
-    await shell.openExternal(externalTarget);
-    return true;
-  } catch (error) {
+  void shell.openExternal(externalTarget).catch((error: unknown) => {
     if (externalTarget !== rawTarget) {
-      try {
-        await shell.openExternal(rawTarget);
-        return true;
-      } catch {}
+      void shell.openExternal(rawTarget).catch(() => {
+        console.error(`Failed to open URL: ${rawTarget}`, error);
+      });
+      return;
     }
     console.error(`Failed to open URL: ${rawTarget}`, error);
-    return false;
-  }
+  });
+  return true;
 }
 
 async function openQuickLinkById(id: string, dynamicValues?: Record<string, string>): Promise<boolean> {
@@ -10079,9 +10063,7 @@ async function runCommandById(commandId: string, source: 'launcher' | 'hotkey' |
       const created = createScriptCommandTemplate();
       invalidateScriptCommandsCache();
       invalidateCache();
-      try {
-        await shell.openPath(created.scriptPath);
-      } catch {}
+      void shell.openPath(created.scriptPath).catch(() => {});
       console.log(`[ScriptCommand] Created: ${path.basename(created.scriptPath)}`);
       if (source === 'launcher') {
         setTimeout(() => hideWindow(), 50);
@@ -10096,7 +10078,9 @@ async function runCommandById(commandId: string, source: 'launcher' | 'hotkey' |
   if (commandId === 'system-open-script-commands') {
     try {
       const dir = getSuperCmdScriptCommandsDirectory();
-      await shell.openPath(dir);
+      void shell.openPath(dir).catch((error: unknown) => {
+        console.error('Failed to open script command directory:', error);
+      });
       if (source === 'launcher') {
         setTimeout(() => hideWindow(), 50);
       }
@@ -13162,7 +13146,9 @@ app.whenReady().then(async () => {
   ipcMain.handle('open-custom-scripts-folder', async () => {
     try {
       const ensured = ensureSampleScriptCommand();
-      await shell.openPath(ensured.scriptsDir);
+      void shell.openPath(ensured.scriptsDir).catch((error: unknown) => {
+        console.error('Failed to open custom scripts folder:', error);
+      });
       return {
         success: true,
         folderPath: ensured.scriptsDir,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8211,9 +8211,21 @@ async function showWindow(options?: { systemCommandId?: string }): Promise<void>
   if (launcherMode !== 'onboarding') {
     captureFrontmostAppContext();
     launcherEntryFrontmostApp = cloneFrontmostAppContext(lastFrontmostApp);
-    await captureWindowManagementTargetWindow();
-    launcherEntryWindowManagementTargetWindowId = String(windowManagementTargetWindowId || '').trim() || null;
-    launcherEntryWindowManagementTargetWorkArea = cloneWorkArea(windowManagementTargetWorkArea);
+    // Window-management target capture is a worker IPC (~50 ms). Don't block
+    // the show path on it — fire-and-forget, then assign the launcher-entry
+    // vars when it resolves. Consumers (window-management commands) only run
+    // when the user picks a WM command from the list, which is well after
+    // 50 ms. resolveLauncherEntryTargetWindowId() also falls back to
+    // windowManagementTargetWindowId (set as a side-effect of the capture)
+    // so the data is still available if a consumer races the assignment.
+    launcherEntryWindowManagementTargetWindowId = null;
+    launcherEntryWindowManagementTargetWorkArea = null;
+    void captureWindowManagementTargetWindow()
+      .then(() => {
+        launcherEntryWindowManagementTargetWindowId = String(windowManagementTargetWindowId || '').trim() || null;
+        launcherEntryWindowManagementTargetWorkArea = cloneWorkArea(windowManagementTargetWorkArea);
+      })
+      .catch(() => {});
     // AX-only selection capture on window open: avoid clipboard fallback
     // (synthetic Cmd+C) here because the promise is not awaited — by the
     // time the AX check completes (~50 ms osascript spawn), mainWindow.show()

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10226,10 +10226,16 @@ async function runCommandById(commandId: string, source: 'launcher' | 'hotkey' |
     }
   }
 
-  const success = await executeCommand(commandId);
-  if (success && source === 'launcher') {
+  // Hide the launcher up-front rather than waiting on executeCommand to
+  // resolve. With openAppByPath now fire-and-forget, executeCommand returns
+  // ~instantly for app/settings, but if any future code path adds a slow
+  // await, this reorder keeps the launcher feeling instantaneous. The
+  // command was selected from the list, so a "command not found" failure
+  // here is a logic error, not a normal user path.
+  if (source === 'launcher') {
     setTimeout(() => hideWindow(), 50);
   }
+  const success = await executeCommand(commandId);
   return success;
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8215,13 +8215,9 @@ async function showWindow(options?: { systemCommandId?: string }): Promise<void>
   if (launcherMode !== 'onboarding') {
     captureFrontmostAppContext();
     launcherEntryFrontmostApp = cloneFrontmostAppContext(lastFrontmostApp);
-    // Window-management target capture is a worker IPC (~50 ms). Don't block
-    // the show path on it — fire-and-forget, then assign the launcher-entry
-    // vars when it resolves. Consumers (window-management commands) only run
-    // when the user picks a WM command from the list, which is well after
-    // 50 ms. resolveLauncherEntryTargetWindowId() also falls back to
-    // windowManagementTargetWindowId (set as a side-effect of the capture)
-    // so the data is still available if a consumer races the assignment.
+    // Capture is a worker IPC (~50 ms) — don't await it. WM consumers
+    // already fall back to windowManagementTargetWindowId, which the
+    // capture sets as a side-effect, so a racing consumer still sees data.
     launcherEntryWindowManagementTargetWindowId = null;
     launcherEntryWindowManagementTargetWorkArea = null;
     void captureWindowManagementTargetWindow()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1000,13 +1000,12 @@ const App: React.FC = () => {
         setIsCompactCollapsed(true);
         exitAiMode();
       }
-      // Focus the input synchronously, BEFORE any IO. The user's first
-      // keystroke or Enter must land on a focused input even if the show
-      // event arrives back-to-back with the keypress.
+      // Focus synchronously before any IO — a keystroke arriving back-to-back
+      // with the show event must land on a focused input.
       inputRef.current?.focus();
 
-      // Run post-show housekeeping after first paint, so it doesn't compete
-      // with the user's first keystroke or list rendering.
+      // Defer housekeeping past first paint so it doesn't compete with the
+      // user's first keystroke or list rendering.
       const runDeferred = () => {
         const COMMANDS_REFRESH_TTL_MS = 5 * 60_000;
         if (

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1005,8 +1005,8 @@ const App: React.FC = () => {
       // event arrives back-to-back with the keypress.
       inputRef.current?.focus();
 
-      // Defer non-critical post-show work to idle so it doesn't compete
-      // with the user's first interaction or with rendering of the list.
+      // Run post-show housekeeping after first paint, so it doesn't compete
+      // with the user's first keystroke or list rendering.
       const runDeferred = () => {
         const COMMANDS_REFRESH_TTL_MS = 5 * 60_000;
         if (
@@ -1018,11 +1018,8 @@ const App: React.FC = () => {
         loadLauncherPreferences();
         window.electron.aiIsAvailable().then(setAiAvailable);
       };
-      const ric = (window as any).requestIdleCallback as
-        | ((cb: () => void, opts?: { timeout?: number }) => number)
-        | undefined;
-      if (typeof ric === 'function') {
-        ric(runDeferred, { timeout: 200 });
+      if (typeof window.requestIdleCallback === 'function') {
+        window.requestIdleCallback(runDeferred, { timeout: 200 });
       } else {
         setTimeout(runDeferred, 0);
       }
@@ -3033,12 +3030,12 @@ const App: React.FC = () => {
   }, [navigationStyle]);
 
   const handleCommandExecute = async (command: CommandInfo) => {
-    // Drop a second Enter while the first command is still resolving.
-    // Without this guard, a fast double-Enter can re-fire the same command
-    // (or a different one if selection moved during the IPC roundtrip).
+    // Drop a second Enter while the first command is still resolving — a
+    // fast double-press could otherwise re-fire the same command or a
+    // different one if selection moved during the IPC roundtrip.
     if (executingCommandRef.current) return;
-    executingCommandRef.current = true;
     try {
+      executingCommandRef.current = true;
       // Browser-search synthetic action: open the resolved URL/search query
       // in the default browser. Bypasses recent-commands tracking — the
       // browser-search history module records the entry itself.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -799,7 +799,6 @@ const App: React.FC = () => {
       if (!isOnboardingMode) {
         refreshThemeFromStorage(false);
       }
-      console.log('[WINDOW-SHOWN] fired', payload);
       const isWhisperMode = payload?.mode === 'whisper';
       const isSpeakMode = payload?.mode === 'speak';
       const isPromptMode = payload?.mode === 'prompt';

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1000,21 +1000,32 @@ const App: React.FC = () => {
         setIsCompactCollapsed(true);
         exitAiMode();
       }
-      // Skip the per-show fetch when commands are already loaded and recently
-      // fresh — refetching every show triggers a full ~1000-item list
-      // reconciliation that blocks the main thread (and can swallow the
-      // user's first Enter press). Newly installed extensions are still
-      // surfaced via the 'commands-updated' IPC and useBackgroundRefresh.
-      const COMMANDS_REFRESH_TTL_MS = 5 * 60_000;
-      if (
-        commandsRef.current.length === 0 ||
-        Date.now() - lastCommandsFetchAtRef.current > COMMANDS_REFRESH_TTL_MS
-      ) {
-        fetchCommands({ showLoading: false });
-      }
-      loadLauncherPreferences();
-      window.electron.aiIsAvailable().then(setAiAvailable);
+      // Focus the input synchronously, BEFORE any IO. The user's first
+      // keystroke or Enter must land on a focused input even if the show
+      // event arrives back-to-back with the keypress.
       inputRef.current?.focus();
+
+      // Defer non-critical post-show work to idle so it doesn't compete
+      // with the user's first interaction or with rendering of the list.
+      const runDeferred = () => {
+        const COMMANDS_REFRESH_TTL_MS = 5 * 60_000;
+        if (
+          commandsRef.current.length === 0 ||
+          Date.now() - lastCommandsFetchAtRef.current > COMMANDS_REFRESH_TTL_MS
+        ) {
+          fetchCommands({ showLoading: false });
+        }
+        loadLauncherPreferences();
+        window.electron.aiIsAvailable().then(setAiAvailable);
+      };
+      const ric = (window as any).requestIdleCallback as
+        | ((cb: () => void, opts?: { timeout?: number }) => number)
+        | undefined;
+      if (typeof ric === 'function') {
+        ric(runDeferred, { timeout: 200 });
+      } else {
+        setTimeout(runDeferred, 0);
+      }
     });
     return cleanupWindowShown;
   }, [expandLauncherForDirectLaunch, fetchCommands, loadLauncherPreferences, refreshSelectedTextSnapshot, openWhisper, openSpeak, openCursorPrompt, resetCursorPromptState, exitAiMode, setShowCursorPrompt, setShowWhisperHint, setMemoryFeedback, setMemoryActionLoading, setScriptCommandSetup, setScriptCommandOutput, setExtensionView, setSearchQuery, setSelectedIndex, setShowSnippetManager, setShowNotesSearch, setShowCanvasSearch, setShowQuickLinkManager, setShowFileSearch, openClipboardManager, setShowClipboardManager, openSnippetManager, openQuickLinkManager, openFileSearch, openSchedule, openCamera, openOnboarding, setShowCamera, setShowSchedule, setShowWindowManager, setShowWhisper, setShowSpeak, setShowWhisperOnboarding]);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -447,6 +447,7 @@ const App: React.FC = () => {
   const inlineQuickLinkInputRefs = useRef<Array<HTMLInputElement | null>>([]);
   const fileSearchRequestSeqRef = useRef(0);
   const commandsRef = useRef<CommandInfo[]>([]);
+  const lastCommandsFetchAtRef = useRef(0);
   const showActionsRef = useRef(false);
   const selectedCommandRef = useRef<CommandInfo | null>(null);
   commandsRef.current = commands;
@@ -719,6 +720,7 @@ const App: React.FC = () => {
     try {
       const fetchedCommands = await window.electron.getCommands();
       setCommands(fetchedCommands);
+      lastCommandsFetchAtRef.current = Date.now();
     } catch (error) {
       console.error('Failed to fetch commands:', error);
     } finally {
@@ -998,9 +1000,18 @@ const App: React.FC = () => {
         setIsCompactCollapsed(true);
         exitAiMode();
       }
-      // Re-fetch commands every time the window is shown
-      // so newly installed extensions appear immediately
-      fetchCommands({ showLoading: false });
+      // Skip the per-show fetch when commands are already loaded and recently
+      // fresh — refetching every show triggers a full ~1000-item list
+      // reconciliation that blocks the main thread (and can swallow the
+      // user's first Enter press). Newly installed extensions are still
+      // surfaced via the 'commands-updated' IPC and useBackgroundRefresh.
+      const COMMANDS_REFRESH_TTL_MS = 5 * 60_000;
+      if (
+        commandsRef.current.length === 0 ||
+        Date.now() - lastCommandsFetchAtRef.current > COMMANDS_REFRESH_TTL_MS
+      ) {
+        fetchCommands({ showLoading: false });
+      }
       loadLauncherPreferences();
       window.electron.aiIsAvailable().then(setAiAvailable);
       inputRef.current?.focus();

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -448,6 +448,7 @@ const App: React.FC = () => {
   const fileSearchRequestSeqRef = useRef(0);
   const commandsRef = useRef<CommandInfo[]>([]);
   const lastCommandsFetchAtRef = useRef(0);
+  const executingCommandRef = useRef(false);
   const showActionsRef = useRef(false);
   const selectedCommandRef = useRef<CommandInfo | null>(null);
   commandsRef.current = commands;
@@ -3033,6 +3034,11 @@ const App: React.FC = () => {
   }, [navigationStyle]);
 
   const handleCommandExecute = async (command: CommandInfo) => {
+    // Drop a second Enter while the first command is still resolving.
+    // Without this guard, a fast double-Enter can re-fire the same command
+    // (or a different one if selection moved during the IPC roundtrip).
+    if (executingCommandRef.current) return;
+    executingCommandRef.current = true;
     try {
       // Browser-search synthetic action: open the resolved URL/search query
       // in the default browser. Bypasses recent-commands tracking — the
@@ -3187,6 +3193,8 @@ const App: React.FC = () => {
       setSelectedIndex(0);
     } catch (error) {
       console.error('Failed to execute command:', error);
+    } finally {
+      executingCommandRef.current = false;
     }
   };
   const handleCommandRowClick = useCallback(


### PR DESCRIPTION
## Summary

Targets two perceived-latency bugs:

- **Slow show after global hotkey** — the show path was awaiting a ~50 ms window-management worker IPC before `mainWindow.show()`, the `window-shown` IPC fired before the OS painted the window, and the renderer ran heavy state-resets + a per-show `fetchCommands` (full ~1000-item reconciliation) before focusing the input. Fixed by reordering the show path, dropping the await, skipping `fetchCommands` when the cache is fresh, focusing the input synchronously, and deferring non-critical post-show work to `requestIdleCallback`. Also disabled `backgroundThrottling` on the launcher window so the first frame after `show()` isn't catch-up.
- **Enter felt slow / sometimes ignored** — every launch primitive (`openAppByPath`, `openSettingsPane`, `openTargetWithApplication`, `shell.openPath`, `shell.openExternal`, `browser-search-history.openInDefaultBrowser`, the script-commands folder IPCs) was awaited, holding the renderer's IPC await — and therefore the launcher window — for the full LaunchServices dispatch (commonly 1–3 s on macOS for first launch / Gatekeeper checks). Now all of those are fire-and-forget; the launcher hides on the existing 50 ms timer regardless of the launch's own duration. Added an in-flight guard on `handleCommandExecute` so a fast double-Enter no longer re-fires the same command.

## Test plan

- [ ] Trigger the global hotkey ten times in a row from a cold state — launcher should appear within one frame each time.
- [ ] Type a few characters and press Enter once — must execute on the first press, every time.
- [ ] Press Enter twice rapidly on a slow command — the second press must be ignored (no double-launch).
- [ ] Launch Microsoft Word (or any app with slow first-launch) — launcher must hide instantly while Word starts in the background.
- [ ] Open a System Settings pane (Display, About) — launcher must hide instantly even when System Settings is already running.
- [ ] Run a quicklink (URL, file path, app target) — launcher must hide instantly.
- [ ] Run a browser search — launcher must hide instantly.
- [ ] Window-management presets must still target the previously-frontmost window correctly (verifies the lazy WM capture in commit \`0ffc5b1\` / \`b606ee8\`).
- [ ] Install or uninstall an extension — list refreshes via the existing \`commands-updated\` IPC, confirming the per-show fetch skip didn't break staleness recovery.
