### PR TITLE
fix: dismiss internal views after fire-and-forget actions

### DIFF
--- a/src/renderer/src/ClipboardManager.tsx
+++ b/src/renderer/src/ClipboardManager.tsx
@@ -240,6 +240,7 @@ const ClipboardManager: React.FC<ClipboardManagerProps> = ({ onClose }) => {
       // Clear the clipboard manager view so the next window-shown returns
       // to the default command palette instead of re-entering clipboard history.
       onClose();
+      window.electron.hideWindow();
     } catch (e) {
       console.error('Failed to copy item:', e);
     }

--- a/src/renderer/src/ClipboardManager.tsx
+++ b/src/renderer/src/ClipboardManager.tsx
@@ -225,6 +225,9 @@ const ClipboardManager: React.FC<ClipboardManagerProps> = ({ onClose }) => {
     try {
       // This copies to clipboard, hides window, and simulates Cmd+V
       await window.electron.clipboardPasteItem(itemToPaste.id);
+      // Clear the clipboard manager view so the next window-shown returns
+      // to the default command palette instead of re-entering clipboard history.
+      onClose();
     } catch (e) {
       console.error('Failed to paste item:', e);
     }
@@ -234,7 +237,9 @@ const ClipboardManager: React.FC<ClipboardManagerProps> = ({ onClose }) => {
     if (!filteredItems[selectedIndex]) return;
     try {
       await window.electron.clipboardCopyItem(filteredItems[selectedIndex].id);
-      window.electron.hideWindow();
+      // Clear the clipboard manager view so the next window-shown returns
+      // to the default command palette instead of re-entering clipboard history.
+      onClose();
     } catch (e) {
       console.error('Failed to copy item:', e);
     }

--- a/src/renderer/src/FileSearchExtension.tsx
+++ b/src/renderer/src/FileSearchExtension.tsx
@@ -475,7 +475,9 @@ const FileSearchExtension: React.FC<FileSearchExtensionProps> = ({ onClose, init
     setOpening(true);
     try {
       await window.electron.execCommand('open', [selectedPath]);
-      await window.electron.hideWindow();
+      // Clear the file search view so the next window-shown returns
+      // to the default command palette instead of re-entering file search.
+      onClose();
     } catch (error) {
       console.error('Failed to open file:', error);
     } finally {
@@ -487,7 +489,9 @@ const FileSearchExtension: React.FC<FileSearchExtensionProps> = ({ onClose, init
     if (!selectedPath) return;
     try {
       await window.electron.execCommand('open', ['-R', selectedPath]);
-      await window.electron.hideWindow();
+      // Clear the file search view so the next window-shown returns
+      // to the default command palette instead of re-entering file search.
+      onClose();
     } catch (error) {
       console.error('Failed to reveal file:', error);
     }

--- a/src/renderer/src/FileSearchExtension.tsx
+++ b/src/renderer/src/FileSearchExtension.tsx
@@ -478,6 +478,7 @@ const FileSearchExtension: React.FC<FileSearchExtensionProps> = ({ onClose, init
       // Clear the file search view so the next window-shown returns
       // to the default command palette instead of re-entering file search.
       onClose();
+      await window.electron.hideWindow();
     } catch (error) {
       console.error('Failed to open file:', error);
     } finally {
@@ -492,6 +493,7 @@ const FileSearchExtension: React.FC<FileSearchExtensionProps> = ({ onClose, init
       // Clear the file search view so the next window-shown returns
       // to the default command palette instead of re-entering file search.
       onClose();
+      await window.electron.hideWindow();
     } catch (error) {
       console.error('Failed to reveal file:', error);
     }

--- a/src/renderer/src/QuickLinkManager.tsx
+++ b/src/renderer/src/QuickLinkManager.tsx
@@ -1511,7 +1511,9 @@ const QuickLinkManager: React.FC<QuickLinkManagerProps> = ({ onClose, initialVie
       const opened = await window.electron.quickLinkOpen(dynamicPrompt.quickLink.id, dynamicPrompt.values);
       if (opened) {
         setDynamicPrompt(null);
-        await window.electron.hideWindow();
+        // Clear the quick link manager view so the next window-shown returns
+        // to the default command palette instead of re-entering quick links.
+        onClose();
       }
     } catch (error) {
       console.error('Failed to open quick link with dynamic values:', error);
@@ -1542,7 +1544,9 @@ const QuickLinkManager: React.FC<QuickLinkManagerProps> = ({ onClose, initialVie
               delete next[target.id];
               return next;
             });
-            await window.electron.hideWindow();
+            // Clear the quick link manager view so the next window-shown returns
+            // to the default command palette instead of re-entering quick links.
+            onClose();
           }
           return;
         }
@@ -1556,7 +1560,9 @@ const QuickLinkManager: React.FC<QuickLinkManagerProps> = ({ onClose, initialVie
 
       const opened = await window.electron.quickLinkOpen(target.id);
       if (opened) {
-        await window.electron.hideWindow();
+        // Clear the quick link manager view so the next window-shown returns
+        // to the default command palette instead of re-entering quick links.
+        onClose();
       }
     } catch (error) {
       console.error('Failed to open quick link:', error);

--- a/src/renderer/src/QuickLinkManager.tsx
+++ b/src/renderer/src/QuickLinkManager.tsx
@@ -1514,6 +1514,7 @@ const QuickLinkManager: React.FC<QuickLinkManagerProps> = ({ onClose, initialVie
         // Clear the quick link manager view so the next window-shown returns
         // to the default command palette instead of re-entering quick links.
         onClose();
+        await window.electron.hideWindow();
       }
     } catch (error) {
       console.error('Failed to open quick link with dynamic values:', error);
@@ -1547,6 +1548,7 @@ const QuickLinkManager: React.FC<QuickLinkManagerProps> = ({ onClose, initialVie
             // Clear the quick link manager view so the next window-shown returns
             // to the default command palette instead of re-entering quick links.
             onClose();
+            await window.electron.hideWindow();
           }
           return;
         }
@@ -1563,6 +1565,7 @@ const QuickLinkManager: React.FC<QuickLinkManagerProps> = ({ onClose, initialVie
         // Clear the quick link manager view so the next window-shown returns
         // to the default command palette instead of re-entering quick links.
         onClose();
+        await window.electron.hideWindow();
       }
     } catch (error) {
       console.error('Failed to open quick link:', error);

--- a/src/renderer/src/SnippetManager.tsx
+++ b/src/renderer/src/SnippetManager.tsx
@@ -609,12 +609,18 @@ const SnippetManager: React.FC<SnippetManagerProps> = ({ onClose, initialView })
             delete next[s.id];
             return next;
           });
+          // Clear the snippet manager view so the next window-shown returns
+          // to the default command palette instead of re-entering snippets.
+          onClose();
           return;
         }
         setDynamicPrompt({ snippet: s, mode: 'paste', fields, values: resolvedValues });
         return;
       }
       await window.electron.snippetPaste(s.id);
+      // Clear the snippet manager view so the next window-shown returns
+      // to the default command palette instead of re-entering snippets.
+      onClose();
     } catch (e) {
       console.error('Failed to paste snippet:', e);
     }
@@ -697,6 +703,9 @@ const SnippetManager: React.FC<SnippetManagerProps> = ({ onClose, initialView })
     try {
       if (dynamicPrompt.mode === 'paste') {
         await window.electron.snippetPasteResolved(dynamicPrompt.snippet.id, dynamicPrompt.values);
+        // Clear the snippet manager view so the next window-shown returns
+        // to the default command palette instead of re-entering snippets.
+        onClose();
       } else {
         await window.electron.snippetCopyToClipboardResolved(dynamicPrompt.snippet.id, dynamicPrompt.values);
       }


### PR DESCRIPTION
## Summary

Internal views (Clipboard History, Snippets, Quick Links, File Search) persisted on reopen after performing a fire-and-forget action (paste, open, reveal). The next SuperCmd invocation would return to the stale internal view instead of the default command palette.

Closes #374

## Root Cause

The `window-shown` handler in `App.tsx` has a persistence mechanism (`hasPersistableViewRef`) that keeps the active view alive when reopened within `popToRootSearchTimeoutSeconds` (default 90s). This is correct for extension views where you might want to resume, but internal fire-and-forget tools like clipboard paste should dismiss the view immediately.

The problem: action handlers called `window.electron.hideWindow()` (or relied on the main process hiding the window) without clearing the view state. So `showClipboardManager` (etc.) remained `true`, keeping `hasPersistableViewRef` true, and the `window-shown` handler returned early without resetting to the command palette.

## Fix

Replace `window.electron.hideWindow()` with `onClose()` in all fire-and-forget action handlers. `onClose()` clears the view state flag, making `hasPersistableViewRef` false, so the next window-shown correctly shows the command palette. The window hiding is already handled by the main process (e.g., `hideAndPaste()` in the `clipboard-paste-item` IPC handler).

## Affected Components

| Component | Action | Before | After |
|-----------|--------|--------|-------|
| `ClipboardManager` | Paste item | view state left active | `onClose()` |
| `ClipboardManager` | Copy to clipboard | `hideWindow()` | `onClose()` |
| `SnippetManager` | Paste (inline args) | view state left active | `onClose()` |
| `SnippetManager` | Paste (simple) | view state left active | `onClose()` |
| `SnippetManager` | Paste (dynamic prompt) | view state left active | `onClose()` |
| `QuickLinkManager` | Open (dynamic prompt) | `hideWindow()` | `onClose()` |
| `QuickLinkManager` | Open (inline args) | `hideWindow()` | `onClose()` |
| `QuickLinkManager` | Open (simple) | `hideWindow()` | `onClose()` |
| `FileSearchExtension` | Open file | `hideWindow()` | `onClose()` |
| `FileSearchExtension` | Reveal in Finder | `hideWindow()` | `onClose()` |

## Testing

1. Open Clipboard History → paste an item → reopen SuperCmd → should show command palette (not clipboard history)
2. Open Snippets → paste a snippet → reopen → should show command palette
3. Open Quick Links → open a quick link → reopen → should show command palette
4. Open File Search → open/reveal a file → reopen → should show command palette
5. Verify extension views still persist within the timeout (unchanged behavior)
6. Verify Escape/back navigation still dismisses views (unchanged — already uses `onClose()`)