### PR TITLE
fix: prevent flash of unfiltered list when pressing Enter to open app

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2333,9 +2333,10 @@ const App: React.FC = () => {
       const ok = await browserSearch.executeBrowserSearch(trimmed);
       if (ok) {
         setBrowserSearchSkipAutoComplete(false);
-        try { await window.electron.hideWindow(); } catch {}
-        setSearchQuery('');
-        setSelectedIndex(0);
+        try { window.electron.hideWindow(); } catch {}
+        // Don't clear searchQuery/selectedIndex — onWindowShown resets them
+        // when the window reopens. Clearing now causes a flash of the
+        // unfiltered list during the fade-out animation.
       }
       return ok;
     },
@@ -2836,10 +2837,9 @@ const App: React.FC = () => {
         await fetchCommands();
       } else if (!options?.background) {
         await window.electron.hideWindow();
-        // Clear search after hide to prevent a flash of the
-        // unfiltered command list while the window fades out.
-        setSearchQuery('');
-        setSelectedIndex(0);
+        // Don't clear searchQuery/selectedIndex — onWindowShown resets them
+        // when the window reopens. Clearing now causes a flash of the
+        // unfiltered list during the fade-out animation.
       }
 
       if (!options?.background && !options?.skipRecent) {
@@ -2888,8 +2888,8 @@ const App: React.FC = () => {
             setQuickLinkDynamicPrompt(null);
             await updateRecentCommands(command.id);
             await window.electron.hideWindow();
-            setSearchQuery('');
-            setSelectedIndex(0);
+            // Don't clear searchQuery/selectedIndex — onWindowShown resets
+            // them on reopen; clearing now causes a flash during fade-out.
             return true;
           }
           setShowActions(false);
@@ -2918,8 +2918,8 @@ const App: React.FC = () => {
       setQuickLinkDynamicPrompt(null);
       await updateRecentCommands(command.id);
       await window.electron.hideWindow();
-      setSearchQuery('');
-      setSelectedIndex(0);
+      // Don't clear searchQuery/selectedIndex — onWindowShown resets
+      // them on reopen; clearing now causes a flash during fade-out.
       return true;
     },
     [
@@ -3026,8 +3026,8 @@ const App: React.FC = () => {
       const filePath = getFileResultPathFromCommand(command);
       if (filePath) {
         await openFileResultByPath(filePath);
-        setSearchQuery('');
-        setSelectedIndex(0);
+        // openFileResultByPath already calls hideWindow(); don't clear
+        // searchQuery/selectedIndex here — onWindowShown resets them.
         return;
       }
 
@@ -3084,11 +3084,9 @@ const App: React.FC = () => {
             } else {
               upsertMenuBarExtension(hydratedWithInlineArguments);
             }
-            // Hide the window before clearing search to avoid a flash of
-            // the unfiltered list while the window fades out.
-            try { await window.electron.hideWindow(); } catch {}
-            setSearchQuery('');
-            setSelectedIndex(0);
+            try { window.electron.hideWindow(); } catch {}
+            // Don't clear searchQuery/selectedIndex — onWindowShown resets
+            // them on reopen; clearing now causes a flash during fade-out.
             await updateRecentCommands(command.id);
             return;
           }
@@ -3154,9 +3152,9 @@ const App: React.FC = () => {
           const confirmed = await window.electron.executeCommand(command.id);
           if (!confirmed) return;
           await updateRecentCommands(command.id);
-          try { await window.electron.hideWindow(); } catch {}
-          setSearchQuery('');
-          setSelectedIndex(0);
+          try { window.electron.hideWindow(); } catch {}
+          // Don't clear searchQuery/selectedIndex — onWindowShown resets
+          // them on reopen; clearing now causes a flash during fade-out.
           return;
         }
         const ok = window.confirm(`Run "${command.title}"?`);
@@ -3165,13 +3163,10 @@ const App: React.FC = () => {
 
       await window.electron.executeCommand(command.id);
       await updateRecentCommands(command.id);
-      // Hide the window before clearing the search query to prevent a
-      // brief flash of the unfiltered command list. The main process
-      // also schedules hideWindow() with a 50ms delay, but React
-      // re-renders with the cleared search before that timer fires.
-      try { await window.electron.hideWindow(); } catch {}
-      setSearchQuery('');
-      setSelectedIndex(0);
+      try { window.electron.hideWindow(); } catch {}
+      // Don't clear searchQuery/selectedIndex — onWindowShown resets them
+      // on reopen. Clearing now causes a flash of the unfiltered list
+      // during the window's fade-out animation.
     } catch (error) {
       console.error('Failed to execute command:', error);
     }
@@ -3763,10 +3758,8 @@ const App: React.FC = () => {
             upsertMenuBarExtension(updatedBundle);
           }
           window.electron.hideWindow();
-          // Don't clear searchQuery here — onWindowShown resets it.
-          // Clearing before the window is visually hidden causes a flash
-          // of the unfiltered list.
-          setSelectedIndex(0);
+          // Don't clear searchQuery/selectedIndex — onWindowShown resets
+          // them on reopen; clearing now causes a flash during fade-out.
           localStorage.removeItem(LAST_EXT_KEY);
         }}
         setExtensionPreferenceSetup={setExtensionPreferenceSetup}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2334,9 +2334,6 @@ const App: React.FC = () => {
       if (ok) {
         setBrowserSearchSkipAutoComplete(false);
         try { window.electron.hideWindow(); } catch {}
-        // Don't clear searchQuery/selectedIndex — onWindowShown resets them
-        // when the window reopens. Clearing now causes a flash of the
-        // unfiltered list during the fade-out animation.
       }
       return ok;
     },
@@ -2837,9 +2834,6 @@ const App: React.FC = () => {
         await fetchCommands();
       } else if (!options?.background) {
         await window.electron.hideWindow();
-        // Don't clear searchQuery/selectedIndex — onWindowShown resets them
-        // when the window reopens. Clearing now causes a flash of the
-        // unfiltered list during the fade-out animation.
       }
 
       if (!options?.background && !options?.skipRecent) {
@@ -2888,8 +2882,6 @@ const App: React.FC = () => {
             setQuickLinkDynamicPrompt(null);
             await updateRecentCommands(command.id);
             await window.electron.hideWindow();
-            // Don't clear searchQuery/selectedIndex — onWindowShown resets
-            // them on reopen; clearing now causes a flash during fade-out.
             return true;
           }
           setShowActions(false);
@@ -2918,8 +2910,6 @@ const App: React.FC = () => {
       setQuickLinkDynamicPrompt(null);
       await updateRecentCommands(command.id);
       await window.electron.hideWindow();
-      // Don't clear searchQuery/selectedIndex — onWindowShown resets
-      // them on reopen; clearing now causes a flash during fade-out.
       return true;
     },
     [
@@ -3026,8 +3016,6 @@ const App: React.FC = () => {
       const filePath = getFileResultPathFromCommand(command);
       if (filePath) {
         await openFileResultByPath(filePath);
-        // openFileResultByPath already calls hideWindow(); don't clear
-        // searchQuery/selectedIndex here — onWindowShown resets them.
         return;
       }
 
@@ -3085,8 +3073,6 @@ const App: React.FC = () => {
               upsertMenuBarExtension(hydratedWithInlineArguments);
             }
             try { window.electron.hideWindow(); } catch {}
-            // Don't clear searchQuery/selectedIndex — onWindowShown resets
-            // them on reopen; clearing now causes a flash during fade-out.
             await updateRecentCommands(command.id);
             return;
           }
@@ -3153,8 +3139,6 @@ const App: React.FC = () => {
           if (!confirmed) return;
           await updateRecentCommands(command.id);
           try { window.electron.hideWindow(); } catch {}
-          // Don't clear searchQuery/selectedIndex — onWindowShown resets
-          // them on reopen; clearing now causes a flash during fade-out.
           return;
         }
         const ok = window.confirm(`Run "${command.title}"?`);
@@ -3164,9 +3148,6 @@ const App: React.FC = () => {
       await window.electron.executeCommand(command.id);
       await updateRecentCommands(command.id);
       try { window.electron.hideWindow(); } catch {}
-      // Don't clear searchQuery/selectedIndex — onWindowShown resets them
-      // on reopen. Clearing now causes a flash of the unfiltered list
-      // during the window's fade-out animation.
     } catch (error) {
       console.error('Failed to execute command:', error);
     }
@@ -3758,8 +3739,6 @@ const App: React.FC = () => {
             upsertMenuBarExtension(updatedBundle);
           }
           window.electron.hideWindow();
-          // Don't clear searchQuery/selectedIndex — onWindowShown resets
-          // them on reopen; clearing now causes a flash during fade-out.
           localStorage.removeItem(LAST_EXT_KEY);
         }}
         setExtensionPreferenceSetup={setExtensionPreferenceSetup}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2332,12 +2332,10 @@ const App: React.FC = () => {
       if (!trimmed) return false;
       const ok = await browserSearch.executeBrowserSearch(trimmed);
       if (ok) {
+        setBrowserSearchSkipAutoComplete(false);
+        try { await window.electron.hideWindow(); } catch {}
         setSearchQuery('');
         setSelectedIndex(0);
-        setBrowserSearchSkipAutoComplete(false);
-        try {
-          window.electron.hideWindow();
-        } catch {}
       }
       return ok;
     },
@@ -2838,6 +2836,8 @@ const App: React.FC = () => {
         await fetchCommands();
       } else if (!options?.background) {
         await window.electron.hideWindow();
+        // Clear search after hide to prevent a flash of the
+        // unfiltered command list while the window fades out.
         setSearchQuery('');
         setSelectedIndex(0);
       }
@@ -2887,9 +2887,9 @@ const App: React.FC = () => {
             clearInlineQuickLinkDynamicValuesForId(quickLinkId);
             setQuickLinkDynamicPrompt(null);
             await updateRecentCommands(command.id);
+            await window.electron.hideWindow();
             setSearchQuery('');
             setSelectedIndex(0);
-            await window.electron.hideWindow();
             return true;
           }
           setShowActions(false);
@@ -2917,9 +2917,9 @@ const App: React.FC = () => {
       clearInlineQuickLinkDynamicValuesForId(quickLinkId);
       setQuickLinkDynamicPrompt(null);
       await updateRecentCommands(command.id);
+      await window.electron.hideWindow();
       setSearchQuery('');
       setSelectedIndex(0);
-      await window.electron.hideWindow();
       return true;
     },
     [
@@ -3084,7 +3084,9 @@ const App: React.FC = () => {
             } else {
               upsertMenuBarExtension(hydratedWithInlineArguments);
             }
-            window.electron.hideWindow();
+            // Hide the window before clearing search to avoid a flash of
+            // the unfiltered list while the window fades out.
+            try { await window.electron.hideWindow(); } catch {}
             setSearchQuery('');
             setSelectedIndex(0);
             await updateRecentCommands(command.id);
@@ -3151,6 +3153,7 @@ const App: React.FC = () => {
         ) {
           await window.electron.executeCommand(command.id);
           await updateRecentCommands(command.id);
+          try { await window.electron.hideWindow(); } catch {}
           setSearchQuery('');
           setSelectedIndex(0);
           return;
@@ -3161,6 +3164,11 @@ const App: React.FC = () => {
 
       await window.electron.executeCommand(command.id);
       await updateRecentCommands(command.id);
+      // Hide the window before clearing the search query to prevent a
+      // brief flash of the unfiltered command list. The main process
+      // also schedules hideWindow() with a 50ms delay, but React
+      // re-renders with the cleared search before that timer fires.
+      try { await window.electron.hideWindow(); } catch {}
       setSearchQuery('');
       setSelectedIndex(0);
     } catch (error) {
@@ -3754,7 +3762,9 @@ const App: React.FC = () => {
             upsertMenuBarExtension(updatedBundle);
           }
           window.electron.hideWindow();
-          setSearchQuery('');
+          // Don't clear searchQuery here — onWindowShown resets it.
+          // Clearing before the window is visually hidden causes a flash
+          // of the unfiltered list.
           setSelectedIndex(0);
           localStorage.removeItem(LAST_EXT_KEY);
         }}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3151,7 +3151,8 @@ const App: React.FC = () => {
           command.id === 'system-restart' ||
           command.id === 'system-logout'
         ) {
-          await window.electron.executeCommand(command.id);
+          const confirmed = await window.electron.executeCommand(command.id);
+          if (!confirmed) return;
           await updateRecentCommands(command.id);
           try { await window.electron.hideWindow(); } catch {}
           setSearchQuery('');

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -773,6 +773,8 @@ const App: React.FC = () => {
   useEffect(() => {
     const cleanupWindowHidden = window.electron.onWindowHidden(() => {
       lastWindowHiddenAtRef.current = Date.now();
+      setSearchQuery('');
+      setSelectedIndex(0);
     });
     return cleanupWindowHidden;
   }, []);
@@ -838,8 +840,6 @@ const App: React.FC = () => {
         setScriptCommandOutput(null);
         setExtensionView(null);
         localStorage.removeItem(LAST_EXT_KEY);
-        setSearchQuery('');
-        setSelectedIndex(0);
         exitAiMode();
         if (!isOnboardingMode) {
           expandLauncherForDirectLaunch();
@@ -933,8 +933,6 @@ const App: React.FC = () => {
         setMemoryFeedback(null);
         setMemoryActionLoading(false);
         setSelectedTextSnapshot(String(payload?.selectedTextSnapshot || '').trim());
-        setSearchQuery('');
-        setSelectedIndex(0);
         exitAiMode();
         expandLauncherForDirectLaunch();
         return;
@@ -984,10 +982,10 @@ const App: React.FC = () => {
       const pendingQuery = pendingWindowShownQueryRef.current;
       pendingWindowShownQueryRef.current = null;
       if (pendingQuery) {
+        setSearchQuery(pendingQuery);
+        setSelectedIndex(0);
         pendingFocusInlineArgRef.current = true;
       }
-      setSearchQuery(pendingQuery ?? '');
-      setSelectedIndex(0);
       // When a pending query is pre-filled (e.g. hotkey-triggered no-view
       // command with missing args), expand out of compact so results are
       // immediately visible.


### PR DESCRIPTION
## Summary

Fixes a visible flash of the default (unfiltered) command list that appears when pressing Enter to open an application from search, and the corresponding flash of stale search results when reopening the launcher.

Closes #370

## Problem

Two related flash issues:

**On close:** When pressing Enter on a search result, the renderer clears `searchQuery` after the IPC call returns, triggering a React re-render of the unfiltered list while the window is still visible (the main process hides it on a 50ms delay).

**On reopen:** If the search state is *not* cleared before hiding, the filtered list persists while the window is hidden — and when the window reopens, `onWindowShown` resets the search, causing a flash of the old filtered state before it clears.

### Before:

https://github.com/user-attachments/assets/42c2263d-3094-4c25-99a8-4c17d0700fed

### After:

https://github.com/user-attachments/assets/1736bb5d-b0df-447f-806f-d76fc5c925fc


## Fix

Clear the search state (`searchQuery` and `selectedIndex`) in the `window-hidden` handler instead. The window is already invisible at that point, so the React re-render happens offscreen — no flash on close. When the window reopens, the state is already empty — no flash on open.

In `onWindowShown`, search state is only set when there is a `pendingQuery` (pre-filled search for hotkey-triggered commands with missing args). The redundant `setSearchQuery("")` / `setSelectedIndex(0)` calls throughout the hide-and-clear code paths are removed entirely.

Additionally, the return value of `executeCommand()` is now checked for system commands with native confirmation dialogs (`system-close-all-apps`, `system-restart`, `system-logout`) — if the user cancels, the launcher stays open.

### Changes in `App.tsx`

| Change | Details |
|--------|---------|
| `onWindowHidden` handler | Added `setSearchQuery("")` and `setSelectedIndex(0)` — clears state while window is invisible |
| `onWindowShown` handler | Removed unconditional `setSearchQuery("")` / `setSelectedIndex(0)` from routed system command, direct-launch guard, and default reopen paths; only sets search when `pendingQuery` is present |
| `handleCommandExecute` — generic app commands | Removed `setSearchQuery("")` / `setSelectedIndex(0)` after `hideWindow()` |
| `handleCommandExecute` — system commands with confirmation | Check `executeCommand()` return value; removed redundant search clear |
| `handleCommandExecute` — menu-bar extension toggle | Removed `setSearchQuery("")` / `setSelectedIndex(0)` after `hideWindow()` |
| `handleCommandExecute` — file result path | Removed `setSearchQuery("")` / `setSelectedIndex(0)` (already calls `hideWindow()` via `openFileResultByPath`) |
| `submitBrowserSearch` | Removed `setSearchQuery("")` / `setSelectedIndex(0)` after `hideWindow()` |
| `executeQuickLinkCommand` (×2) | Removed `setSearchQuery("")` / `setSelectedIndex(0)` after `hideWindow()` |
| `runScriptCommand` — hidden result mode | Removed `setSearchQuery("")` / `setSelectedIndex(0)` after `hideWindow()` |
| `ExtensionPreferenceSetupView` save callback | Removed `setSearchQuery("")` and `setSelectedIndex(0)` |

## Testing

- Search for an application, press Enter → no flash, window hides cleanly
- Reopen launcher → no flash, empty search shown immediately
- Browser search (Tab → Enter) → no flash on close or reopen
- Quick link execution → no flash
- Menu-bar extension toggle → no flash
- Script command with inline result → no flash
- Cancel native confirmation dialog (e.g. Restart) → launcher stays open
- Hotkey-triggered command with missing args → reopens with pre-filled search