### PR TITLE
feat: add Helium browser history import

### DIFF
--- a/src/main/browser-search-history.ts
+++ b/src/main/browser-search-history.ts
@@ -25,6 +25,7 @@ const execFileAsync = promisify(execFile);
 export type BrowserSearchEntryType = 'url' | 'search';
 export type BrowserSearchSource =
   | 'user'
+  | 'helium'
   | 'chrome'
   | 'arc'
   | 'brave'
@@ -118,6 +119,7 @@ function sanitizeEntry(raw: any): BrowserSearchEntry | null {
 
 const ALLOWED_SOURCES: Set<string> = new Set([
   'user',
+  'helium',
   'chrome',
   'arc',
   'brave',
@@ -379,6 +381,7 @@ export function listImportableBrowsers(): ImportableBrowser[] {
 
   // Chromium-family default profiles
   const chromium: { id: BrowserSearchSource; name: string; dbPath: string }[] = [
+    { id: 'helium', name: 'Helium', dbPath: path.join(home, 'Library/Application Support/net.imput.helium/Default/History') },
     { id: 'chrome', name: 'Google Chrome', dbPath: path.join(home, 'Library/Application Support/Google/Chrome/Default/History') },
     { id: 'arc', name: 'Arc', dbPath: path.join(home, 'Library/Application Support/Arc/User Data/Default/History') },
     { id: 'brave', name: 'Brave', dbPath: path.join(home, 'Library/Application Support/BraveSoftware/Brave-Browser/Default/History') },

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -278,6 +278,7 @@ export type BrowserSearchEntryType = 'url' | 'search';
 
 export type BrowserSearchSource =
   | 'user'
+  | 'helium'
   | 'chrome'
   | 'arc'
   | 'brave'


### PR DESCRIPTION
Closes #409

## What changed
Adds Helium to the browser search source type surface and detects the Chromium History database under ~/Library/Application Support/net.imput.helium/Default/History so existing browser-history import can ingest it.

## Why
This keeps the browser/root-search work split into reviewable slices instead of submitting the full integrated branch as one large change.

## Compatibility impact
No dependency on other PRs.

## How tested
Manually tested by importing Helium from Settings > Advanced > Browser Search and searching known Helium history entries from root search. Direct build checks on the integrated branch: TypeScript main build passed, Vite renderer build passed, root-search ranking tests passed, browser-search lag tests passed. Native build is blocked locally by pnpm/npx native-addon environment resolution.

Full integrated branch for build/testing: https://github.com/JustYannicc/SuperCmd/tree/my-build

Focused diff for review: https://github.com/JustYannicc/SuperCmd/compare/main...JustYannicc:SuperCmd:feat/helium-browser-history-import

Feedback and requested adjustments are very welcome; I am happy to reshape the split or behavior to match the project direction.