### PR TITLE
fix: correct settings toggle knob alignment for all font sizes

### DIFF
--- a/src/renderer/src/settings/AITab.tsx
+++ b/src/renderer/src/settings/AITab.tsx
@@ -798,10 +798,10 @@ const AITab: React.FC = () => {
       aria-label={label}
     >
       <span
-        className={`absolute left-0.5 top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border shadow-sm transition-transform ${
+        className={`absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border shadow-sm transition-all ${
           enabled
-            ? 'translate-x-[18px] bg-[var(--bg-overlay-strong)] border-[var(--ui-segment-border)]'
-            : 'translate-x-0 bg-[var(--bg-overlay-strong)] border-[var(--ui-segment-border)]'
+            ? 'right-0.5 left-auto bg-[var(--bg-overlay-strong)] border-[var(--ui-segment-border)]'
+            : 'left-0.5 right-auto bg-[var(--bg-overlay-strong)] border-[var(--ui-segment-border)]'
         }`}
       />
     </button>
@@ -825,10 +825,10 @@ const AITab: React.FC = () => {
             }`}
           >
             <span
-              className={`absolute left-0.5 top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border shadow-sm transition-transform ${
+              className={`absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border shadow-sm transition-all ${
                 ai.enabled
-                  ? 'translate-x-[18px] bg-[var(--bg-overlay-strong)] border-[var(--ui-segment-border)]'
-                  : 'translate-x-0 bg-[var(--bg-overlay-strong)] border-[var(--ui-segment-border)]'
+                  ? 'right-0.5 left-auto bg-[var(--bg-overlay-strong)] border-[var(--ui-segment-border)]'
+                  : 'left-0.5 right-auto bg-[var(--bg-overlay-strong)] border-[var(--ui-segment-border)]'
               }`}
             />
           </button>

--- a/src/renderer/src/settings/ExtensionsTab.tsx
+++ b/src/renderer/src/settings/ExtensionsTab.tsx
@@ -2290,8 +2290,8 @@ const EmojiPickerSettingsSection: React.FC<{
           }`}
         >
           <span
-            className={`absolute left-0.5 top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border shadow-sm bg-[var(--bg-overlay-strong)] border-[var(--ui-segment-border)] transition-transform ${
-              enabled ? 'translate-x-[18px]' : 'translate-x-0'
+            className={`absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border shadow-sm bg-[var(--bg-overlay-strong)] border-[var(--ui-segment-border)] transition-all ${
+              enabled ? 'right-0.5 left-auto' : 'left-0.5 right-auto'
             }`}
           />
         </button>


### PR DESCRIPTION
### Problem

Settings toggle sliders (AITab, ExtensionsTab) had a broken "on" position where the knob overshot the pill slightly (in the `small` font size), making it look inconsistent with the "off" position.

| Before | After |
|-|-|
| <img width="202" height="244" alt="image" src="https://github.com/user-attachments/assets/3800d00b-4b3f-45b3-8744-efa3f77bd931" /> |  <img width="192" height="246" alt="image" src="https://github.com/user-attachments/assets/b32f3cb1-a6ec-40d3-9b11-bfb2b20e61a9" /> |

### Root cause

The "off" position used `left-0.5` (0.125rem) but the "on" position used a hardcoded `translate-x-[18px]`. Since the app supports dynamic root font sizes (12–20px), this fixed pixel value did not scale with the pill width, causing misalignment at **different font sizes**.

### Fix

Replaced the asymmetric `left-0.5` / `translate-x-[18px]` approach with a symmetric `left-0.5` ↔ `right-0.5` toggle. This guarantees identical inner padding on both sides at any font size, keeping the knob perfectly flush inside the pill.

### Files changed

- `src/renderer/src/settings/AITab.tsx` (2 toggle instances)
- `src/renderer/src/settings/ExtensionsTab.tsx` (emoji picker toggle)
