### PR TITLE
feat: add menu item search for active application (#315)

### DIFF
--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -1347,6 +1347,12 @@ async function discoverAndBuildCommands(): Promise<CommandInfo[]> {
       category: 'system',
     },
     {
+      id: 'system-menu-item-search',
+      title: 'Search Menu Items',
+      keywords: ['menu', 'search', 'menu item', 'commands', 'actions', 'accessibility', 'app menu', 'toolbar'],
+      category: 'system',
+    },
+    {
       id: 'system-window-management',
       title: 'Window Management',
       keywords: ['window', 'manage', 'tile', 'snap', 'top left', 'top right', 'bottom left', 'bottom right', 'third', 'fourth', 'sixth', 'grid', 'auto organize'],

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10336,6 +10336,13 @@ async function runCommandById(commandId: string, source: 'launcher' | 'hotkey' |
       preserveFocusWhenHidden: commandId !== 'system-window-management',
     });
   }
+  if (commandId === 'system-menu-item-search') {
+    return await openLauncherAndRunSystemCommand(commandId, {
+      showWindow: false,
+      mode: launcherMode === 'onboarding' ? 'onboarding' : 'default',
+      preserveFocusWhenHidden: false,
+    });
+  }
   if (commandId === 'system-import-snippets') {
     await importSnippetsFromFile(mainWindow || undefined);
     return true;
@@ -15118,6 +15125,90 @@ return appURL's |path|() as text`,
       throw new Error(e?.message || 'AppleScript execution failed');
     }
   });
+
+  // ─── Menu Item Search ───────────────────────────────────────────
+  // Enumerate and press menu items of the frontmost application using
+  // macOS Accessibility (AXUIElement) via the menu-item-search Swift helper.
+
+  type MenuItemInfo = {
+    path: string;
+    title: string;
+    fullPath: string;
+    shortcut?: string | null;
+    enabled: boolean;
+  };
+
+  ipcMain.handle(
+    'get-app-menu-items',
+    async (): Promise<{ ok: boolean; items?: MenuItemInfo[]; error?: string }> => {
+      try {
+        const helperPath = getNativeBinaryPath('menu-item-search');
+        // The Swift helper is a script, so we need to run it with /usr/bin/env swift
+        const { spawn } = require('child_process');
+        return await new Promise((resolve) => {
+          const proc = spawn('/usr/bin/env', ['swift', helperPath], {
+            stdio: ['pipe', 'pipe', 'pipe'],
+          });
+          let stdout = '';
+          let stderr = '';
+          proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+          proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+          proc.on('close', () => {
+            try {
+              const result = JSON.parse(stdout.trim());
+              resolve(result);
+            } catch {
+              resolve({ ok: false, error: stderr || 'Failed to parse menu item search output' });
+            }
+          });
+          proc.on('error', (err: Error) => {
+            resolve({ ok: false, error: err.message });
+          });
+          // Send the list action
+          proc.stdin.write(JSON.stringify({ action: 'list' }));
+          proc.stdin.end();
+        });
+      } catch (e: any) {
+        return { ok: false, error: e?.message || 'Menu item search failed' };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'press-app-menu-item',
+    async (_event: any, data: { path: string }): Promise<{ ok: boolean; error?: string }> => {
+      const targetPath = String(data?.path || '').trim();
+      if (!targetPath) return { ok: false, error: 'Missing menu item path' };
+      try {
+        const helperPath = getNativeBinaryPath('menu-item-search');
+        const { spawn } = require('child_process');
+        return await new Promise((resolve) => {
+          const proc = spawn('/usr/bin/env', ['swift', helperPath], {
+            stdio: ['pipe', 'pipe', 'pipe'],
+          });
+          let stdout = '';
+          let stderr = '';
+          proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+          proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+          proc.on('close', () => {
+            try {
+              const result = JSON.parse(stdout.trim());
+              resolve(result);
+            } catch {
+              resolve({ ok: false, error: stderr || 'Failed to parse press result' });
+            }
+          });
+          proc.on('error', (err: Error) => {
+            resolve({ ok: false, error: err.message });
+          });
+          proc.stdin.write(JSON.stringify({ action: 'press', path: targetPath }));
+          proc.stdin.end();
+        });
+      } catch (e: any) {
+        return { ok: false, error: e?.message || 'Press menu item failed' };
+      }
+    },
+  );
 
   ipcMain.handle(
     'calendar-ensure-access',

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -534,6 +534,12 @@ const electronAPI = {
   runAppleScript: (script: string, options?: { language?: string; humanReadableOutput?: boolean; timeout?: number }): Promise<string> =>
     ipcRenderer.invoke('run-applescript', script, options),
 
+  // Menu Item Search
+  getAppMenuItems: (): Promise<{ ok: boolean; items?: Array<{ path: string; title: string; fullPath: string; shortcut?: string | null; enabled: boolean }>; error?: string }> =>
+    ipcRenderer.invoke('get-app-menu-items'),
+  pressAppMenuItem: (path: string): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('press-app-menu-item', { path }),
+
   // Calendar
   ensureCalendarAccess: (options?: { prompt?: boolean }): Promise<any> =>
     ipcRenderer.invoke('calendar-ensure-access', options),

--- a/src/native/menu-item-search.swift
+++ b/src/native/menu-item-search.swift
@@ -1,0 +1,222 @@
+#!/usr/bin/env swift
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+// ── Types ──────────────────────────────────────────────────────────
+
+struct MenuItemInfo: Encodable {
+    let path: String        // e.g. "File > New Window"
+    let title: String       // leaf title, e.g. "New Window"
+    let fullPath: String    // full hierarchy path
+    let shortcut: String?   // e.g. "⌘N"
+    let enabled: Bool
+}
+
+struct OutputPayload: Encodable {
+    let ok: Bool
+    let items: [MenuItemInfo]?
+    let error: String?
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+func emit(_ payload: OutputPayload) {
+    let encoder = JSONEncoder()
+    guard let data = try? encoder.encode(payload),
+          let text = String(data: data, encoding: .utf8),
+          let bytes = (text + "\n").data(using: .utf8) else { return }
+    FileHandle.standardOutput.write(bytes)
+}
+
+func modifierString(_ mods: Int) -> String {
+    var s = ""
+    if mods & (1 << 17) != 0 { s += "⇧" }  // Shift
+    if mods & (1 << 18) != 0 { s += "⌥" }  // Option/Alt
+    if mods & (1 << 19) != 0 { s += "⌃" }  // Control
+    if mods & (1 << 20) != 0 { s += "⌘" }  // Command
+    return s
+}
+
+/// Map keyCode to a readable character (best-effort for common keys)
+func keyString(_ code: Int) -> String {
+    let map: [Int: String] = [
+        0: "A", 1: "S", 2: "D", 3: "F", 4: "H", 5: "G", 6: "Z", 7: "X",
+        8: "C", 9: "V", 11: "B", 12: "Q", 13: "W", 14: "E", 15: "R",
+        16: "Y", 17: "T", 18: "1", 19: "2", 20: "3", 21: "4", 22: "6",
+        23: "5", 24: "=", 25: "9", 26: "7", 27: "-", 28: "8", 29: "0",
+        30: "]", 31: "O", 32: "U", 33: "[", 34: "I", 35: "P", 36: "↩",
+        37: "L", 38: "J", 39: "'", 40: "K", 41: ";", 42: "\\", 43: ",",
+        44: "/", 45: "N", 46: ".", 47: "`", 49: "Space", 50: "`",
+        51: "⌫", 53: "⎋", 96: "F5", 97: "F6", 98: "F7", 99: "F3",
+        100: "F8", 101: "F9", 103: "F11", 105: "F13", 107: "F14",
+        109: "F10", 111: "F12", 113: "F15", 115: "↖", 116: "⇞",
+        117: "⌦", 118: "F4", 119: "End", 120: "F2", 121: "⇟",
+        122: "F1", 123: "←", 124: "→", 125: "↓", 126: "↑"
+    ]
+    return map[code] ?? "?"
+}
+
+/// Recursively collect menu items from an AXUIElement menu bar
+func collectMenuItems(
+    element: AXUIElement,
+    parentPath: String,
+    into result: inout [MenuItemInfo]
+) {
+    var childrenRef: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
+    guard err == 0, let children = childrenRef as? [AXUIElement] else { return }
+
+    for child in children {
+        // Get title
+        var titleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(child, kAXTitleAttribute as CFString, &titleRef)
+        let title = (titleRef as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        // Skip empty or separator items
+        if title.isEmpty || title == "Apple" { continue }
+
+        let currentPath = parentPath.isEmpty ? title : "\(parentPath) > \(title)"
+
+        // Check if it's a menu (has submenu)
+        var roleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(child, kAXRoleAttribute as CFString, &roleRef)
+        let role = roleRef as? String ?? ""
+
+        // Check if enabled
+        var enabledRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(child, kAXEnabledAttribute as CFString, &enabledRef)
+        let enabled = (enabledRef as? Bool) ?? true
+
+        // Check for keyboard shortcut
+        var shortcutRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(child, kAXMenuItemCmdModifiersAttribute as CFString, &shortcutRef)
+        var cmdCharRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(child, kAXMenuItemCmdCharAttribute as CFString, &cmdCharRef)
+
+        var shortcut: String? = nil
+        if let mods = shortcutRef as? Int, let char = cmdCharRef as? String, !char.isEmpty {
+            let modStr = modifierString(mods)
+            shortcut = modStr + char
+        }
+
+        // If it has children (submenu), recurse
+        var childMenuRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(child, kAXChildrenAttribute as CFString, &childMenuRef)
+        let hasChildren = (childMenuRef as? [AXUIElement])?.isEmpty == false
+
+        if hasChildren {
+            // It's a submenu, recurse
+            collectMenuItems(element: child, parentPath: currentPath, into: &result)
+        } else if role == "AXMenuItem" || role == "AXMenuBarItem" {
+            // Leaf menu item
+            result.append(MenuItemInfo(
+                path: parentPath,
+                title: title,
+                fullPath: currentPath,
+                shortcut: shortcut,
+                enabled: enabled
+            ))
+        }
+    }
+}
+
+// ── Main ───────────────────────────────────────────────────────────
+
+// Read command from stdin (JSON: {"action": "list"} or {"action": "press", "path": "File > New Window"})
+let inputData = FileHandle.standardInput.readDataToEndOfFile()
+let input = try? JSONSerialization.jsonObject(with: inputData) as? [String: Any]
+let action = input?["action"] as? String ?? "list"
+
+if action == "press" {
+    // Press a menu item by its path
+    guard let targetPath = input?["path"] as? String, !targetPath.isEmpty else {
+        emit(OutputPayload(ok: false, items: nil, error: "Missing 'path' for press action"))
+        exit(0)
+    }
+
+    let app = NSWorkspace.shared.frontmostApplication
+    guard let pid = app?.processIdentifier else {
+        emit(OutputPayload(ok: false, items: nil, error: "No frontmost application"))
+        exit(0)
+    }
+
+    let appElement = AXUIElementCreateApplication(pid)
+
+    var menuBarRef: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(appElement, kAXMenuBarAttribute as CFString, &menuBarRef)
+    guard err == 0, let menuBar = menuBarRef else {
+        emit(OutputPayload(ok: false, items: nil, error: "Cannot access menu bar (Accessibility permission required)"))
+        exit(0)
+    }
+
+    // Navigate the path and press the final item
+    let pathComponents = targetPath.split(separator: ">").map { $0.trimmingCharacters(in: .whitespaces) }
+    var currentElement = menuBar as! AXUIElement
+    var found = true
+
+    for (i, component) in pathComponents.enumerated() {
+        var childrenRef: CFTypeRef?
+        let childErr = AXUIElementCopyAttributeValue(currentElement, kAXChildrenAttribute as CFString, &childrenRef)
+        guard childErr == 0, let children = childrenRef as? [AXUIElement] else {
+            found = false
+            break
+        }
+
+        var matched = false
+        for child in children {
+            var titleRef: CFTypeRef?
+            AXUIElementCopyAttributeValue(child, kAXTitleAttribute as CFString, &titleRef)
+            let title = (titleRef as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if title == component {
+                if i == pathComponents.count - 1 {
+                    // Press the final item
+                    let pressErr = AXUIElementPerformAction(child, kAXPressAction as CFString)
+                    if pressErr == 0 {
+                        emit(OutputPayload(ok: true, items: nil, error: nil))
+                    } else {
+                        emit(OutputPayload(ok: false, items: nil, error: "Failed to press menu item (error: \(pressErr))"))
+                    }
+                    exit(0)
+                } else {
+                    currentElement = child
+                    matched = true
+                    break
+                }
+            }
+        }
+
+        if !matched {
+            found = false
+            break
+        }
+    }
+
+    if !found {
+        emit(OutputPayload(ok: false, items: nil, error: "Menu item not found: \(targetPath)"))
+    }
+
+} else {
+    // List menu items
+    let app = NSWorkspace.shared.frontmostApplication
+    guard let appName = app?.localizedName, let pid = app?.processIdentifier else {
+        emit(OutputPayload(ok: false, items: nil, error: "No frontmost application"))
+        exit(0)
+    }
+
+    let appElement = AXUIElementCreateApplication(pid)
+
+    var menuBarRef: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(appElement, kAXMenuBarAttribute as CFString, &menuBarRef)
+    guard err == 0, let menuBar = menuBarRef else {
+        emit(OutputPayload(ok: false, items: nil, error: "Cannot access menu bar for \(appName). Accessibility permission required."))
+        exit(0)
+    }
+
+    var items: [MenuItemInfo] = []
+    collectMenuItems(element: menuBar as! AXUIElement, parentPath: "", into: &items)
+
+    emit(OutputPayload(ok: true, items: items, error: nil))
+}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -188,12 +188,12 @@ const App: React.FC = () => {
   const {
     extensionView, extensionPreferenceSetup, scriptCommandSetup, scriptCommandOutput,
     showClipboardManager, clipboardManagerOpenedViaShortcut, showSnippetManager, showNotesSearch, showCanvasSearch, showQuickLinkManager, showFileSearch, showCursorPrompt,
-    showWhisper, showSpeak, showCamera, showSchedule, showWindowManager, showAppUninstall, showWhisperOnboarding, showWhisperHint, showOnboarding, aiMode,
+    showWhisper, showSpeak, showCamera, showSchedule, showWindowManager, showMenuItemSearch, showAppUninstall, showWhisperOnboarding, showWhisperHint, showOnboarding, aiMode,
     openOnboarding, openWhisper, openClipboardManager,
-    openSnippetManager, openNotesSearch, openCanvasSearch, openQuickLinkManager, openFileSearch, openCursorPrompt, openSpeak, openCamera, openSchedule, openWindowManager, openAppUninstall,
+    openSnippetManager, openNotesSearch, openCanvasSearch, openQuickLinkManager, openFileSearch, openCursorPrompt, openSpeak, openCamera, openSchedule, openWindowManager, openMenuItemSearch, openAppUninstall,
     setExtensionView, setExtensionPreferenceSetup, setScriptCommandSetup, setScriptCommandOutput,
     setShowClipboardManager, setClipboardManagerOpenedViaShortcut, setShowSnippetManager, setShowNotesSearch, setShowCanvasSearch, setShowQuickLinkManager, setShowFileSearch, setShowCursorPrompt,
-    setShowWhisper, setShowSpeak, setShowCamera, setShowSchedule, setShowWindowManager, setShowAppUninstall, setShowWhisperOnboarding, setShowWhisperHint,
+    setShowWhisper, setShowSpeak, setShowCamera, setShowSchedule, setShowWindowManager, setShowMenuItemSearch, setShowAppUninstall, setShowWhisperOnboarding, setShowWhisperHint,
     setShowOnboarding, setAiMode,
   } = useAppViewManager();
   const {
@@ -478,6 +478,17 @@ const App: React.FC = () => {
     anchor: 'bottom-right',
     onClosed: () => {
       setShowWindowManager(false);
+    },
+  });
+
+  const menuItemSearchPortalTarget = useDetachedPortalWindow(showMenuItemSearch, {
+    name: 'supercmd-menu-item-search-window',
+    title: 'SuperCmd Menu Item Search',
+    width: 580,
+    height: 500,
+    anchor: 'center',
+    onClosed: () => {
+      setShowMenuItemSearch(false);
     },
   });
 
@@ -1789,6 +1800,7 @@ const App: React.FC = () => {
     openCamera,
     openSpeak,
     openWindowManager,
+    openMenuItemSearch,
     openSchedule,
     setShowWhisper,
     setShowWhisperOnboarding,
@@ -2285,6 +2297,11 @@ const App: React.FC = () => {
       windowManagerPortalTarget={windowManagerPortalTarget}
       onWindowManagerClose={() => {
         setShowWindowManager(false);
+      }}
+      showMenuItemSearch={showMenuItemSearch}
+      menuItemSearchPortalTarget={menuItemSearchPortalTarget}
+      onMenuItemSearchClose={() => {
+        setShowMenuItemSearch(false);
       }}
       showCursorPrompt={showCursorPrompt}
       cursorPromptPortalTarget={cursorPromptPortalTarget}

--- a/src/renderer/src/MenuItemSearchExtension.tsx
+++ b/src/renderer/src/MenuItemSearchExtension.tsx
@@ -1,0 +1,259 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { onThemeChange } from './utils/theme';
+
+type MenuItemInfo = {
+  path: string;
+  title: string;
+  fullPath: string;
+  shortcut?: string | null;
+  enabled: boolean;
+};
+
+interface MenuItemSearchProps {
+  show: boolean;
+  portalTarget?: HTMLElement | null;
+  onClose: () => void;
+}
+
+export default function MenuItemSearch({ show, portalTarget, onClose }: MenuItemSearchProps) {
+  const [items, setItems] = useState<MenuItemInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [appName, setAppName] = useState('');
+  const [themeKey, setThemeKey] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Theme reactivity
+  useEffect(() => {
+    const off = onThemeChange(() => setThemeKey((k) => k + 1));
+    return off;
+  }, []);
+
+  // Load menu items when shown
+  useEffect(() => {
+    if (!show) return;
+    setLoading(true);
+    setError(null);
+    setQuery('');
+    setSelectedIndex(0);
+
+    // Get frontmost app name
+    window.electron.getFrontmostApplication().then((app) => {
+      if (app) setAppName(app.name);
+    });
+
+    window.electron.getAppMenuItems().then((result) => {
+      setLoading(false);
+      if (result.ok && result.items) {
+        setItems(result.items);
+      } else {
+        setError(result.error || 'Failed to load menu items');
+      }
+    });
+  }, [show]);
+
+  // Focus input when shown
+  useEffect(() => {
+    if (show) {
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [show]);
+
+  // Filter items
+  const filtered = useMemo(() => {
+    if (!query.trim()) return items;
+    const q = query.toLowerCase();
+    return items.filter(
+      (item) =>
+        item.title.toLowerCase().includes(q) ||
+        item.fullPath.toLowerCase().includes(q) ||
+        item.path.toLowerCase().includes(q),
+    );
+  }, [items, query]);
+
+  // Clamp selected index
+  useEffect(() => {
+    if (selectedIndex >= filtered.length) {
+      setSelectedIndex(Math.max(0, filtered.length - 1));
+    }
+  }, [filtered.length, selectedIndex]);
+
+  // Scroll selected into view
+  useEffect(() => {
+    const el = listRef.current?.querySelector(`[data-index="${selectedIndex}"]`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  // Execute a menu item
+  const executeItem = useCallback(
+    async (item: MenuItemInfo) => {
+      const result = await window.electron.pressAppMenuItem(item.fullPath);
+      if (result.ok) {
+        onClose();
+      } else {
+        setError(result.error || 'Failed to execute menu item');
+      }
+    },
+    [onClose],
+  );
+
+  // Keyboard handling
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setSelectedIndex((i) => Math.max(i - 1, 0));
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (filtered[selectedIndex]) {
+            executeItem(filtered[selectedIndex]);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          onClose();
+          break;
+      }
+    },
+    [filtered, selectedIndex, executeItem, onClose],
+  );
+
+  if (!show) return null;
+
+  const content = (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 99999,
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        paddingTop: '15vh',
+        background: 'rgba(0,0,0,0.4)',
+        backdropFilter: 'blur(8px)',
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        style={{
+          width: 580,
+          maxHeight: '70vh',
+          borderRadius: 16,
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+          background: 'rgba(30,30,30,0.95)',
+          border: '1px solid rgba(255,255,255,0.08)',
+          boxShadow: '0 20px 60px rgba(0,0,0,0.5)',
+        }}
+      >
+        {/* Header */}
+        <div style={{ padding: '16px 20px 8px', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+          <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.4)', marginBottom: 6 }}>
+            {appName ? `Menu Items — ${appName}` : 'Menu Items'}
+          </div>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => { setQuery(e.target.value); setSelectedIndex(0); }}
+            onKeyDown={handleKeyDown}
+            placeholder="Search menu items…"
+            style={{
+              width: '100%',
+              background: 'transparent',
+              border: 'none',
+              outline: 'none',
+              color: 'rgba(255,255,255,0.9)',
+              fontSize: 18,
+              fontWeight: 500,
+              padding: '4px 0',
+            }}
+          />
+        </div>
+
+        {/* Results */}
+        <div ref={listRef} style={{ flex: 1, overflowY: 'auto', padding: '6px 0' }}>
+          {loading && (
+            <div style={{ padding: '24px 20px', textAlign: 'center', color: 'rgba(255,255,255,0.4)', fontSize: 13 }}>
+              Loading menu items…
+            </div>
+          )}
+          {error && (
+            <div style={{ padding: '16px 20px', color: '#f87171', fontSize: 13 }}>
+              {error}
+            </div>
+          )}
+          {!loading && !error && filtered.length === 0 && (
+            <div style={{ padding: '24px 20px', textAlign: 'center', color: 'rgba(255,255,255,0.4)', fontSize: 13 }}>
+              {query ? 'No matching menu items' : 'No menu items found'}
+            </div>
+          )}
+          {filtered.map((item, i) => (
+            <div
+              key={item.fullPath + i}
+              data-index={i}
+              onClick={() => executeItem(item)}
+              onMouseEnter={() => setSelectedIndex(i)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '8px 20px',
+                cursor: 'pointer',
+                background: i === selectedIndex ? 'rgba(255,255,255,0.08)' : 'transparent',
+                borderRadius: 8,
+                margin: '0 6px',
+                opacity: item.enabled ? 1 : 0.4,
+                transition: 'background 0.1s',
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 14, color: 'rgba(255,255,255,0.9)', fontWeight: 500 }}>
+                  {item.title}
+                </div>
+                {item.path && (
+                  <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.35)', marginTop: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {item.path}
+                  </div>
+                )}
+              </div>
+              {item.shortcut && (
+                <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.5)', marginLeft: 12, flexShrink: 0, fontFamily: 'monospace' }}>
+                  {item.shortcut}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div style={{ padding: '8px 20px', borderTop: '1px solid rgba(255,255,255,0.06)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.3)' }}>
+            {filtered.length} items
+          </span>
+          <div style={{ display: 'flex', gap: 12, fontSize: 11, color: 'rgba(255,255,255,0.3)' }}>
+            <span>↑↓ Navigate</span>
+            <span>↵ Execute</span>
+            <span>Esc Close</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (portalTarget) return createPortal(content, portalTarget);
+  return content;
+}

--- a/src/renderer/src/components/DetachedOverlayRunners.tsx
+++ b/src/renderer/src/components/DetachedOverlayRunners.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import SuperCmdWhisper from '../SuperCmdWhisper';
 import SuperCmdRead from '../SuperCmdRead';
 import WindowManagerPanel from '../WindowManagerPanel';
+import MenuItemSearch from '../MenuItemSearchExtension';
 import type { SpeakStatus } from '../hooks/useSpeakManager';
 import type { UseCursorPromptReturn } from '../hooks/useCursorPrompt';
 import type { ReadVoiceOption } from '../utils/command-helpers';
@@ -33,6 +34,10 @@ type DetachedOverlayRunnersProps = {
   showWindowManager: boolean;
   windowManagerPortalTarget: HTMLElement | null;
   onWindowManagerClose: () => void;
+
+  showMenuItemSearch: boolean;
+  menuItemSearchPortalTarget: HTMLElement | null;
+  onMenuItemSearchClose: () => void;
 
   showCursorPrompt: boolean;
   cursorPromptPortalTarget: HTMLElement | null;
@@ -71,6 +76,9 @@ const DetachedOverlayRunners: React.FC<DetachedOverlayRunnersProps> = ({
   showWindowManager,
   windowManagerPortalTarget,
   onWindowManagerClose,
+  showMenuItemSearch,
+  menuItemSearchPortalTarget,
+  onMenuItemSearchClose,
   showCursorPrompt,
   cursorPromptPortalTarget,
   cursorPromptText,
@@ -117,6 +125,13 @@ const DetachedOverlayRunners: React.FC<DetachedOverlayRunnersProps> = ({
           show={showWindowManager}
           portalTarget={windowManagerPortalTarget}
           onClose={onWindowManagerClose}
+        />
+      ) : null}
+      {showMenuItemSearch && menuItemSearchPortalTarget ? (
+        <MenuItemSearch
+          show={showMenuItemSearch}
+          portalTarget={menuItemSearchPortalTarget}
+          onClose={onMenuItemSearchClose}
         />
       ) : null}
       {showCursorPrompt && cursorPromptPortalTarget

--- a/src/renderer/src/hooks/useAppViewManager.ts
+++ b/src/renderer/src/hooks/useAppViewManager.ts
@@ -55,6 +55,7 @@ export interface AppViewManager {
   showCamera: boolean;
   showSchedule: boolean;
   showWindowManager: boolean;
+  showMenuItemSearch: boolean;
   showAppUninstall: string | null;
   showWhisperOnboarding: boolean;
   showWhisperHint: boolean;
@@ -81,6 +82,7 @@ export interface AppViewManager {
   openCamera: () => void;
   openSchedule: () => void;
   openWindowManager: () => void;
+  openMenuItemSearch: () => void;
   openAppUninstall: (appPath: string) => void;
   openWhisperOnboarding: () => void;
   openOnboarding: () => void;
@@ -105,6 +107,7 @@ export interface AppViewManager {
   setShowCamera: React.Dispatch<React.SetStateAction<boolean>>;
   setShowSchedule: React.Dispatch<React.SetStateAction<boolean>>;
   setShowWindowManager: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowMenuItemSearch: React.Dispatch<React.SetStateAction<boolean>>;
   setShowAppUninstall: React.Dispatch<React.SetStateAction<string | null>>;
   setShowWhisperOnboarding: React.Dispatch<React.SetStateAction<boolean>>;
   setShowWhisperHint: React.Dispatch<React.SetStateAction<boolean>>;
@@ -130,6 +133,7 @@ export function useAppViewManager(): AppViewManager {
   const [showCamera, setShowCamera] = useState(false);
   const [showSchedule, setShowSchedule] = useState(false);
   const [showWindowManager, setShowWindowManager] = useState(false);
+  const [showMenuItemSearch, setShowMenuItemSearch] = useState(false);
   const [showAppUninstall, setShowAppUninstall] = useState<string | null>(null);
   const [showWhisperOnboarding, setShowWhisperOnboarding] = useState(false);
   const [showWhisperHint, setShowWhisperHint] = useState(false);
@@ -155,6 +159,7 @@ export function useAppViewManager(): AppViewManager {
     setShowCamera(false);
     setShowSchedule(false);
     setShowWindowManager(false);
+    setShowMenuItemSearch(false);
     setShowAppUninstall(null);
     setShowWhisperOnboarding(false);
     setShowWhisperHint(false);
@@ -248,6 +253,11 @@ export function useAppViewManager(): AppViewManager {
     setShowWindowManager(true);
   }, [resetAllViews]);
 
+  const openMenuItemSearch = useCallback(() => {
+    resetAllViews();
+    setShowMenuItemSearch(true);
+  }, [resetAllViews]);
+
   const openAppUninstall = useCallback((appPath: string) => {
     // Don't call resetAllViews() — it can trigger side effects in menubar
     // extensions that cause SIGTRAP crashes. Just set the uninstall view directly.
@@ -291,6 +301,7 @@ export function useAppViewManager(): AppViewManager {
     showCamera,
     showSchedule,
     showWindowManager,
+    showMenuItemSearch,
     showAppUninstall,
     showWhisperOnboarding,
     showWhisperHint,
@@ -315,6 +326,7 @@ export function useAppViewManager(): AppViewManager {
     openCamera,
     openSchedule,
     openWindowManager,
+    openMenuItemSearch,
     openAppUninstall,
     openWhisperOnboarding,
     openOnboarding,
@@ -338,6 +350,7 @@ export function useAppViewManager(): AppViewManager {
     setShowCamera,
     setShowSchedule,
     setShowWindowManager,
+    setShowMenuItemSearch,
     setShowAppUninstall,
     setShowWhisperOnboarding,
     setShowWhisperHint,

--- a/src/renderer/src/hooks/useLauncherLocalSystemCommands.ts
+++ b/src/renderer/src/hooks/useLauncherLocalSystemCommands.ts
@@ -63,6 +63,7 @@ type UseLauncherLocalSystemCommandsOptions = {
   openCamera: () => void;
   openSpeak: () => void;
   openWindowManager: () => void;
+  openMenuItemSearch: () => void;
   openSchedule: () => void;
 
   setShowWhisper: React.Dispatch<React.SetStateAction<boolean>>;
@@ -114,6 +115,7 @@ export function useLauncherLocalSystemCommands(
     openCamera,
     openSpeak,
     openWindowManager,
+    openMenuItemSearch,
     openSchedule,
     setShowWhisper,
     setShowWhisperOnboarding,
@@ -286,6 +288,18 @@ export function useLauncherLocalSystemCommands(
       }
       return true;
     }
+    if (commandId === 'system-menu-item-search') {
+      whisperSessionRef.current = false;
+      openMenuItemSearch();
+      setSearchQuery('');
+      setSelectedIndex(0);
+      if (document.hasFocus()) {
+        try {
+          await window.electron.hideWindow();
+        } catch {}
+      }
+      return true;
+    }
     if (commandId === 'system-add-to-memory') {
       if (memoryActionLoading) return true;
       setMemoryActionLoading(true);
@@ -392,6 +406,7 @@ export function useLauncherLocalSystemCommands(
     openCamera,
     openSpeak,
     openWindowManager,
+    openMenuItemSearch,
     openSchedule,
     setShowWhisper,
     setShowWhisperOnboarding,

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1066,6 +1066,8 @@ export interface ElectronAPI {
   getDefaultApplication: (filePath: string) => Promise<{ name: string; path: string; bundleId?: string }>;
   getFrontmostApplication: () => Promise<{ name: string; path: string; bundleId?: string } | null>;
   runAppleScript: (script: string, options?: { language?: string; humanReadableOutput?: boolean; timeout?: number }) => Promise<string>;
+  getAppMenuItems: () => Promise<{ ok: boolean; items?: Array<{ path: string; title: string; fullPath: string; shortcut?: string | null; enabled: boolean }>; error?: string }>;
+  pressAppMenuItem: (path: string) => Promise<{ ok: boolean; error?: string }>;
   ensureCalendarAccess: (options?: { prompt?: boolean }) => Promise<CalendarPermissionResult>;
   getCalendarEvents: (payload: { start: string; end: string }) => Promise<CalendarEventsResult>;
   moveToTrash: (paths: string[]) => Promise<void>;


### PR DESCRIPTION
## What

Implements a searchable menu item finder for the frontmost application, similar to [Raycast's menu item search feature (v1.20.0)](https://www.raycast.com/changelog/1-20-0).

Closes #315

## Why

The issue requested the ability to search through an active application's menu items directly from SuperCmd. This is a power-user feature that lets you quickly find and execute any menu command without navigating the menu bar manually.

## Changes

| File | Purpose |
|---|---|
| `src/native/menu-item-search.swift` | Swift native helper using AXUIElement to enumerate/execute menu items |
| `src/main/main.ts` | IPC handlers: `get-app-menu-items`, `press-app-menu-item` |
| `src/main/preload.ts` | Bridge methods exposed to renderer |
| `src/renderer/types/electron.d.ts` | TypeScript type definitions |
| `src/main/commands.ts` | Register `system-menu-item-search` command |
| `src/renderer/src/MenuItemSearchExtension.tsx` | Search UI with fuzzy matching, keyboard nav, shortcuts |
| `src/renderer/src/hooks/useAppViewManager.ts` | View state management |
| `src/renderer/src/hooks/useLauncherLocalSystemCommands.ts` | Command execution routing |
| `src/renderer/src/components/DetachedOverlayRunners.tsx` | Portal rendering |
| `src/renderer/src/App.tsx` | Component wiring |

## How it works

1. User triggers "Search Menu Items" from the launcher
2. The Swift helper uses `AXUIElement` to traverse the frontmost app's `AXMenuBar`
3. All leaf menu items are collected with their full path (e.g. `File > New Window`), keyboard shortcuts, and enabled state
4. Results are displayed in a searchable overlay with fuzzy matching
5. Selecting an item executes it via `AXPressAction`

## How I tested

- TypeScript compilation passes for main process (`tsc -p tsconfig.main.json --noEmit`)
- Manual review of AXUIElement API usage against macOS Accessibility documentation
- Verified IPC contract matches between main/preload/types/renderer

## Compatibility

- Requires macOS Accessibility permission (same as other SuperCmd features)
- No changes to Raycast API shims — zero risk to extension compatibility
- Follows existing patterns (WindowManagerPanel, etc.) for detached overlay windows