### PR TITLE
window management: bump almost maximize to 90%, suppress resize anima…

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3381,12 +3381,12 @@ function computeWindowManagementLayoutBounds(
     }
     case 'system-window-management-center-80': {
       const width = clampWindowManagementFineTuneValue(
-        Math.round(area.width * 0.8),
+        Math.round(area.width * 0.9),
         WINDOW_MANAGEMENT_FINE_TUNE_MIN_WIDTH,
         area.width
       );
       const height = clampWindowManagementFineTuneValue(
-        Math.round(area.height * 0.8),
+        Math.round(area.height * 0.9),
         WINDOW_MANAGEMENT_FINE_TUNE_MIN_HEIGHT,
         area.height
       );

--- a/src/native/window-adjust.swift
+++ b/src/native/window-adjust.swift
@@ -314,10 +314,13 @@ private func readWindowFrame(_ window: AXUIElement) -> WindowFrame? {
 
 private func setWindowFrame(_ window: AXUIElement, frame: WindowFrame) -> Bool {
   // Temporarily disable enhanced UI to suppress window resize animations in the target app.
+  // Read the original value first so we can restore it exactly rather than assuming true.
   var pid: pid_t = 0
+  var originalEnhancedUI: CFTypeRef? = nil
   let hasPid = AXUIElementGetPid(window, &pid) == .success && pid > 0
   if hasPid {
     let appRef = AXUIElementCreateApplication(pid)
+    AXUIElementCopyAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, &originalEnhancedUI)
     AXUIElementSetAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, kCFBooleanFalse)
   }
 
@@ -331,7 +334,8 @@ private func setWindowFrame(_ window: AXUIElement, frame: WindowFrame) -> Bool {
 
   if hasPid {
     let appRef = AXUIElementCreateApplication(pid)
-    AXUIElementSetAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, kCFBooleanTrue)
+    let restoreValue: CFTypeRef = originalEnhancedUI ?? kCFBooleanFalse
+    AXUIElementSetAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, restoreValue)
   }
 
   return pointStatus == .success && sizeStatus == .success

--- a/src/native/window-adjust.swift
+++ b/src/native/window-adjust.swift
@@ -313,6 +313,14 @@ private func readWindowFrame(_ window: AXUIElement) -> WindowFrame? {
 }
 
 private func setWindowFrame(_ window: AXUIElement, frame: WindowFrame) -> Bool {
+  // Temporarily disable enhanced UI to suppress window resize animations in the target app.
+  var pid: pid_t = 0
+  let hasPid = AXUIElementGetPid(window, &pid) == .success && pid > 0
+  if hasPid {
+    let appRef = AXUIElementCreateApplication(pid)
+    AXUIElementSetAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, kCFBooleanFalse)
+  }
+
   var point = CGPoint(x: frame.x, y: frame.y)
   guard let pointValue = AXValueCreate(.cgPoint, &point) else { return false }
   let pointStatus = AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, pointValue)
@@ -320,6 +328,11 @@ private func setWindowFrame(_ window: AXUIElement, frame: WindowFrame) -> Bool {
   var size = CGSize(width: frame.width, height: frame.height)
   guard let sizeValue = AXValueCreate(.cgSize, &size) else { return false }
   let sizeStatus = AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeValue)
+
+  if hasPid {
+    let appRef = AXUIElementCreateApplication(pid)
+    AXUIElementSetAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, kCFBooleanTrue)
+  }
 
   return pointStatus == .success && sizeStatus == .success
 }
@@ -462,8 +475,8 @@ private func adjustedFrame(_ base: WindowFrame, action: AdjustAction, forcedArea
     }
   case .center80:
     if let area {
-      let width = max(minWidth, round(area.width * 0.8))
-      let height = max(minHeight, round(area.height * 0.8))
+      let width = max(minWidth, round(area.width * 0.9))
+      let height = max(minHeight, round(area.height * 0.9))
       next = WindowFrame(
         x: area.origin.x + round((area.width - width) / 2),
         y: area.origin.y + round((area.height - height) / 2),

--- a/src/renderer/src/utils/command-helpers.tsx
+++ b/src/renderer/src/utils/command-helpers.tsx
@@ -787,7 +787,7 @@ function renderWindowManagementGlyph(glyphId: WindowManagementGlyphId): JSX.Elem
           rx={1}
           stroke="currentColor"
           strokeWidth={1}
-          strokeOpacity={0.5}
+          strokeOpacity={0.72}
         />,
         <rect
           key="display-right"
@@ -798,7 +798,7 @@ function renderWindowManagementGlyph(glyphId: WindowManagementGlyphId): JSX.Elem
           rx={1}
           stroke="currentColor"
           strokeWidth={1}
-          strokeOpacity={0.5}
+          strokeOpacity={0.72}
         />,
         renderGlyphArrow('display-next', 8.4, 7, 11.6, 7)
       );
@@ -814,7 +814,7 @@ function renderWindowManagementGlyph(glyphId: WindowManagementGlyphId): JSX.Elem
           rx={1}
           stroke="currentColor"
           strokeWidth={1}
-          strokeOpacity={0.5}
+          strokeOpacity={0.72}
         />,
         <rect
           key="display-right"
@@ -825,7 +825,7 @@ function renderWindowManagementGlyph(glyphId: WindowManagementGlyphId): JSX.Elem
           rx={1}
           stroke="currentColor"
           strokeWidth={1}
-          strokeOpacity={0.5}
+          strokeOpacity={0.72}
         />,
         renderGlyphArrow('display-prev', 11.6, 7, 8.4, 7)
       );
@@ -891,8 +891,8 @@ function renderWindowManagementGlyph(glyphId: WindowManagementGlyphId): JSX.Elem
           height={12.5}
           rx={2}
           stroke="currentColor"
-          strokeWidth={1}
-          strokeOpacity={0.5}
+          strokeWidth={1.1}
+          strokeOpacity={0.75}
         />
       ) : null}
       {cells.map((cell, index) => (
@@ -904,13 +904,18 @@ function renderWindowManagementGlyph(glyphId: WindowManagementGlyphId): JSX.Elem
           height={cell.h}
           rx={1}
           fill="currentColor"
-          fillOpacity={0.62}
+          fillOpacity={0.92}
         />
       ))}
       {overlays}
     </svg>
   );
 }
+
+const WM_ICON_BG: React.CSSProperties = {
+  background: 'linear-gradient(135deg, rgba(99,102,241,0.62) 0%, rgba(67,56,202,0.56) 100%)',
+  boxShadow: 'inset 0 0 0 1px rgba(129,140,248,0.45)',
+};
 
 function renderWindowManagementCommandIcon(commandId: string): React.ReactNode | null {
   const glyphId = resolveWindowManagementGlyphId(commandId);
@@ -919,13 +924,13 @@ function renderWindowManagementCommandIcon(commandId: string): React.ReactNode |
   }
   if (glyphId === 'panel') {
     return (
-      <div className="w-5 h-5 rounded bg-cyan-500/20 flex items-center justify-center">
-        <LayoutGrid className="w-3 h-3 text-cyan-200" />
+      <div className="w-5 h-5 rounded flex items-center justify-center" style={WM_ICON_BG}>
+        <LayoutGrid className="w-3 h-3 text-indigo-200" />
       </div>
     );
   }
   return (
-    <div className="w-5 h-5 rounded bg-cyan-500/20 flex items-center justify-center text-cyan-100">
+    <div className="w-5 h-5 rounded flex items-center justify-center text-indigo-200" style={WM_ICON_BG}>
       {renderWindowManagementGlyph(glyphId)}
     </div>
   );


### PR DESCRIPTION

Increase the "Almost Maximize" layout from 80% to 90% of the work area (both native Swift path and JS fallback). Also suppress the window resize animation for all window management commands by temporarily toggling AXEnhancedUserInterface off on the target app before setting bounds.