### PR TITLE
fix: close Clipboard Manager in one Escape when opened via shortcut (#407)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -390,12 +390,12 @@ const App: React.FC = () => {
   const homeDir = String((window.electron as any).homeDir || '');
   const {
     extensionView, extensionPreferenceSetup, scriptCommandSetup, scriptCommandOutput,
-    showClipboardManager, showSnippetManager, showNotesSearch, showCanvasSearch, showQuickLinkManager, showFileSearch, showCursorPrompt,
+    showClipboardManager, clipboardManagerOpenedViaShortcut, showSnippetManager, showNotesSearch, showCanvasSearch, showQuickLinkManager, showFileSearch, showCursorPrompt,
     showWhisper, showSpeak, showCamera, showSchedule, showWindowManager, showAppUninstall, showWhisperOnboarding, showWhisperHint, showOnboarding, aiMode,
     openOnboarding, openWhisper, openClipboardManager,
     openSnippetManager, openNotesSearch, openCanvasSearch, openQuickLinkManager, openFileSearch, openCursorPrompt, openSpeak, openCamera, openSchedule, openWindowManager, openAppUninstall,
     setExtensionView, setExtensionPreferenceSetup, setScriptCommandSetup, setScriptCommandOutput,
-    setShowClipboardManager, setShowSnippetManager, setShowNotesSearch, setShowCanvasSearch, setShowQuickLinkManager, setShowFileSearch, setShowCursorPrompt,
+    setShowClipboardManager, setClipboardManagerOpenedViaShortcut, setShowSnippetManager, setShowNotesSearch, setShowCanvasSearch, setShowQuickLinkManager, setShowFileSearch, setShowCursorPrompt,
     setShowWhisper, setShowSpeak, setShowCamera, setShowSchedule, setShowWindowManager, setShowAppUninstall, setShowWhisperOnboarding, setShowWhisperHint,
     setShowOnboarding, setAiMode,
   } = useAppViewManager();
@@ -887,7 +887,7 @@ const App: React.FC = () => {
         if (routedSystemCommandId === 'system-clipboard-manager') {
           setShowSnippetManager(null);
           setShowFileSearch(false);
-          openClipboardManager();
+          openClipboardManager(true);
           return;
         }
         if (routedSystemCommandId === 'system-search-snippets') {
@@ -2667,7 +2667,10 @@ const App: React.FC = () => {
     }
     if (commandId === 'system-clipboard-manager') {
       whisperSessionRef.current = false;
-      openClipboardManager();
+      // fromMainEvent ⇒ delivered by the global-shortcut dispatch
+      // (window-shown + the 180ms run-system-command fallback in main.ts).
+      // Launcher-list selection (handleCommandExecute) passes no options.
+      openClipboardManager(options?.fromMainEvent === true);
       return true;
     }
     if (commandId === 'system-search-snippets') {
@@ -4039,9 +4042,17 @@ const App: React.FC = () => {
         >
           <ClipboardManager
             onClose={() => {
+              const openedViaShortcut = clipboardManagerOpenedViaShortcut;
               setShowClipboardManager(false);
+              setClipboardManagerOpenedViaShortcut(false);
               setSearchQuery('');
               setSelectedIndex(0);
+              if (openedViaShortcut) {
+                // Opened directly via global shortcut — there is no launcher
+                // list to fall back to, so one Escape dismisses the window (#407).
+                window.electron.hideWindow();
+                return;
+              }
               setTimeout(() => inputRef.current?.focus(), 50);
             }}
           />

--- a/src/renderer/src/hooks/useAppViewManager.ts
+++ b/src/renderer/src/hooks/useAppViewManager.ts
@@ -43,6 +43,7 @@ export interface AppViewManager {
   scriptCommandSetup: ScriptCommandSetup | null;
   scriptCommandOutput: ScriptCommandOutput | null;
   showClipboardManager: boolean;
+  clipboardManagerOpenedViaShortcut: boolean;
   showSnippetManager: 'search' | 'create' | null;
   showNotesSearch: boolean;
   showCanvasSearch: boolean;
@@ -68,7 +69,7 @@ export interface AppViewManager {
   openExtensionPreferenceSetup: (setup: ExtensionPreferenceSetup) => void;
   openScriptCommandSetup: (setup: ScriptCommandSetup) => void;
   openScriptCommandOutput: (output: ScriptCommandOutput) => void;
-  openClipboardManager: () => void;
+  openClipboardManager: (openedViaShortcut?: boolean) => void;
   openSnippetManager: (mode: 'search' | 'create') => void;
   openNotesSearch: () => void;
   openCanvasSearch: () => void;
@@ -92,6 +93,7 @@ export interface AppViewManager {
   setScriptCommandSetup: React.Dispatch<React.SetStateAction<ScriptCommandSetup | null>>;
   setScriptCommandOutput: React.Dispatch<React.SetStateAction<ScriptCommandOutput | null>>;
   setShowClipboardManager: React.Dispatch<React.SetStateAction<boolean>>;
+  setClipboardManagerOpenedViaShortcut: React.Dispatch<React.SetStateAction<boolean>>;
   setShowSnippetManager: React.Dispatch<React.SetStateAction<'search' | 'create' | null>>;
   setShowNotesSearch: React.Dispatch<React.SetStateAction<boolean>>;
   setShowCanvasSearch: React.Dispatch<React.SetStateAction<boolean>>;
@@ -116,6 +118,7 @@ export function useAppViewManager(): AppViewManager {
   const [scriptCommandSetup, setScriptCommandSetup] = useState<ScriptCommandSetup | null>(null);
   const [scriptCommandOutput, setScriptCommandOutput] = useState<ScriptCommandOutput | null>(null);
   const [showClipboardManager, setShowClipboardManager] = useState(false);
+  const [clipboardManagerOpenedViaShortcut, setClipboardManagerOpenedViaShortcut] = useState(false);
   const [showSnippetManager, setShowSnippetManager] = useState<'search' | 'create' | null>(null);
   const [showNotesSearch, setShowNotesSearch] = useState(false);
   const [showCanvasSearch, setShowCanvasSearch] = useState(false);
@@ -140,6 +143,7 @@ export function useAppViewManager(): AppViewManager {
     setScriptCommandSetup(null);
     setScriptCommandOutput(null);
     setShowClipboardManager(false);
+    setClipboardManagerOpenedViaShortcut(false);
     setShowSnippetManager(null);
     setShowNotesSearch(false);
     setShowCanvasSearch(false);
@@ -178,9 +182,10 @@ export function useAppViewManager(): AppViewManager {
     setScriptCommandOutput(output);
   }, [resetAllViews]);
 
-  const openClipboardManager = useCallback(() => {
+  const openClipboardManager = useCallback((openedViaShortcut = false) => {
     resetAllViews();
     setShowClipboardManager(true);
+    setClipboardManagerOpenedViaShortcut(openedViaShortcut);
   }, [resetAllViews]);
 
   const openSnippetManager = useCallback((mode: 'search' | 'create') => {
@@ -274,6 +279,7 @@ export function useAppViewManager(): AppViewManager {
     scriptCommandSetup,
     scriptCommandOutput,
     showClipboardManager,
+    clipboardManagerOpenedViaShortcut,
     showSnippetManager,
     showNotesSearch,
     showCanvasSearch,
@@ -320,6 +326,7 @@ export function useAppViewManager(): AppViewManager {
     setScriptCommandSetup,
     setScriptCommandOutput,
     setShowClipboardManager,
+    setClipboardManagerOpenedViaShortcut,
     setShowSnippetManager,
     setShowNotesSearch,
     setShowCanvasSearch,


### PR DESCRIPTION
## What

Closes #407. Opened straight from its global shortcut, Clipboard Manager needed two Escape presses to dismiss. The first press dropped back to the launcher list; the second hid the window. When there's no list to go back to, one Escape should close it.

## Why it happened

`ClipboardManager`'s `onClose` in `App.tsx` always ran `setShowClipboardManager(false)`, which returns to the launcher list no matter how the manager was opened. That's right when you navigated in from the list, wrong when you opened it from a shortcut.

## The fix

A new `clipboardManagerOpenedViaShortcut` flag in `useAppViewManager` records how it was opened:

- `onWindowShown` routed payload (`systemCommandId === 'system-clipboard-manager'`): shortcut
- `runLocalSystemCommand` with `fromMainEvent`: shortcut (the 180 ms `run-system-command` fallback `main.ts` fires for window-shown-routed commands)
- launcher-list selection via `handleCommandExecute`, no options: not a shortcut

Worth calling out: a shortcut hits `openClipboardManager` twice, once from the `window-shown` payload and again 180 ms later from the fallback. Both shortcut paths pass `true`, so the late fallback can't flip the flag back to `false`. When the flag is set, `onClose` hides the window directly; otherwise the old return-to-list behavior is untouched. The Cmd+K actions overlay still consumes its own Escape first.

## Testing

No renderer/IPC test harness in the repo, so this was manual.

- Shortcut path: one Escape hides the window. Confirmed at the OS level: `mainWindow.isVisible()` was `false` right after hide and still `false` 150 ms later, across several open/close cycles.
- Launcher-list path: Escape goes back to the list, second Escape hides. Unchanged.
- Cmd+K overlay closes on its own Escape first in both cases.
- `tsc` on the touched files adds no new type errors; `build:main` and `build:renderer` both pass.

All acceptance criteria in #407 check out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)