### PR TITLE
fix(clipboard): use privileged sc-clipboard protocol for image previews in dev mode

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12227,6 +12227,17 @@ protocol.registerSchemesAsPrivileged([
       stream: true,
     },
   },
+  {
+    scheme: 'sc-clipboard',
+    privileges: {
+      standard: true,
+      secure: true,
+      corsEnabled: true,
+      bypassCSP: true,
+      supportFetchAPI: true,
+      stream: true,
+    },
+  },
 ]);
 
 app.whenReady().then(async () => {
@@ -12325,6 +12336,27 @@ app.whenReady().then(async () => {
 
       const { pathToFileURL } = require('url');
       // Convert via pathToFileURL so spaces/special chars are encoded correctly.
+      return net.fetch(pathToFileURL(filePath).toString());
+    } catch {
+      return new Response('Bad Request', { status: 400 });
+    }
+  });
+
+  // Register the sc-clipboard:// protocol handler to serve clipboard image
+  // files. In development the renderer is on http://localhost, so raw file://
+  // URLs are blocked by webSecurity. sc-clipboard:// is privileged and works
+  // from any origin.
+  protocol.handle('sc-clipboard', (request: any) => {
+    try {
+      const url = new URL(request.url);
+      let filePath = decodeURIComponent(url.pathname || '');
+      if (process.platform === 'win32' && /^\/[a-zA-Z]:/.test(filePath)) {
+        filePath = filePath.slice(1);
+      }
+      if (!filePath) {
+        return new Response('Bad Request', { status: 400 });
+      }
+      const { pathToFileURL } = require('url');
       return net.fetch(pathToFileURL(filePath).toString());
     } catch {
       return new Response('Bad Request', { status: 400 });

--- a/src/renderer/src/ClipboardManager.tsx
+++ b/src/renderer/src/ClipboardManager.tsx
@@ -16,10 +16,11 @@ interface ClipboardManagerProps {
   onClose: () => void;
 }
 
-function fileUrl(filePath: string): string {
-  // Paths can contain spaces (e.g. /Library/Application Support/...) so use
-  // encodeURI to make a valid file:// URL while leaving path separators alone.
-  return `file://${encodeURI(filePath)}`;
+function clipboardImageUrl(filePath: string): string {
+  // In development the renderer is served on http://localhost, so raw file://
+  // URLs are blocked by webSecurity. sc-clipboard:// is a privileged custom
+  // protocol that works from any origin and is handled by the main process.
+  return `sc-clipboard://image${encodeURI(filePath)}`;
 }
 
 interface Action {
@@ -600,7 +601,7 @@ const ClipboardManager: React.FC<ClipboardManagerProps> = ({ onClose }) => {
                     {item.type === 'image' ? (
                       <>
                         <img
-                          src={fileUrl(item.content)}
+                          src={clipboardImageUrl(item.content)}
                           alt="Clipboard"
                           className="w-7 h-7 object-cover rounded flex-shrink-0"
                           onError={(e) => {
@@ -608,7 +609,7 @@ const ClipboardManager: React.FC<ClipboardManagerProps> = ({ onClose }) => {
                             const img = e.currentTarget;
                             if (fallback && img.dataset.fallback !== '1') {
                               img.dataset.fallback = '1';
-                              img.src = fileUrl(fallback);
+                              img.src = clipboardImageUrl(fallback);
                             }
                           }}
                         />
@@ -659,7 +660,7 @@ const ClipboardManager: React.FC<ClipboardManagerProps> = ({ onClose }) => {
               <div className="flex-1 min-h-0 overflow-auto custom-scrollbar p-3.5 flex items-center justify-center">
                 {selectedItem.type === 'image' ? (
                   <img
-                    src={fileUrl(selectedItem.content)}
+                    src={clipboardImageUrl(selectedItem.content)}
                     alt="Clipboard"
                     className="max-w-full max-h-full object-contain"
                     onError={(e) => {
@@ -667,7 +668,7 @@ const ClipboardManager: React.FC<ClipboardManagerProps> = ({ onClose }) => {
                       const img = e.currentTarget;
                       if (fallback && img.dataset.fallback !== '1') {
                         img.dataset.fallback = '1';
-                        img.src = fileUrl(fallback);
+                        img.src = clipboardImageUrl(fallback);
                       }
                     }}
                   />


### PR DESCRIPTION
In development the renderer is served on http://localhost, so raw file:// URLs for clipboard images are blocked by Electron's webSecurity. This PR registers sc-clipboard:// as a privileged custom protocol, adds a main-process handler that serves files via net.fetch(), and switches the ClipboardManager renderer to use it.

| Before | After |
|-|-|
|  <img width="1744" height="1184" alt="image" src="https://github.com/user-attachments/assets/8ca779b0-352b-4fdc-9444-52a594f8ded3" /> | <img width="1744" height="1184" alt="image" src="https://github.com/user-attachments/assets/4c370cba-d3db-4b44-8e1b-849461d4efa8" /> |

Changes:
- Register sc-clipboard in registerSchemesAsPrivileged with standard/secure/cors/bypassCSP/supportFetchAPI/stream flags
- Add protocol handler in app.whenReady that decodes the path, normalises Windows drive letters, and serves via net.fetch()
- Replace fileUrl() with clipboardImageUrl() in ClipboardManager.tsx to generate sc-clipboard:// URLs for image previews