### PR TITLE
(feat) LM Studio provider

### DIFF
--- a/src/main/ai-provider.ts
+++ b/src/main/ai-provider.ts
@@ -32,7 +32,7 @@ export interface AIChatRequestOptions {
 // ─── Model routing ────────────────────────────────────────────────────
 
 interface ModelRoute {
-  provider: 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'openai-compatible';
+  provider: 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'lm-studio' | 'openai-compatible';
   modelId: string;
 }
 
@@ -66,10 +66,10 @@ function resolveModel(model: string | undefined, config: AISettings): ModelRoute
   // If the model key is not in our routing table, strip provider prefix and route directly
   if (model) {
     // Order matters: check longer prefixes first to avoid partial matches
-    const prefixes = ['openai-compatible-', 'anthropic-', 'gemini-', 'ollama-', 'openai-'] as const;
+    const prefixes = ['openai-compatible-', 'lm-studio-', 'anthropic-', 'gemini-', 'ollama-', 'openai-'] as const;
     for (const prefix of prefixes) {
       if (model.startsWith(prefix)) {
-        return { provider: prefix.slice(0, -1) as 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'openai-compatible', modelId: model.slice(prefix.length) };
+        return { provider: prefix.slice(0, -1) as 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'openai-compatible' | 'lm-studio', modelId: model.slice(prefix.length) };
       }
     }
     return { provider: config.provider, modelId: model };
@@ -81,10 +81,10 @@ function resolveModel(model: string | undefined, config: AISettings): ModelRoute
     }
     // Handle dynamic model IDs (e.g. "ollama-llama3.2")
     // Order matters: check longer prefixes first to avoid partial matches
-    const prefixes = ['openai-compatible-', 'anthropic-', 'gemini-', 'ollama-', 'openai-'] as const;
+    const prefixes = ['openai-compatible-', 'lm-studio-', 'anthropic-', 'gemini-', 'ollama-', 'openai-'] as const;
     for (const prefix of prefixes) {
       if (config.defaultModel.startsWith(prefix)) {
-        return { provider: prefix.slice(0, -1) as 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'openai-compatible', modelId: config.defaultModel.slice(prefix.length) };
+        return { provider: prefix.slice(0, -1) as 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'openai-compatible' | 'lm-studio', modelId: config.defaultModel.slice(prefix.length) };
       }
     }
   }
@@ -95,6 +95,7 @@ function resolveModel(model: string | undefined, config: AISettings): ModelRoute
     gemini: 'gemini-2.5-flash',
     ollama: 'llama3',
     'openai-compatible': config.openaiCompatibleModel?.trim() || 'gpt-4o',
+    'lm-studio': config.lmStudioModel?.trim() || 'local-model',
   };
   return { provider: config.provider, modelId: defaults[config.provider] || 'gpt-4o-mini' };
 }
@@ -126,6 +127,8 @@ function hasProviderCredentials(provider: ModelRoute['provider'], config: AISett
       return !!config.ollamaBaseUrl;
     case 'openai-compatible':
       return !!(config.openaiCompatibleBaseUrl && config.openaiCompatibleApiKey);
+    case 'lm-studio':
+      return !!config.lmStudioBaseUrl;
     default:
       return false;
   }
@@ -178,6 +181,17 @@ export async function* streamAI(
         options.signal
       );
       break;
+    case 'lm-studio':
+      yield* streamOpenAICompatible(
+        config.lmStudioBaseUrl || 'http://127.0.0.1:1234/v1',
+        config.lmStudioApiKey || 'lm-studio',
+        route.modelId,
+        options.prompt,
+        temperature,
+        options.systemPrompt,
+        options.signal
+      );
+      break;
   }
 }
 
@@ -207,6 +221,17 @@ export async function* streamAIChat(
       yield* streamOpenAICompatibleChat(
         config.openaiCompatibleBaseUrl,
         config.openaiCompatibleApiKey,
+        route.modelId,
+        options.messages,
+        temperature,
+        options.systemPrompt,
+        options.signal
+      );
+      break;
+    case 'lm-studio':
+      yield* streamOpenAICompatibleChat(
+        config.lmStudioBaseUrl || 'http://127.0.0.1:1234/v1',
+        config.lmStudioApiKey || 'lm-studio',
         route.modelId,
         options.messages,
         temperature,

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -20,6 +20,7 @@ const SENSITIVE_AI_KEYS = [
   'elevenlabsApiKey',
   'mistralApiKey',
   'supermemoryApiKey',
+  'lmStudioApiKey',
   'openaiCompatibleApiKey',
 ] as const;
 
@@ -34,7 +35,7 @@ function oauthVaultKey(provider: string): string {
 }
 
 export interface AISettings {
-  provider: 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'openai-compatible';
+  provider: 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'openai-compatible' | 'lm-studio';
   openaiApiKey: string;
   anthropicApiKey: string;
   geminiApiKey: string;
@@ -59,6 +60,9 @@ export interface AISettings {
   openaiCompatibleBaseUrl: string;
   openaiCompatibleApiKey: string;
   openaiCompatibleModel: string;
+  lmStudioBaseUrl: string;
+  lmStudioModel: string;
+  lmStudioApiKey: string;
 }
 
 export type HyperKeySourceKey =
@@ -186,6 +190,9 @@ const DEFAULT_AI_SETTINGS: AISettings = {
   openaiCompatibleBaseUrl: '',
   openaiCompatibleApiKey: '',
   openaiCompatibleModel: '',
+  lmStudioBaseUrl: 'http://127.0.0.1:1234/v1',
+  lmStudioModel: '',
+  lmStudioApiKey: '',
 };
 
 const DEFAULT_SETTINGS: AppSettings = {

--- a/src/renderer/src/i18n/locales/de.json
+++ b/src/renderer/src/i18n/locales/de.json
@@ -205,6 +205,7 @@
           "anthropic": "Anthropic",
           "ollama": "Ollama (lokal)",
           "gemini": "Gemini",
+          "lmStudio": "LM Studio",
           "openaiCompatible": "Benutzerdefiniert (OpenAI-kompatibel)"
         },
         "model": {
@@ -277,6 +278,17 @@
         "defaultModel": {
           "label": "Standardmodell",
           "auto": "Automatisch (Provider-Standard)"
+        },
+        "lmStudio": {
+          "baseUrl": {
+            "label": "Server-URL",
+            "hint": "Lokale Server-URL von LM Studio (Standard: http://127.0.0.1:1234/v1)"
+          },
+          "apiKey": {
+            "toggle": "Optionaler API-Schlüssel",
+            "placeholder": "Leer lassen, wenn nicht benötigt",
+            "hint": "Nur erforderlich, wenn Sie in LM Studio eine Authentifizierung konfiguriert haben."
+          }
         }
       },
       "whisper": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -260,6 +260,7 @@
           "anthropic": "Claude",
           "gemini": "Gemini",
           "ollama": "Ollama",
+          "lmStudio": "LM Studio",
           "openaiCompatible": "Custom (OpenAI-compatible)"
         },
         "providerDescriptions": {
@@ -267,6 +268,7 @@
           "anthropic": "Anthropic Claude models",
           "gemini": "Google Gemini models",
           "ollama": "Local models",
+          "lmStudio": "Local models via LM Studio",
           "openaiCompatible": "Any OpenAI-compatible API (OpenRouter, Together, etc.)"
         },
         "ollama": {
@@ -299,6 +301,17 @@
             "gemma2": "Google open model (9B)",
             "qwen25": "Alibaba multilingual model (7B)",
             "deepseekR1": "Reasoning-focused model (7B)"
+          }
+        },
+        "lmStudio": {
+          "baseUrl": {
+            "label": "Server URL",
+            "hint": "LM Studio's local server URL (default: http://127.0.0.1:1234/v1)"
+          },
+          "apiKey": {
+            "toggle": "Optional API Key",
+            "placeholder": "Leave empty if not required",
+            "hint": "Only needed if you have configured authentication in LM Studio."
           }
         },
         "openaiCompatible": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -205,6 +205,7 @@
           "anthropic": "Anthropic",
           "ollama": "Ollama (local)",
           "gemini": "Gemini",
+          "lmStudio": "LM Studio",
           "openaiCompatible": "Personalizado (compatible con OpenAI)"
         },
         "model": {
@@ -277,6 +278,17 @@
         "defaultModel": {
           "label": "Modelo predeterminado",
           "auto": "Auto (predeterminado del proveedor)"
+        },
+        "lmStudio": {
+          "baseUrl": {
+            "label": "URL del servidor",
+            "hint": "URL del servidor local de LM Studio (predeterminado: http://127.0.0.1:1234/v1)"
+          },
+          "apiKey": {
+            "toggle": "Clave API opcional",
+            "placeholder": "Dejar vacío si no es necesario",
+            "hint": "Solo es necesario si has configurado autenticación en LM Studio."
+          }
         }
       },
       "whisper": {

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -205,6 +205,7 @@
           "anthropic": "Anthropic",
           "ollama": "Ollama (local)",
           "gemini": "Gemini",
+          "lmStudio": "LM Studio",
           "openaiCompatible": "Personnalise (compatible OpenAI)"
         },
         "model": {
@@ -277,6 +278,17 @@
         "defaultModel": {
           "label": "Modele par defaut",
           "auto": "Auto (par defaut du fournisseur)"
+        },
+        "lmStudio": {
+          "baseUrl": {
+            "label": "URL du serveur",
+            "hint": "URL du serveur local LM Studio (par défaut : http://127.0.0.1:1234/v1)"
+          },
+          "apiKey": {
+            "toggle": "Clé API optionnelle",
+            "placeholder": "Laisser vide si non requis",
+            "hint": "Nécessaire uniquement si vous avez configuré l'authentification dans LM Studio."
+          }
         }
       },
       "whisper": {

--- a/src/renderer/src/i18n/locales/it.json
+++ b/src/renderer/src/i18n/locales/it.json
@@ -259,6 +259,7 @@
           "anthropic": "Claude",
           "gemini": "Gemini",
           "ollama": "Ollama",
+          "lmStudio": "LM Studio",
           "openaiCompatible": "Personalizzato (compatibile OpenAI)"
         },
         "providerDescriptions": {
@@ -266,7 +267,8 @@
           "anthropic": "Modelli Anthropic Claude",
           "gemini": "Modelli Google Gemini",
           "ollama": "Modelli locali",
-          "openaiCompatible": "Qualsiasi API compatibile OpenAI (OpenRouter, Together, ecc.)"
+          "openaiCompatible": "Qualsiasi API compatibile OpenAI (OpenRouter, Together, ecc.)",
+          "lmStudio": "Modelli locali tramite LM Studio"
         },
         "ollama": {
           "serverUrl": {
@@ -319,6 +321,17 @@
         "defaultModel": {
           "label": "Modello predefinito",
           "auto": "Automatico (predefinito del provider)"
+        },
+        "lmStudio": {
+          "baseUrl": {
+            "label": "URL del server",
+            "hint": "URL del server locale di LM Studio (predefinito: http://127.0.0.1:1234/v1)"
+          },
+          "apiKey": {
+            "toggle": "Chiave API opzionale",
+            "placeholder": "Lascia vuoto se non richiesto",
+            "hint": "Necessario solo se hai configurato l'autenticazione in LM Studio."
+          }
         }
       },
       "whisper": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -260,6 +260,7 @@
           "anthropic": "Claude",
           "gemini": "Gemini",
           "ollama": "Ollama",
+          "lmStudio": "LM Studio",
           "openaiCompatible": "カスタム（OpenAI 互換）"
         },
         "providerDescriptions": {
@@ -267,7 +268,8 @@
           "anthropic": "Anthropic Claude モデル",
           "gemini": "Google Gemini モデル",
           "ollama": "ローカルモデル",
-          "openaiCompatible": "任意の OpenAI 互換 API（OpenRouter、Together など）"
+          "openaiCompatible": "任意の OpenAI 互換 API（OpenRouter、Together など）",
+          "lmStudio": "LM Studio でローカルモデルを使用"
         },
         "ollama": {
           "serverUrl": {
@@ -320,6 +322,17 @@
         "defaultModel": {
           "label": "デフォルトモデル",
           "auto": "自動（プロバイダのデフォルト）"
+        },
+        "lmStudio": {
+          "baseUrl": {
+            "label": "サーバー URL",
+            "hint": "LM Studio のローカルサーバー URL（デフォルト：http://127.0.0.1:1234/v1）"
+          },
+          "apiKey": {
+            "toggle": "オプションのAPIキー",
+            "placeholder": "不要な場合は空白のままにしてください",
+            "hint": "LM Studioで認証を設定している場合のみ必要です。"
+          }
         }
       },
       "whisper": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -260,6 +260,7 @@
           "anthropic": "Claude",
           "gemini": "Gemini",
           "ollama": "Ollama",
+          "lmStudio": "LM Studio",
           "openaiCompatible": "사용자 지정(OpenAI 호환)"
         },
         "providerDescriptions": {
@@ -267,7 +268,8 @@
           "anthropic": "Claude 계열 모델",
           "gemini": "Google Gemini 모델",
           "ollama": "로컬 모델",
-          "openaiCompatible": "모든 OpenAI 호환 API(OpenRouter, Together 등)"
+          "openaiCompatible": "모든 OpenAI 호환 API(OpenRouter, Together 등)",
+          "lmStudio": "LM Studio를 통한 로컬 모델"
         },
         "ollama": {
           "serverUrl": {
@@ -320,6 +322,17 @@
         "defaultModel": {
           "label": "기본 모델",
           "auto": "자동(제공자 기본값)"
+        },
+        "lmStudio": {
+          "baseUrl": {
+            "label": "서버 URL",
+            "hint": "LM Studio 로컬 서버 URL（기본값：http://127.0.0.1:1234/v1）"
+          },
+          "apiKey": {
+            "toggle": "선택적 API 키",
+            "placeholder": "필요하지 않으면 비워두세요",
+            "hint": "LM Studio에서 인증을 구성한 경우에만 필요합니다."
+          }
         }
       },
       "whisper": {

--- a/src/renderer/src/i18n/locales/zh-Hans.json
+++ b/src/renderer/src/i18n/locales/zh-Hans.json
@@ -260,6 +260,7 @@
           "anthropic": "Claude",
           "gemini": "Gemini",
           "ollama": "Ollama",
+          "lmStudio": "LM Studio",
           "openaiCompatible": "自定义 (OpenAI 兼容)"
         },
         "providerDescriptions": {
@@ -267,7 +268,8 @@
           "anthropic": "Anthropic Claude 模型",
           "gemini": "Google Gemini 模型",
           "ollama": "本地模型",
-          "openaiCompatible": "任意 OpenAI 兼容 API（OpenRouter、Together 等）"
+          "openaiCompatible": "任意 OpenAI 兼容 API（OpenRouter、Together 等）",
+          "lmStudio": "通过 LM Studio 使用本地模型"
         },
         "ollama": {
           "serverUrl": {
@@ -320,6 +322,17 @@
         "defaultModel": {
           "label": "默认模型",
           "auto": "自动（提供商默认）"
+        },
+        "lmStudio": {
+          "baseUrl": {
+            "label": "服务器地址",
+            "hint": "LM Studio 本地服务器地址（默认：http://127.0.0.1:1234/v1）"
+          },
+          "apiKey": {
+            "toggle": "可选 API 密钥",
+            "placeholder": "如不需要，请留空",
+            "hint": "仅当您在 LM Studio 中配置了身份验证时才需要。"
+          }
         }
       },
       "whisper": {

--- a/src/renderer/src/i18n/locales/zh-Hant.json
+++ b/src/renderer/src/i18n/locales/zh-Hant.json
@@ -243,6 +243,7 @@
           "anthropic": "Claude",
           "gemini": "Gemini",
           "ollama": "Ollama",
+          "lmStudio": "LM Studio",
           "openaiCompatible": "自訂 (OpenAI 相容)"
         },
         "ollama": {
@@ -302,7 +303,19 @@
           "anthropic": "Anthropic Claude 模型",
           "gemini": "Google Gemini 模型",
           "ollama": "本地模型",
-          "openaiCompatible": "任何 OpenAI 相容 API（OpenRouter、Together 等）"
+          "openaiCompatible": "任何 OpenAI 相容 API（OpenRouter、Together 等）",
+          "lmStudio": "透過 LM Studio 使用本地模型"
+        },
+        "lmStudio": {
+          "baseUrl": {
+            "label": "伺服器網址",
+            "hint": "LM Studio 本地伺服器網址（預設：http://127.0.0.1:1234/v1）"
+          },
+          "apiKey": {
+            "toggle": "可選 API 金鑰",
+            "placeholder": "如不需要，請留空",
+            "hint": "僅當您在 LM Studio 中設定了驗證時才需要。"
+          }
         }
       },
       "whisper": {

--- a/src/renderer/src/settings/AITab.tsx
+++ b/src/renderer/src/settings/AITab.tsx
@@ -44,6 +44,7 @@ const getProviderOptions = (t: (key: string) => string) => [
   { id: 'anthropic' as const, label: t('settings.ai.llm.provider.anthropic'), description: t('settings.ai.llm.providerDescriptions.anthropic') },
   { id: 'gemini' as const, label: t('settings.ai.llm.provider.gemini'), description: t('settings.ai.llm.providerDescriptions.gemini') },
   { id: 'ollama' as const, label: t('settings.ai.llm.provider.ollama'), description: t('settings.ai.llm.providerDescriptions.ollama') },
+  { id: 'lm-studio' as const, label: t('settings.ai.llm.provider.lmStudio'), description: t('settings.ai.llm.providerDescriptions.lmStudio') },
   { id: 'openai-compatible' as const, label: t('settings.ai.llm.provider.openaiCompatible'), description: t('settings.ai.llm.providerDescriptions.openaiCompatible') },
 ];
 
@@ -244,6 +245,10 @@ const AITab: React.FC = () => {
   const [showMistralKey, setShowMistralKey] = useState(false);
   const [showSupermemoryKey, setShowSupermemoryKey] = useState(false);
   const [showOpenAICompatibleKey, setShowOpenAICompatibleKey] = useState(false);
+  const [showLmStudioApiKey, setShowLmStudioApiKey] = useState(false);
+  const [lmStudioShowApiKey, setLmStudioShowApiKey] = useState(false);
+  const [lmStudioModels, setLmStudioModels] = useState<string[]>([]);
+  const lmStudioFetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saved'>('idle');
   const [hotkeyStatus, setHotkeyStatus] = useState<{
     type: 'idle' | 'success' | 'error';
@@ -279,6 +284,27 @@ const AITab: React.FC = () => {
   useEffect(() => {
     settingsRef.current = settings;
   }, [settings]);
+
+  const fetchLmStudioModels = useCallback((baseUrl: string) => {
+    if (lmStudioFetchTimerRef.current) clearTimeout(lmStudioFetchTimerRef.current);
+    lmStudioFetchTimerRef.current = setTimeout(() => {
+      const url = baseUrl.trim().replace(/\/+$/, '');
+      const modelsUrl = url.endsWith('/v1') ? `${url}/models` : `${url}/v1/models`;
+      fetch(modelsUrl)
+        .then((r) => r.json())
+        .then((json) => {
+          const ids: string[] = (json?.data ?? []).map((m: { id: string }) => m.id).filter(Boolean);
+          setLmStudioModels(ids);
+        })
+        .catch(() => setLmStudioModels([]));
+    }, 300);
+  }, []);
+
+  useEffect(() => {
+    if (settings?.ai?.provider === 'lm-studio') {
+      fetchLmStudioModels(settings.ai.lmStudioBaseUrl || 'http://127.0.0.1:1234/v1');
+    }
+  }, [settings?.ai?.provider, settings?.ai?.lmStudioBaseUrl, fetchLmStudioModels]);
 
   useEffect(() => {
     let cancelled = false;
@@ -639,7 +665,9 @@ const AITab: React.FC = () => {
           id: `openai-compatible-${ai.openaiCompatibleModel}`,
           label: ai.openaiCompatibleModel,
         }]
-      : MODELS_BY_PROVIDER[ai.provider] || [];
+      : ai.provider === 'lm-studio'
+        ? lmStudioModels.map((id) => ({ id: `lm-studio-${id}`, label: id }))
+        : MODELS_BY_PROVIDER[ai.provider] || [];
 
   const whisperModelValue = (!ai.speechToTextModel || ai.speechToTextModel === 'default')
     ? 'whispercpp'
@@ -1009,6 +1037,10 @@ const AITab: React.FC = () => {
                             updateAI({ provider: p.id, defaultModel: nextDefault });
                             return;
                           }
+                          if (p.id === 'lm-studio') {
+                            updateAI({ provider: p.id, defaultModel: '' });
+                            return;
+                          }
                           updateAI({ provider: p.id, defaultModel: '' });
                         }}
                         className={`rounded-md border px-2 py-2 text-left transition-colors ${
@@ -1034,6 +1066,58 @@ const AITab: React.FC = () => {
                       placeholder="http://localhost:11434"
                       className="sc-input"
                     />
+                  </div>
+                )}
+
+                {ai.provider === 'lm-studio' && (
+                  <div className="space-y-3">
+                    <div>
+                      <label className="text-[0.75rem] text-[var(--text-muted)] mb-1 block">{t('settings.ai.llm.lmStudio.baseUrl.label')}</label>
+                      <input
+                        type="text"
+                        value={ai.lmStudioBaseUrl}
+                        onChange={(e) => {
+                          const url = e.target.value.trim();
+                          updateAI({ lmStudioBaseUrl: url });
+                          fetchLmStudioModels(url || 'http://127.0.0.1:1234/v1');
+                        }}
+                        placeholder="http://127.0.0.1:1234/v1"
+                        className="sc-input"
+                      />
+                      <p className="text-[0.625rem] text-[var(--text-subtle)] mt-1">{t('settings.ai.llm.lmStudio.baseUrl.hint')}</p>
+                    </div>
+
+                    <div>
+                      <button
+                        type="button"
+                        className="text-[0.75rem] text-[var(--text-muted)] flex items-center gap-1 hover:text-[var(--text-default)] transition-colors"
+                        onClick={() => setShowLmStudioApiKey((v) => !v)}
+                      >
+                        {showLmStudioApiKey ? <EyeOff size={12} /> : <Eye size={12} />}
+                        {t('settings.ai.llm.lmStudio.apiKey.toggle')}
+                      </button>
+                      {showLmStudioApiKey && (
+                        <div className="mt-2">
+                          <div className="relative">
+                            <input
+                              type={lmStudioShowApiKey ? 'text' : 'password'}
+                              value={ai.lmStudioApiKey ?? ''}
+                              onChange={(e) => updateAI({ lmStudioApiKey: e.target.value })}
+                              placeholder={t('settings.ai.llm.lmStudio.apiKey.placeholder')}
+                              className="sc-input pr-8"
+                            />
+                            <button
+                              type="button"
+                              onClick={() => setLmStudioShowApiKey((v) => !v)}
+                              className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-default)]"
+                            >
+                              {lmStudioShowApiKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                            </button>
+                          </div>
+                          <p className="text-[0.625rem] text-[var(--text-subtle)] mt-1">{t('settings.ai.llm.lmStudio.apiKey.hint')}</p>
+                        </div>
+                      )}
+                    </div>
                   </div>
                 )}
 
@@ -1077,7 +1161,7 @@ const AITab: React.FC = () => {
                         value={ai.openaiCompatibleModel}
                         onChange={(e) => {
                           const modelName = e.target.value.trim();
-                          updateAI({ 
+                          updateAI({
                             openaiCompatibleModel: modelName,
                             defaultModel: modelName ? `openai-compatible-${modelName}` : ''
                           });

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -159,7 +159,7 @@ export interface ExtensionBundle {
 }
 
 export interface AISettings {
-  provider: 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'openai-compatible';
+  provider: 'openai' | 'anthropic' | 'gemini' | 'ollama' | 'lm-studio' | 'openai-compatible';
   openaiApiKey: string;
   anthropicApiKey: string;
   geminiApiKey: string;
@@ -185,6 +185,9 @@ export interface AISettings {
   openaiCompatibleBaseUrl: string;
   openaiCompatibleApiKey: string;
   openaiCompatibleModel: string;
+  lmStudioBaseUrl: string;
+  lmStudioModel: string;
+  lmStudioApiKey: string;
 }
 
 export interface EdgeTtsVoice {


### PR DESCRIPTION
Adding support for LM Studio as a provider:
- Selectable "LM Studio" in the LLM config page (next to Ollama, Custom OpenAI compatible, etc.)
- Ability to set a server base URL (defaults to local LM Studio at `http://127.0.0.1:1234/v1`)
- Ability to set an optional API Key (by default hidden as LM Studio usually doesn't require an API Key) 
- Ability to choose a model (fetches a list from LM Studio) or when using Auto it uses the currently loaded model (if none is loaded it auto-loads the last used model)

I also added translations for: German, English, Spanish, French, Italian, Japanese, Korean, Chinese (Simplified & Traditional)

Closes #173

<img width="1191" height="752" alt="image" src="https://github.com/user-attachments/assets/67112f04-4fb4-4ce1-b25b-30f23ef6bd1a" />