### PR TITLE
feat: command search history navigation with up/down keys

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -43,6 +43,7 @@ import { useLauncherLocalSystemCommands } from './hooks/useLauncherLocalSystemCo
 import { useLauncherCommandExecution } from './hooks/useLauncherCommandExecution';
 import { useLauncherWindowShownHandler } from './hooks/useLauncherWindowShownHandler';
 import { useLauncherKeyboardControls } from './hooks/useLauncherKeyboardControls';
+import { useCommandSearchHistory } from './hooks/useCommandSearchHistory';
 import { AI_CHAT_STORAGE_KEY, LAST_EXT_KEY, MAX_RECENT_COMMANDS } from './utils/constants';
 import { applyBaseColor } from './utils/base-color';
 import { resetAccessToken } from './raycast-api';
@@ -158,6 +159,13 @@ const App: React.FC = () => {
   );
   const [searchQuery, setSearchQuery] = useState('');
   const deferredSearchQuery = useDeferredValue(searchQuery);
+  const {
+    historyIndex,
+    addToHistory,
+    resetHistoryIndex,
+    navigateHistoryUp,
+    navigateHistoryDown,
+  } = useCommandSearchHistory();
   const [autoQuitAppPaths, setAutoQuitAppPaths] = useState<Set<string>>(new Set());
   const browserSearch = useBrowserSearch(searchQuery);
   const [, setBrowserSearchSkipAutoComplete] = useState(false);
@@ -705,9 +713,10 @@ const App: React.FC = () => {
       lastWindowHiddenAtRef.current = Date.now();
       setSearchQuery('');
       setSelectedIndex(0);
+      resetHistoryIndex();
     });
     return cleanupWindowHidden;
-  }, []);
+  }, [resetHistoryIndex]);
 
   useEffect(() => {
     const cleanup = window.electron.onCommandsUpdated?.(() => {
@@ -1751,6 +1760,7 @@ const App: React.FC = () => {
     const normalizedQuery = String(query || '').trim();
     if (!stableKey || !normalizedQuery) return;
     if (command.id === BROWSER_SEARCH_SHOW_ALL_RESULTS_ID) return;
+    addToHistory(normalizedQuery);
     const nextRanking = recordRootSearchLaunchInState(rootSearchRankingRef.current, stableKey, normalizedQuery);
     rootSearchRankingRef.current = nextRanking;
     setRootSearchRanking(nextRanking);
@@ -1764,7 +1774,7 @@ const App: React.FC = () => {
     } catch (error) {
       console.warn('Failed to record root search launch:', error);
     }
-  }, []);
+  }, [addToHistory]);
 
   const { runLocalSystemCommand } = useLauncherLocalSystemCommands({
     expandLauncherForDirectLaunch,
@@ -2360,6 +2370,10 @@ const App: React.FC = () => {
     setContextMenu,
     setActionsCommand,
     setSelectedActionIndex,
+    historyIndex,
+    navigateHistoryUp,
+    navigateHistoryDown,
+    resetHistoryIndex,
     startAiChat,
     restoreLauncherFocus,
     handleCommandExecute,

--- a/src/renderer/src/hooks/useCommandSearchHistory.ts
+++ b/src/renderer/src/hooks/useCommandSearchHistory.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback } from 'react';
+import { SEARCH_HISTORY_KEY, MAX_SEARCH_HISTORY } from '../utils/constants';
+
+export function useCommandSearchHistory() {
+  const [history, setHistory] = useState<string[]>(() => {
+    try {
+      const stored = localStorage.getItem(SEARCH_HISTORY_KEY);
+      return stored ? (JSON.parse(stored) as string[]) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  const [historyIndex, setHistoryIndex] = useState(-1);
+
+  const addToHistory = useCallback((query: string) => {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    setHistory((prev) => {
+      const filtered = prev.filter((q) => q !== trimmed);
+      const next = [trimmed, ...filtered].slice(0, MAX_SEARCH_HISTORY);
+      try {
+        localStorage.setItem(SEARCH_HISTORY_KEY, JSON.stringify(next));
+      } catch {}
+      return next;
+    });
+  }, []);
+
+  const resetHistoryIndex = useCallback(() => {
+    setHistoryIndex(-1);
+  }, []);
+
+  // Navigate to an older (less recent) history entry.
+  // Returns the query string, or null if there are no more entries.
+  const navigateHistoryUp = useCallback((): string | null => {
+    if (history.length === 0) return null;
+    const next = historyIndex + 1;
+    if (next >= history.length) return null;
+    setHistoryIndex(next);
+    return history[next];
+  }, [history, historyIndex]);
+
+  // Navigate to a newer (more recent) history entry, or exit history mode.
+  // Returns '' when exiting history mode, or null if not currently in history mode.
+  const navigateHistoryDown = useCallback((): string | null => {
+    if (historyIndex < 0) return null;
+    if (historyIndex === 0) {
+      setHistoryIndex(-1);
+      return '';
+    }
+    const next = historyIndex - 1;
+    setHistoryIndex(next);
+    return history[next];
+  }, [history, historyIndex]);
+
+  return {
+    historyIndex,
+    addToHistory,
+    resetHistoryIndex,
+    navigateHistoryUp,
+    navigateHistoryDown,
+  };
+}

--- a/src/renderer/src/hooks/useLauncherKeyboardControls.ts
+++ b/src/renderer/src/hooks/useLauncherKeyboardControls.ts
@@ -50,6 +50,11 @@ export type UseLauncherKeyboardControlsOptions = {
   setActionsCommand: React.Dispatch<React.SetStateAction<CommandInfo | null>>;
   setSelectedActionIndex: React.Dispatch<React.SetStateAction<number>>;
 
+  historyIndex: number;
+  navigateHistoryUp: () => string | null;
+  navigateHistoryDown: () => string | null;
+  resetHistoryIndex: () => void;
+
   startAiChat: (query: string) => void;
   restoreLauncherFocus: () => void;
 
@@ -136,6 +141,10 @@ export function useLauncherKeyboardControls(
     setContextMenu,
     setActionsCommand,
     setSelectedActionIndex,
+    historyIndex,
+    navigateHistoryUp,
+    navigateHistoryDown,
+    resetHistoryIndex,
     startAiChat,
     restoreLauncherFocus,
     handleCommandExecute,
@@ -398,11 +407,29 @@ export function useLauncherKeyboardControls(
             window.electron.resizeLauncherWindow(true);
             break;
           }
+          // When browsing history, Down navigates toward newer entries (or exits history mode)
+          if (historyIndex >= 0 && isSearchInputTarget) {
+            const entry = navigateHistoryDown();
+            if (entry !== null) {
+              setSearchQuery(entry);
+              setSelectedIndex(0);
+            }
+            break;
+          }
           moveSelection('down');
           break;
 
         case 'ArrowUp':
           e.preventDefault();
+          // When at the top of the list with an empty search query, navigate search history
+          if (selectedIndex === 0 && !searchQuery && isSearchInputTarget) {
+            const entry = navigateHistoryUp();
+            if (entry !== null) {
+              setSearchQuery(entry);
+              setSelectedIndex(0);
+            }
+            break;
+          }
           moveSelection('up');
           break;
 
@@ -447,6 +474,7 @@ export function useLauncherKeyboardControls(
           if (searchQuery.length > 0) {
             setSearchQuery('');
             setSelectedIndex(0);
+            resetHistoryIndex();
             if (launcherViewMode === 'compact') {
               setIsCompactCollapsed(true);
               window.electron.resizeLauncherWindow(false);
@@ -508,10 +536,15 @@ export function useLauncherKeyboardControls(
       submitBrowserSearch,
       handleCommandExecute,
       launcherInputValue,
+      historyIndex,
+      navigateHistoryUp,
+      navigateHistoryDown,
+      resetHistoryIndex,
     ]
   );
 
   const handleLauncherInputChange = useCallback((value: string) => {
+    resetHistoryIndex();
     setSearchQuery(value);
 
     if (launcherViewMode === 'compact') {
@@ -526,6 +559,7 @@ export function useLauncherKeyboardControls(
   }, [
     isCompactCollapsed,
     launcherViewMode,
+    resetHistoryIndex,
     setIsCompactCollapsed,
     setSearchQuery,
   ]);

--- a/src/renderer/src/utils/constants.ts
+++ b/src/renderer/src/utils/constants.ts
@@ -16,4 +16,6 @@ export const CMD_ARGS_KEY_PREFIX = 'sc-ext-cmd-args:';
 export const SCRIPT_CMD_ARGS_KEY_PREFIX = 'sc-script-cmd-args:';
 export const HIDDEN_MENUBAR_CMDS_KEY = 'sc-hidden-menubar-cmds';
 export const MAX_RECENT_COMMANDS = 30;
+export const SEARCH_HISTORY_KEY = 'sc-search-history';
+export const MAX_SEARCH_HISTORY = 50;
 export const NO_AI_MODEL_ERROR = 'No AI model available. Configure one in Settings -> AI.';


### PR DESCRIPTION
Implements #440 - pressing Up when the search bar is empty cycles through previous search queries. Down navigates back toward recent entries. History persisted to localStorage across sessions (max 50 entries).

Generated with [Claude Code](https://claude.ai/code)