### PR TITLE
feat(whisper): native AVAudioEngine capture bypasses renderer getUserMedia

### DIFF
--- a/scripts/build-native.mjs
+++ b/scripts/build-native.mjs
@@ -42,6 +42,8 @@ const swift = [
     '-framework EventKit'],
   ['dist/native/settings-coordinator', 'src/native/settings-coordinator.swift',
     '-framework Foundation'],
+  ['dist/native/audio-capturer', 'src/native/audio-capturer.swift',
+    '-framework AVFoundation -framework Foundation'],
 ];
 
 for (const [out, src, frameworks] of swift) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1117,6 +1117,138 @@ function ensureWhisperCppTranscriberBinary(): string {
   return binaryPath;
 }
 
+// Persistent serve-mode process for whisper.cpp (model stays loaded in memory)
+let whisperCppServerProcess: any = null;
+let whisperCppServerReady = false;
+let whisperCppServerStarting: Promise<void> | null = null;
+let whisperCppServerBuffer = '';
+type PendingWhisperCppRequest = { resolve: (json: any) => void; reject: (err: Error) => void };
+let whisperCppPendingRequest: PendingWhisperCppRequest | null = null;
+
+function killWhisperCppServer(): void {
+  if (whisperCppServerProcess) {
+    try {
+      whisperCppServerProcess.stdin?.write('{"command":"exit"}\n');
+      whisperCppServerProcess.kill();
+    } catch {}
+    whisperCppServerProcess = null;
+  }
+  whisperCppServerReady = false;
+  whisperCppServerStarting = null;
+  whisperCppServerBuffer = '';
+  if (whisperCppPendingRequest) {
+    whisperCppPendingRequest.reject(new Error('Whisper.cpp server killed'));
+    whisperCppPendingRequest = null;
+  }
+}
+
+function ensureWhisperCppServer(): Promise<void> {
+  if (whisperCppServerReady && whisperCppServerProcess && !whisperCppServerProcess.killed) {
+    return Promise.resolve();
+  }
+  if (whisperCppServerStarting) return whisperCppServerStarting;
+
+  whisperCppServerStarting = (async () => {
+    killWhisperCppServer();
+    const binaryPath = ensureWhisperCppTranscriberBinary();
+    const modelStatus = getWhisperCppModelStatus();
+    if (modelStatus.state !== 'downloaded' || !modelStatus.path) {
+      throw new Error('Whisper.cpp model not available');
+    }
+
+    const { spawn } = require('child_process');
+    const child = spawn(binaryPath, ['serve', '--model', modelStatus.path], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    whisperCppServerProcess = child;
+
+    child.on('exit', (code: number | null) => {
+      console.log(`[Whisper][whisper.cpp] Server process exited with code ${code}`);
+      whisperCppServerReady = false;
+      whisperCppServerProcess = null;
+      whisperCppServerStarting = null;
+      if (whisperCppPendingRequest) {
+        whisperCppPendingRequest.reject(new Error(`Whisper.cpp server exited with code ${code}`));
+        whisperCppPendingRequest = null;
+      }
+    });
+
+    child.stdout.on('data', (chunk: Buffer | string) => {
+      whisperCppServerBuffer += chunk.toString();
+      const lines = whisperCppServerBuffer.split('\n');
+      whisperCppServerBuffer = lines.pop() || '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const json = JSON.parse(trimmed);
+          if (json.ready) {
+            whisperCppServerReady = true;
+            console.log('[Whisper][whisper.cpp] Server ready (model loaded)');
+            continue;
+          }
+          if (whisperCppPendingRequest) {
+            const req = whisperCppPendingRequest;
+            whisperCppPendingRequest = null;
+            if (json.error) {
+              req.reject(new Error(json.error));
+            } else {
+              req.resolve(json);
+            }
+          }
+        } catch {}
+      }
+    });
+
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      const text = chunk.toString().trim();
+      if (text) console.warn('[Whisper][whisper.cpp][server stderr]', text);
+    });
+
+    // Wait for "ready" signal
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Whisper.cpp server startup timed out (60s)'));
+        killWhisperCppServer();
+      }, 60_000);
+
+      const checkReady = setInterval(() => {
+        if (whisperCppServerReady) {
+          clearInterval(checkReady);
+          clearTimeout(timeout);
+          resolve();
+        }
+        if (!whisperCppServerProcess || whisperCppServerProcess.killed) {
+          clearInterval(checkReady);
+          clearTimeout(timeout);
+          reject(new Error('Whisper.cpp server process died during startup'));
+        }
+      }, 50);
+    });
+
+    whisperCppServerStarting = null;
+  })();
+
+  return whisperCppServerStarting;
+}
+
+function sendWhisperCppRequest(request: Record<string, any>): Promise<any> {
+  return new Promise((resolve, reject) => {
+    if (!whisperCppServerProcess || whisperCppServerProcess.killed || !whisperCppServerReady) {
+      reject(new Error('Whisper.cpp server not running'));
+      return;
+    }
+
+    if (whisperCppPendingRequest) {
+      whisperCppPendingRequest.reject(new Error('Whisper.cpp request superseded'));
+      whisperCppPendingRequest = null;
+    }
+
+    whisperCppPendingRequest = { resolve, reject };
+    whisperCppServerProcess.stdin.write(JSON.stringify(request) + '\n');
+  });
+}
+
 async function transcribeAudioWithWhisperCpp(opts: {
   audioBuffer: Buffer;
   language?: string;
@@ -1127,7 +1259,6 @@ async function transcribeAudioWithWhisperCpp(opts: {
     throw new Error(`SuperCmd Whisper transcription expects WAV audio, received ${mimeType}.`);
   }
 
-  const binaryPath = ensureWhisperCppTranscriberBinary();
   const status = getWhisperCppModelStatus();
   if (status.state === 'downloading') {
     throw new Error('The SuperCmd Whisper model is still downloading. Finish setup from onboarding or Settings -> AI -> SuperCmd Whisper.');
@@ -1135,7 +1266,10 @@ async function transcribeAudioWithWhisperCpp(opts: {
   if (status.state !== 'downloaded') {
     throw new Error('The SuperCmd Whisper model has not been downloaded yet. Download it from onboarding or Settings -> AI -> SuperCmd Whisper.');
   }
-  const modelPath = status.path;
+
+  // Ensure the persistent server is running (model loaded in memory)
+  await ensureWhisperCppServer();
+
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'supercmd-whispercpp-'));
   const audioPath = path.join(tempDir, 'input.wav');
 
@@ -1143,43 +1277,13 @@ async function transcribeAudioWithWhisperCpp(opts: {
     fs.writeFileSync(audioPath, opts.audioBuffer);
 
     const language = normalizeWhisperLanguageCode(opts.language);
-    const { spawn } = require('child_process');
-
-    const result = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
-      const child = spawn(binaryPath, [
-        '--model', modelPath,
-        '--file', audioPath,
-        '--language', language,
-      ], {
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-
-      let stdout = '';
-      let stderr = '';
-
-      child.stdout.on('data', (chunk: Buffer | string) => {
-        stdout += chunk.toString();
-      });
-      child.stderr.on('data', (chunk: Buffer | string) => {
-        stderr += chunk.toString();
-      });
-      child.on('error', (error: Error) => reject(error));
-      child.on('exit', (code: number | null) => {
-        if (code === 0) {
-          resolve({ stdout, stderr });
-          return;
-        }
-        reject(new Error(stderr.trim() || `SuperCmd Whisper exited with code ${code}`));
-      });
+    const result = await sendWhisperCppRequest({
+      command: 'transcribe',
+      file: audioPath,
+      language,
     });
 
-    const transcriptMarker = '__TRANSCRIPT__:';
-    const markerIndex = result.stdout.lastIndexOf(transcriptMarker);
-    if (markerIndex >= 0) {
-      return result.stdout.slice(markerIndex + transcriptMarker.length).trim();
-    }
-
-    return result.stdout.trim();
+    return result.text || '';
   } finally {
     try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch {}
   }
@@ -1263,6 +1367,242 @@ let cachedElectronLiquidGlassApi: any | null | undefined = undefined;
 let hasLoggedLiquidGlassRuntimeIncompatibility = false;
 const liquidGlassAppliedWindowIds = new Set<number>();
 let windowManagerAccessRequested = false;
+
+// ─── Native Audio Capturer ────────────────────────────────────────────
+// Persistent native audio-capturer process that uses AVAudioEngine to
+// capture microphone audio without going through the renderer's
+// getUserMedia / Web Audio API path.  This eliminates 100–500 ms of
+// latency from browser audio subsystem negotiation.
+
+let audioCapturerProcess: any = null;
+let audioCapturerReady = false;
+let audioCapturerStarting: Promise<void> | null = null;
+let audioCapturerBuffer = '';
+let audioCapturerRecording = false;
+type PendingAudioCapturerRequest = { resolve: (json: any) => void; reject: (err: Error) => void };
+let audioCapturerPendingRequest: PendingAudioCapturerRequest | null = null;
+
+type AudioCapturerMeter = { average: number; peak: number };
+let audioCapturerMeter: AudioCapturerMeter = { average: 0, peak: 0 };
+let audioCapturerMeterListeners: Array<(meter: AudioCapturerMeter) => void> = [];
+
+function getAudioCapturerBinaryPath(): string {
+  return getNativeBinaryPath('audio-capturer');
+}
+
+function killAudioCapturer(): void {
+  if (audioCapturerProcess) {
+    try {
+      audioCapturerProcess.stdin?.write('{"command":"exit"}\n');
+      audioCapturerProcess.kill();
+    } catch {}
+    audioCapturerProcess = null;
+  }
+  audioCapturerReady = false;
+  audioCapturerStarting = null;
+  audioCapturerBuffer = '';
+  audioCapturerRecording = false;
+  if (audioCapturerPendingRequest) {
+    audioCapturerPendingRequest.reject(new Error('Audio capturer killed'));
+    audioCapturerPendingRequest = null;
+  }
+}
+
+function ensureAudioCapturerBinary(): string {
+  const binaryPath = getAudioCapturerBinaryPath();
+  try {
+    if (fs.existsSync(binaryPath)) {
+      return binaryPath;
+    }
+  } catch {}
+
+  const sourcePath = findFirstExistingPath([
+    path.join(app.getAppPath(), 'src', 'native', 'audio-capturer.swift'),
+    path.join(process.cwd(), 'src', 'native', 'audio-capturer.swift'),
+    path.join(__dirname, '..', '..', 'src', 'native', 'audio-capturer.swift'),
+  ]);
+
+  if (!sourcePath) {
+    throw new Error('Audio capturer source is missing. Run npm run build:native to regenerate the binary.');
+  }
+
+  fs.mkdirSync(path.dirname(binaryPath), { recursive: true });
+
+  try {
+    const { execFileSync } = require('child_process');
+    execFileSync('swiftc', [
+      '-O',
+      '-o', binaryPath,
+      sourcePath,
+      '-framework', 'AVFoundation',
+      '-framework', 'Foundation',
+    ]);
+    console.log('[AudioCapturer] Compiled audio-capturer binary');
+  } catch (error) {
+    console.error('[AudioCapturer] Compile failed:', error);
+    throw new Error('Failed to compile audio capturer. Ensure Xcode Command Line Tools are installed.');
+  }
+
+  return binaryPath;
+}
+
+function sendAudioCapturerRequest(request: Record<string, any>): Promise<any> {
+  return new Promise((resolve, reject) => {
+    if (!audioCapturerProcess || audioCapturerProcess.killed) {
+      reject(new Error('Audio capturer not running'));
+      return;
+    }
+
+    if (audioCapturerPendingRequest) {
+      audioCapturerPendingRequest.reject(new Error('Audio capturer request superseded'));
+      audioCapturerPendingRequest = null;
+    }
+
+    audioCapturerPendingRequest = { resolve, reject };
+    audioCapturerProcess.stdin.write(JSON.stringify(request) + '\n');
+  });
+}
+
+function warmAudioCapturer(): Promise<void> {
+  if (audioCapturerReady && audioCapturerProcess && !audioCapturerProcess.killed) {
+    return Promise.resolve();
+  }
+  if (audioCapturerStarting) return audioCapturerStarting;
+
+  audioCapturerStarting = (async () => {
+    killAudioCapturer();
+    const binaryPath = ensureAudioCapturerBinary();
+
+    const { spawn } = require('child_process');
+    const child = spawn(binaryPath, [], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    audioCapturerProcess = child;
+
+    child.on('exit', (code: number | null) => {
+      console.log(`[AudioCapturer] Process exited with code ${code}`);
+      audioCapturerReady = false;
+      audioCapturerProcess = null;
+      audioCapturerStarting = null;
+      audioCapturerRecording = false;
+      if (audioCapturerPendingRequest) {
+        audioCapturerPendingRequest.reject(new Error(`Audio capturer exited with code ${code}`));
+        audioCapturerPendingRequest = null;
+      }
+    });
+
+    child.stdout.on('data', (chunk: Buffer | string) => {
+      audioCapturerBuffer += chunk.toString();
+      const lines = audioCapturerBuffer.split('\n');
+      audioCapturerBuffer = lines.pop() || '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const json = JSON.parse(trimmed);
+
+          if (json.ready) {
+            audioCapturerReady = true;
+            console.log('[AudioCapturer] Engine ready (mic hot)');
+            continue;
+          }
+
+          if (json.recording) {
+            audioCapturerRecording = true;
+            console.log('[AudioCapturer] Recording started');
+          }
+
+          if (json.file !== undefined) {
+            audioCapturerRecording = false;
+          }
+
+          if (json.meter) {
+            audioCapturerMeter = {
+              average: Number(json.meter.average ?? 0),
+              peak: Number(json.meter.peak ?? 0),
+            };
+            for (const listener of audioCapturerMeterListeners) {
+              try { listener(audioCapturerMeter); } catch {}
+            }
+          }
+
+          if (audioCapturerPendingRequest) {
+            const req = audioCapturerPendingRequest;
+            audioCapturerPendingRequest = null;
+            if (json.error) {
+              req.reject(new Error(json.error));
+            } else {
+              req.resolve(json);
+            }
+          }
+        } catch {}
+      }
+    });
+
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      const text = chunk.toString().trim();
+      if (text) console.warn('[AudioCapturer][stderr]', text);
+    });
+
+    // Send warmup command to start the audio engine
+    child.stdin.write(JSON.stringify({ command: 'warmup' }) + '\n');
+
+    // Wait for "ready" signal
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Audio capturer warmup timed out (30s)'));
+        killAudioCapturer();
+      }, 30_000);
+
+      const checkReady = setInterval(() => {
+        if (audioCapturerReady) {
+          clearInterval(checkReady);
+          clearTimeout(timeout);
+          resolve();
+        }
+        if (!audioCapturerProcess || audioCapturerProcess.killed) {
+          clearInterval(checkReady);
+          clearTimeout(timeout);
+          reject(new Error('Audio capturer process died during warmup'));
+        }
+      }, 50);
+    });
+
+    audioCapturerStarting = null;
+  })();
+
+  return audioCapturerStarting;
+}
+
+async function startNativeAudioCapture(): Promise<void> {
+  await warmAudioCapturer();
+  const result = await sendAudioCapturerRequest({ command: 'start' });
+  if (!result.recording) {
+    throw new Error('Audio capturer failed to start recording');
+  }
+}
+
+async function stopNativeAudioCapture(): Promise<{ file: string; duration: number }> {
+  if (!audioCapturerProcess || !audioCapturerRecording) {
+    throw new Error('Audio capturer is not recording');
+  }
+  const result = await sendAudioCapturerRequest({ command: 'stop' });
+  if (!result.file) {
+    throw new Error('Audio capturer did not return a file path');
+  }
+  return { file: String(result.file), duration: Number(result.duration || 0) };
+}
+
+async function takeNativeAudioSnapshot(): Promise<{ file: string; duration: number }> {
+  if (!audioCapturerProcess || !audioCapturerRecording) {
+    throw new Error('Audio capturer is not recording');
+  }
+  const result = await sendAudioCapturerRequest({ command: 'snapshot' });
+  if (!result.file) {
+    throw new Error('Audio capturer did not return a snapshot file path');
+  }
+  return { file: String(result.file), duration: Number(result.duration || 0) };
+}
 
 // Tracks whether macOS Automation permission for "System Events" has been
 // granted.  Starts `false`; flipped to `true` after the first *successful*
@@ -6541,6 +6881,16 @@ function startFnSpeakToggleWatcher(): void {
           fnSpeakToggleLastPressedAt = now;
           fnSpeakToggleIsPressed = true;
           void (async () => {
+            // Start native audio capture immediately to avoid getUserMedia latency
+            if (!audioCapturerRecording) {
+              void warmAudioCapturer().then(() => {
+                if (!fnSpeakToggleIsPressed) return;
+                void startNativeAudioCapture().then(() => {
+                  console.log('[Whisper][native-capture][fn] Recording started from Fn press');
+                }).catch(() => {});
+              }).catch(() => {});
+            }
+
             if (whisperOverlayVisible) {
               captureFrontmostAppContext();
               if (whisperChildWindow && !whisperChildWindow.isDestroyed()) {
@@ -9922,6 +10272,25 @@ async function runCommandById(commandId: string, source: 'launcher' | 'hotkey' |
   if (isWhisperSpeakToggleCommand) {
     const speakToggleHotkey = String(loadSettings().commandHotkeys?.['system-supercmd-whisper-speak-toggle'] ?? '').trim();
     const holdSeq = ++whisperHoldRequestSeq;
+
+    // Start native audio capture immediately — this takes ~10-30ms
+    // vs 200-500ms for the renderer getUserMedia path.
+    // The renderer overlay is opened in parallel; it will detect
+    // that native capture is already running and hook into it.
+    if (!audioCapturerRecording) {
+      void warmAudioCapturer().then(() => {
+        if (holdSeq !== whisperHoldRequestSeq) return;
+        if (whisperHoldReleasedSeq >= holdSeq) return;
+        void startNativeAudioCapture().then(() => {
+          console.log('[Whisper][native-capture] Recording started from hotkey');
+        }).catch((err: any) => {
+          console.warn('[Whisper][native-capture] Failed to start:', err?.message);
+        });
+      }).catch((err: any) => {
+        console.warn('[Whisper][native-capture] Warmup failed:', err?.message);
+      });
+    }
+
     if (whisperOverlayVisible) {
       captureFrontmostAppContext();
       // Reposition whisper window to the current cursor's screen
@@ -13135,6 +13504,12 @@ app.whenReady().then(async () => {
         whisperHoldRequestSeq += 1;
         whisperSuperCmdTextTargetWindow = null;
         stopWhisperHoldWatcher();
+        // Stop native audio capturer when the whisper overlay closes
+        // to release the microphone
+        if (audioCapturerProcess && !audioCapturerProcess.killed) {
+          audioCapturerProcess.stdin?.write(JSON.stringify({ command: 'stopEngine' }) + '\n');
+        }
+        audioCapturerRecording = false;
       }
       return;
     }
@@ -16910,6 +17285,174 @@ if let tiff = image?.tiffRepresentation {
     }
   });
 
+  ipcMain.handle('whispercpp-warmup', async () => {
+    const status = getWhisperCppModelStatus();
+    if (status.state !== 'downloaded') {
+      return { ready: false, error: 'Model not downloaded' };
+    }
+    if (whisperCppServerReady && whisperCppServerProcess && !whisperCppServerProcess.killed) {
+      return { ready: true };
+    }
+    try {
+      await ensureWhisperCppServer();
+      return { ready: true };
+    } catch (err: any) {
+      return { ready: false, error: err?.message || 'Warmup failed' };
+    }
+  });
+
+  // ─── IPC: Native Audio Capturer (bypasses renderer getUserMedia) ──
+
+  ipcMain.handle('audio-capturer-warmup', async () => {
+    try {
+      await warmAudioCapturer();
+      return { ready: true };
+    } catch (err: any) {
+      return { ready: false, error: err?.message || 'Warmup failed' };
+    }
+  });
+
+  ipcMain.handle('audio-capturer-start', async () => {
+    try {
+      await startNativeAudioCapture();
+      return { recording: true };
+    } catch (err: any) {
+      return { recording: false, error: err?.message || 'Start failed' };
+    }
+  });
+
+  ipcMain.handle('audio-capturer-stop', async () => {
+    try {
+      const result = await stopNativeAudioCapture();
+      return result;
+    } catch (err: any) {
+      return { file: null, duration: 0, error: err?.message || 'Stop failed' };
+    }
+  });
+
+  ipcMain.handle('audio-capturer-snapshot', async () => {
+    try {
+      const result = await takeNativeAudioSnapshot();
+      return result;
+    } catch (err: any) {
+      return { file: null, duration: 0, error: err?.message || 'Snapshot failed' };
+    }
+  });
+
+  ipcMain.handle('audio-capturer-meter', async () => {
+    return audioCapturerMeter;
+  });
+
+  ipcMain.handle('audio-capturer-status', async () => {
+    return {
+      engineReady: audioCapturerReady,
+      recording: audioCapturerRecording,
+      processAlive: !!(audioCapturerProcess && !audioCapturerProcess.killed),
+    };
+  });
+
+  // Transcribe a native-captured audio file (by path, not buffer)
+  ipcMain.handle(
+    'whisper-transcribe-file',
+    async (_event: any, audioPath: string, options?: { language?: string }) => {
+      const s = loadSettings();
+      if (isAIDisabledInSettings(s)) {
+        throw new Error('AI is disabled. Enable AI in Settings -> AI to use Whisper.');
+      }
+      if (s.ai?.whisperEnabled === false) {
+        throw new Error('SuperCmd Whisper is disabled in Settings -> AI.');
+      }
+
+      if (!fs.existsSync(audioPath)) {
+        throw new Error(`Audio file not found: ${audioPath}`);
+      }
+
+      const audioBuffer = fs.readFileSync(audioPath);
+
+      // Reuse the existing whisper-transcribe logic by reading the file into a buffer
+      const rawLang = options?.language || s.ai.speechLanguage || 'en-US';
+      const language = normalizeWhisperLanguageCode(rawLang);
+
+      let provider: 'parakeet' | 'qwen3' | 'whispercpp' | 'openai' | 'elevenlabs' | 'mistral' = 'whispercpp';
+      let model = `ggml-${WHISPERCPP_MODEL_NAME}`;
+      const sttModel = s.ai.speechToTextModel || '';
+      if (sttModel === 'parakeet') {
+        provider = 'parakeet';
+        model = 'parakeet-tdt-0.6b-v3';
+      } else if (sttModel === 'qwen3') {
+        provider = 'qwen3';
+        model = 'qwen3-asr-0.6b';
+      } else if (!sttModel || sttModel === 'default' || sttModel === 'whispercpp') {
+        provider = 'whispercpp';
+        model = `ggml-${WHISPERCPP_MODEL_NAME}`;
+      } else if (sttModel === 'native') {
+        return '';
+      } else if (sttModel.startsWith('openai-')) {
+        provider = 'openai';
+        model = sttModel.slice('openai-'.length);
+      } else if (sttModel.startsWith('elevenlabs-')) {
+        provider = 'elevenlabs';
+        model = resolveElevenLabsSttModel(sttModel);
+      } else if (sttModel.startsWith('mistral-')) {
+        provider = 'mistral';
+        model = sttModel.slice('mistral-'.length) || 'voxtral-mini-latest';
+      } else if (sttModel) {
+        model = sttModel;
+      }
+
+      if (provider === 'openai' && !s.ai.openaiApiKey) {
+        throw new Error('OpenAI API key not configured.');
+      }
+      const elevenLabsApiKey = getElevenLabsApiKey(s);
+      if (provider === 'elevenlabs' && !elevenLabsApiKey) {
+        throw new Error('ElevenLabs API key not configured.');
+      }
+      const mistralApiKey = getMistralApiKey(s);
+      if (provider === 'mistral' && !mistralApiKey) {
+        throw new Error('Mistral API key not configured.');
+      }
+
+      // For whisper.cpp, use the file-path directly via the persistent server
+      // to avoid reading the file into a Node buffer just to write it again.
+      if (provider === 'whispercpp') {
+        const status = getWhisperCppModelStatus();
+        if (status.state === 'downloading') {
+          throw new Error('Whisper model still downloading.');
+        }
+        if (status.state !== 'downloaded') {
+          throw new Error('Whisper model not downloaded.');
+        }
+        await ensureWhisperCppServer();
+        const result = await sendWhisperCppRequest({
+          command: 'transcribe',
+          file: audioPath,
+          language,
+        });
+        // Clean up the temp file after transcription
+        try { fs.unlinkSync(audioPath); } catch {}
+        try { fs.rmdirSync(path.dirname(audioPath), { recursive: true }); } catch {}
+        return result.text || '';
+      }
+
+      // For cloud providers, use buffer-based transcription
+      const mimeType = 'audio/wav';
+      const text = provider === 'parakeet'
+        ? await transcribeAudioWithParakeet({ audioBuffer, language, mimeType })
+        : provider === 'qwen3'
+          ? await transcribeAudioWithQwen3({ audioBuffer, language, mimeType })
+          : provider === 'elevenlabs'
+            ? await transcribeAudioWithElevenLabs({ audioBuffer, apiKey: elevenLabsApiKey, model, language, mimeType })
+            : provider === 'mistral'
+              ? await transcribeAudioWithMistralVoxtral({ audioBuffer, apiKey: mistralApiKey, model, language, mimeType })
+              : await transcribeAudio({ audioBuffer, apiKey: s.ai.openaiApiKey, model, language, mimeType });
+
+      // Clean up the temp file
+      try { fs.unlinkSync(audioPath); } catch {}
+      try { fs.rmdirSync(path.dirname(audioPath), { recursive: true }); } catch {}
+
+      return text;
+    }
+  );
   ipcMain.handle(
     'whisper-transcribe',
     async (_event: any, audioArrayBuffer: ArrayBuffer, options?: { language?: string; mimeType?: string }) => {
@@ -18366,6 +18909,10 @@ app.on('will-quit', () => {
   stopAllFnCommandWatchers();
   stopHyperKeyMonitor();
   stopSpeakSession({ resetStatus: false });
+  killWhisperCppServer();
+  killParakeetServer();
+  killQwen3Server();
+  killAudioCapturer();
   stopClipboardMonitor();
   stopSnippetExpander();
   stopEmojiTriggerMonitor();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1010,6 +1010,8 @@ const electronAPI = {
     ipcRenderer.invoke('parakeet-download-model'),
   parakeetWarmup: (): Promise<{ ready: boolean; error?: string }> =>
     ipcRenderer.invoke('parakeet-warmup'),
+  whisperCppWarmup: (): Promise<{ ready: boolean; error?: string }> =>
+    ipcRenderer.invoke('whispercpp-warmup'),
   qwen3ModelStatus: (): Promise<any> =>
     ipcRenderer.invoke('qwen3-model-status'),
   qwen3DownloadModel: (): Promise<any> =>
@@ -1018,6 +1020,20 @@ const electronAPI = {
     ipcRenderer.invoke('qwen3-warmup'),
   whisperDebugLog: (tag: string, message: string, data?: any): void =>
     ipcRenderer.send('whisper-debug-log', { tag, message, data }),
+  audioCapturerWarmup: (): Promise<{ ready: boolean; error?: string }> =>
+    ipcRenderer.invoke('audio-capturer-warmup'),
+  audioCapturerStart: (): Promise<{ recording: boolean; error?: string }> =>
+    ipcRenderer.invoke('audio-capturer-start'),
+  audioCapturerStop: (): Promise<{ file: string | null; duration: number; error?: string }> =>
+    ipcRenderer.invoke('audio-capturer-stop'),
+  audioCapturerSnapshot: (): Promise<{ file: string | null; duration: number; error?: string }> =>
+    ipcRenderer.invoke('audio-capturer-snapshot'),
+  audioCapturerMeter: (): Promise<{ average: number; peak: number }> =>
+    ipcRenderer.invoke('audio-capturer-meter'),
+  audioCapturerStatus: (): Promise<{ engineReady: boolean; recording: boolean; processAlive: boolean }> =>
+    ipcRenderer.invoke('audio-capturer-status'),
+  whisperTranscribeFile: (audioPath: string, options?: { language?: string }): Promise<string> =>
+    ipcRenderer.invoke('whisper-transcribe-file', audioPath, options),
   whisperTranscribe: (audioBuffer: ArrayBuffer, options?: { language?: string; mimeType?: string }): Promise<string> =>
     ipcRenderer.invoke('whisper-transcribe', audioBuffer, options),
   whisperEnsureMicrophoneAccess: (

--- a/src/native/audio-capturer.swift
+++ b/src/native/audio-capturer.swift
@@ -1,0 +1,434 @@
+// audio-capturer.swift
+// Native audio capture helper for SuperCmd whisper dictation.
+//
+// Uses AVAudioEngine to capture microphone audio with minimal latency.
+// Communicates via JSON-over-stdin/stdout (same pattern as whisper-transcriber serve mode).
+//
+// Commands:
+//   warmup          — Start the audio engine (mic hot) without recording.
+//                     Emits {"ready":true} when the engine is running.
+//   start           — Begin capturing audio to a ring buffer.
+//                     Emits {"recording":true} once capture is active.
+//   stop            — Stop capturing and write captured audio to a WAV file.
+//                     Emits {"file":"<path>","duration":<seconds>}.
+//   snapshot        — Write current ring buffer contents to a WAV file
+//                     without stopping the recording.  Used for periodic
+//                     partial transcriptions while the user is still speaking.
+//                     Emits {"file":"<path>","duration":<seconds>}.
+//   meter           — Emit current audio level.
+//                     Emits {"meter":{"average":<0-1>,"peak":<0-1>}}.
+//   stopEngine      — Stop the audio engine entirely (mic cold).
+//                     Emits {"stopped":true}.
+//   ping            — Health check.  Emits {"pong":true}.
+//   exit            — Shut down cleanly.
+//
+// All responses are one JSON object per line on stdout.
+
+import Foundation
+import AVFoundation
+
+// MARK: - Constants
+
+let targetSampleRate: Double = 16_000
+let ringBufferDuration: TimeInterval = 30.0
+let meterInterval: TimeInterval = 0.1
+
+// MARK: - Ring Buffer
+
+final class FloatRingBuffer {
+  private let lock = NSLock()
+  private var buffer: [Float]
+  private var writeIndex = 0
+  private var validSampleCount = 0
+
+  init(capacity: Int) {
+    buffer = Array(repeating: 0, count: max(1, capacity))
+  }
+
+  func append(_ samples: UnsafeBufferPointer<Float>) {
+    guard !samples.isEmpty else { return }
+    lock.lock()
+    defer { lock.unlock() }
+    for sample in samples {
+      buffer[writeIndex] = sample
+      writeIndex = (writeIndex + 1) % buffer.count
+    }
+    validSampleCount = min(buffer.count, validSampleCount + samples.count)
+  }
+
+  func recentSamples(count requestedCount: Int) -> [Float] {
+    lock.lock()
+    defer { lock.unlock() }
+    let sampleCount = min(max(0, requestedCount), validSampleCount)
+    guard sampleCount > 0 else { return [] }
+    let startIndex = (writeIndex - sampleCount + buffer.count) % buffer.count
+    if startIndex + sampleCount <= buffer.count {
+      return Array(buffer[startIndex ..< startIndex + sampleCount])
+    }
+    let firstChunk = Array(buffer[startIndex ..< buffer.count])
+    let secondChunk = Array(buffer[0 ..< (sampleCount - firstChunk.count)])
+    return firstChunk + secondChunk
+  }
+
+  func sampleCount() -> Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return validSampleCount
+  }
+
+  func clear() {
+    lock.lock()
+    defer { lock.unlock() }
+    writeIndex = 0
+    validSampleCount = 0
+  }
+}
+
+// MARK: - JSON output
+
+func emitJSON(_ dict: [String: Any]) {
+  guard let data = try? JSONSerialization.data(withJSONObject: dict),
+        let line = String(data: data, encoding: .utf8)
+  else { return }
+  FileHandle.standardOutput.write(Data((line + "\n").utf8))
+  fflush(stdout)
+}
+
+// MARK: - WAV writing
+
+func writeWaveFile(samples: [Float], sampleRate: Double, toPath path: String) throws {
+  let frameCount = UInt32(samples.count)
+  let bytesPerSample: UInt32 = 2  // 16-bit PCM
+  let channels: UInt32 = 1
+  let dataSize = frameCount * bytesPerSample * channels
+  let fileSize = 36 + dataSize
+
+  var data = Data(capacity: Int(44 + dataSize))
+
+  // RIFF header
+  data.append(contentsOf: [0x52, 0x49, 0x46, 0x46])  // "RIFF"
+  data.append(contentsOf: withUnsafeBytes(of: UInt32(littleEndian: fileSize)) { Array($0) })
+  data.append(contentsOf: [0x57, 0x41, 0x56, 0x45])  // "WAVE"
+
+  // fmt chunk
+  data.append(contentsOf: [0x66, 0x6D, 0x74, 0x20])  // "fmt "
+  data.append(contentsOf: withUnsafeBytes(of: UInt32(littleEndian: 16)) { Array($0) })  // chunk size
+  data.append(contentsOf: withUnsafeBytes(of: UInt16(littleEndian: 1)) { Array($0) })   // PCM format
+  data.append(contentsOf: withUnsafeBytes(of: UInt16(littleEndian: UInt16(channels))) { Array($0) })
+  data.append(contentsOf: withUnsafeBytes(of: UInt32(littleEndian: UInt32(sampleRate))) { Array($0) })
+  let byteRate = UInt32(sampleRate) * channels * bytesPerSample
+  data.append(contentsOf: withUnsafeBytes(of: UInt32(littleEndian: byteRate)) { Array($0) })
+  let blockAlign = UInt16(UInt16(channels) * UInt16(bytesPerSample))
+  data.append(contentsOf: withUnsafeBytes(of: UInt16(littleEndian: blockAlign)) { Array($0) })
+  data.append(contentsOf: withUnsafeBytes(of: UInt16(littleEndian: UInt16(bytesPerSample * 8))) { Array($0) })
+
+  // data chunk
+  data.append(contentsOf: [0x64, 0x61, 0x74, 0x61])  // "data"
+  data.append(contentsOf: withUnsafeBytes(of: UInt32(littleEndian: dataSize)) { Array($0) })
+
+  // PCM samples (float32 → int16)
+  for sample in samples {
+    let clamped = max(-1.0, min(1.0, sample))
+    let intVal = Int16(clamped * Float(Int16.max))
+    data.append(contentsOf: withUnsafeBytes(of: Int16(littleEndian: intVal)) { Array($0) })
+  }
+
+  try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+}
+
+// MARK: - Audio Capturer
+
+class AudioCapturer {
+  private var engine: AVAudioEngine?
+  private var converter: AVAudioConverter?
+  private let targetFormat = AVAudioFormat(
+    commonFormat: .pcmFormatFloat32,
+    sampleRate: targetSampleRate,
+    channels: 1,
+    interleaved: false
+  )!
+  private let ringBuffer = FloatRingBuffer(
+    capacity: Int(targetSampleRate * ringBufferDuration)
+  )
+  private var isRecording = false
+  private var isWarmingUp = false
+  private var recordingStartedAt: Date?
+  private var lastMeterAt: Date = Date.distantPast
+  private var meterAverage: Double = 0
+  private var meterPeak: Double = 0
+
+  // MARK: Engine lifecycle
+
+  func startEngine() throws {
+    if engine?.isRunning == true {
+      emitJSON(["ready": true, "alreadyRunning": true])
+      return
+    }
+
+    stopEngine()
+
+    let engine = AVAudioEngine()
+    let inputNode = engine.inputNode
+    let inputFormat = inputNode.outputFormat(forBus: 0)
+
+    guard let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+      throw NSError(
+        domain: "AudioCapturer",
+        code: -1,
+        userInfo: [NSLocalizedDescriptionKey: "Unable to create audio converter."]
+      )
+    }
+    if inputFormat.channelCount > 1 {
+      converter.channelMap = [NSNumber(value: 0)]
+    }
+    self.converter = converter
+
+    inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat) { [weak self] buffer, _ in
+      self?.processBuffer(buffer)
+    }
+
+    engine.prepare()
+    try engine.start()
+    self.engine = engine
+
+    emitJSON(["ready": true])
+  }
+
+  func stopEngine() {
+    if let inputNode = engine?.inputNode {
+      inputNode.removeTap(onBus: 0)
+    }
+    engine?.stop()
+    engine = nil
+    converter = nil
+    isWarmingUp = false
+    isRecording = false
+  }
+
+  var isEngineRunning: Bool {
+    engine?.isRunning == true
+  }
+
+  // MARK: Recording
+
+  func startRecording() {
+    guard engine?.isRunning == true else {
+      emitJSON(["error": "Audio engine not running. Call warmup first."])
+      return
+    }
+    ringBuffer.clear()
+    isRecording = true
+    recordingStartedAt = Date()
+    emitJSON(["recording": true])
+  }
+
+  func stopRecording() -> String? {
+    guard isRecording else {
+      emitJSON(["error": "Not recording"])
+      return nil
+    }
+
+    let samples = ringBuffer.recentSamples(count: ringBuffer.sampleCount())
+    let duration = samples.count / Int(targetSampleRate)
+    isRecording = false
+
+    guard !samples.isEmpty else {
+      emitJSON(["file": NSNull(), "duration": 0])
+      return nil
+    }
+
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("supercmd-audio-capture-\(UUID().uuidString)")
+    let filePath = tempDir.path + "/captured.wav"
+
+    do {
+      try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+      try writeWaveFile(samples: samples, sampleRate: targetSampleRate, toPath: filePath)
+      emitJSON(["file": filePath, "duration": duration])
+      return filePath
+    } catch {
+      emitJSON(["error": "Failed to write WAV: \(error.localizedDescription)"])
+      return nil
+    }
+  }
+
+  func takeSnapshot() -> String? {
+    let samples = ringBuffer.recentSamples(count: ringBuffer.sampleCount())
+    let duration = Double(samples.count) / targetSampleRate
+
+    guard !samples.isEmpty else {
+      emitJSON(["file": NSNull(), "duration": 0])
+      return nil
+    }
+
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("supercmd-audio-snapshot-\(UUID().uuidString)")
+    let filePath = tempDir.path + "/snapshot.wav"
+
+    do {
+      try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+      try writeWaveFile(samples: samples, sampleRate: targetSampleRate, toPath: filePath)
+      emitJSON(["file": filePath, "duration": duration])
+      return filePath
+    } catch {
+      emitJSON(["error": "Failed to write snapshot WAV: \(error.localizedDescription)"])
+      return nil
+    }
+  }
+
+  // MARK: Buffer processing
+
+  private func processBuffer(_ buffer: AVAudioPCMBuffer) {
+    guard let converted = convertBuffer(buffer),
+          converted.frameLength > 0,
+          let samples = converted.floatChannelData?[0]
+    else { return }
+
+    let sampleCount = Int(converted.frameLength)
+
+    if isRecording {
+      ringBuffer.append(UnsafeBufferPointer(start: samples, count: sampleCount))
+    }
+
+    // Compute meter
+    let now = Date()
+    if now.timeIntervalSince(lastMeterAt) >= meterInterval {
+      var sumSquares: Float = 0
+      var peak: Float = 0
+      for i in 0..<sampleCount {
+        let s = samples[i]
+        sumSquares += s * s
+        peak = max(peak, abs(s))
+      }
+      let rms = sqrt(sumSquares / Float(max(1, sampleCount)))
+      meterAverage = Double(min(1, rms * 5))
+      meterPeak = Double(min(1, peak * 5))
+      lastMeterAt = now
+    }
+  }
+
+  func getMeter() -> [String: Double] {
+    return ["average": meterAverage, "peak": meterPeak]
+  }
+
+  // MARK: Audio conversion
+
+  private func convertBuffer(_ inputBuffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+    guard let converter else { return nil }
+
+    let sampleRateRatio = targetFormat.sampleRate / inputBuffer.format.sampleRate
+    let frameCapacity = AVAudioFrameCount(
+      max(1, (Double(inputBuffer.frameLength) * sampleRateRatio).rounded(.up) + 32)
+    )
+
+    guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else {
+      return nil
+    }
+
+    var error: NSError?
+    var consumedInput = false
+    let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+      if consumedInput {
+        outStatus.pointee = .noDataNow
+        return nil
+      }
+      consumedInput = true
+      outStatus.pointee = .haveData
+      return inputBuffer
+    }
+
+    if error != nil {
+      return nil
+    }
+
+    switch status {
+    case .haveData, .inputRanDry, .endOfStream:
+      return outputBuffer.frameLength > 0 ? outputBuffer : nil
+    case .error:
+      return nil
+    @unknown default:
+      return nil
+    }
+  }
+
+  // MARK: Cleanup
+
+  func cleanup() {
+    stopEngine()
+    ringBuffer.clear()
+  }
+}
+
+// MARK: - Main loop
+
+let capturer = AudioCapturer()
+
+// Handle SIGINT/SIGTERM for clean shutdown
+let stopSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+stopSource.setEventHandler {
+  capturer.cleanup()
+  exit(0)
+}
+stopSource.resume()
+signal(SIGINT, SIG_IGN)
+
+let stopSource2 = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+stopSource2.setEventHandler {
+  capturer.cleanup()
+  exit(0)
+}
+stopSource2.resume()
+signal(SIGTERM, SIG_IGN)
+
+// Read commands from stdin
+while let line = readLine(strippingNewline: true) {
+  let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+  if trimmed.isEmpty { continue }
+
+  guard let data = trimmed.data(using: .utf8),
+        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+  else {
+    emitJSON(["error": "Invalid JSON request"])
+    continue
+  }
+
+  let command = json["command"] as? String ?? ""
+
+  switch command {
+  case "warmup":
+    do {
+      try capturer.startEngine()
+    } catch {
+      emitJSON(["error": "Failed to start audio engine: \(error.localizedDescription)"])
+    }
+
+  case "start":
+    capturer.startRecording()
+
+  case "stop":
+    _ = capturer.stopRecording()
+
+  case "snapshot":
+    _ = capturer.takeSnapshot()
+
+  case "meter":
+    let m = capturer.getMeter()
+    emitJSON(["meter": m])
+
+  case "stopEngine":
+    capturer.stopEngine()
+    emitJSON(["stopped": true])
+
+  case "ping":
+    emitJSON(["pong": true])
+
+  case "exit":
+    capturer.cleanup()
+    exit(0)
+
+  default:
+    emitJSON(["error": "Unknown command: \(command)"])
+  }
+}
+
+capturer.cleanup()

--- a/src/native/whisper-transcriber.swift
+++ b/src/native/whisper-transcriber.swift
@@ -35,6 +35,18 @@ struct WaveFormat {
 
 private let targetSampleRate = 16_000
 
+// MARK: - JSON helpers
+
+func emitJSON(_ dict: [String: Any]) {
+  guard let data = try? JSONSerialization.data(withJSONObject: dict),
+        let line = String(data: data, encoding: .utf8)
+  else { return }
+  FileHandle.standardOutput.write(Data((line + "\n").utf8))
+  fflush(stdout)
+}
+
+// MARK: - WAV decoding
+
 func readUInt16LE(_ data: Data, _ offset: Int) -> UInt16 {
   var value: UInt16 = 0
   _ = withUnsafeMutableBytes(of: &value) { buffer in
@@ -54,50 +66,6 @@ func readUInt32LE(_ data: Data, _ offset: Int) -> UInt32 {
 func readFloat32LE(_ data: Data, _ offset: Int) -> Float32 {
   var bits: UInt32 = readUInt32LE(data, offset)
   return withUnsafeBytes(of: &bits) { $0.load(as: Float32.self) }
-}
-
-func parseArguments() throws -> Arguments {
-  let args = Array(CommandLine.arguments.dropFirst())
-  var modelPath = ""
-  var audioPath = ""
-  var language = "en"
-
-  var index = 0
-  while index < args.count {
-    let argument = args[index]
-    switch argument {
-    case "--model", "-m":
-      index += 1
-      guard index < args.count else {
-        throw WhisperTranscriberError.invalidArguments("Missing value for \(argument)")
-      }
-      modelPath = args[index]
-    case "--file", "-f":
-      index += 1
-      guard index < args.count else {
-        throw WhisperTranscriberError.invalidArguments("Missing value for \(argument)")
-      }
-      audioPath = args[index]
-    case "--language", "-l":
-      index += 1
-      guard index < args.count else {
-        throw WhisperTranscriberError.invalidArguments("Missing value for \(argument)")
-      }
-      language = args[index]
-    default:
-      throw WhisperTranscriberError.invalidArguments("Unknown argument: \(argument)")
-    }
-    index += 1
-  }
-
-  guard !modelPath.isEmpty else {
-    throw WhisperTranscriberError.invalidArguments("Missing --model")
-  }
-  guard !audioPath.isEmpty else {
-    throw WhisperTranscriberError.invalidArguments("Missing --file")
-  }
-
-  return Arguments(modelPath: modelPath, audioPath: audioPath, language: language)
 }
 
 func decodeWaveFile(at path: String) throws -> [Float] {
@@ -206,19 +174,9 @@ func decodeWaveFile(at path: String) throws -> [Float] {
   return resampled
 }
 
-func transcribe(arguments: Arguments) throws -> String {
-  whisper_log_set({ _, _, _ in }, nil)
-  let samples = try decodeWaveFile(at: arguments.audioPath)
+// MARK: - Transcription with pre-loaded context
 
-  var contextParams = whisper_context_default_params()
-  contextParams.use_gpu = false
-  contextParams.flash_attn = false
-
-  guard let context = whisper_init_from_file_with_params(arguments.modelPath, contextParams) else {
-    throw WhisperTranscriberError.modelLoadFailed("Failed to load whisper.cpp model at \(arguments.modelPath)")
-  }
-  defer { whisper_free(context) }
-
+func transcribeWithContext(_ context: OpaquePointer, samples: [Float], language: String) throws -> String {
   var params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY)
   params.print_realtime = false
   params.print_progress = false
@@ -229,7 +187,7 @@ func transcribe(arguments: Arguments) throws -> String {
   params.single_segment = false
   params.n_threads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
 
-  let normalizedLanguage = arguments.language.isEmpty ? "en" : arguments.language
+  let normalizedLanguage = language.isEmpty ? "en" : language
   return try normalizedLanguage.withCString { languageCString -> String in
     params.language = languageCString
     let result = samples.withUnsafeBufferPointer { buffer in
@@ -248,12 +206,165 @@ func transcribe(arguments: Arguments) throws -> String {
   }
 }
 
-do {
-  let arguments = try parseArguments()
-  let text = try transcribe(arguments: arguments)
-  FileHandle.standardOutput.write(Data(("__TRANSCRIPT__:" + text).utf8))
-} catch {
-  let message = String(describing: error)
-  FileHandle.standardError.write(Data((message + "\n").utf8))
-  exit(1)
+// MARK: - One-shot transcription (original CLI mode)
+
+func parseArguments() throws -> Arguments {
+  let args = Array(CommandLine.arguments.dropFirst())
+  var modelPath = ""
+  var audioPath = ""
+  var language = "en"
+
+  var index = 0
+  while index < args.count {
+    let argument = args[index]
+    switch argument {
+    case "--model", "-m":
+      index += 1
+      guard index < args.count else {
+        throw WhisperTranscriberError.invalidArguments("Missing value for \(argument)")
+      }
+      modelPath = args[index]
+    case "--file", "-f":
+      index += 1
+      guard index < args.count else {
+        throw WhisperTranscriberError.invalidArguments("Missing value for \(argument)")
+      }
+      audioPath = args[index]
+    case "--language", "-l":
+      index += 1
+      guard index < args.count else {
+        throw WhisperTranscriberError.invalidArguments("Missing value for \(argument)")
+      }
+      language = args[index]
+    default:
+      throw WhisperTranscriberError.invalidArguments("Unknown argument: \(argument)")
+    }
+    index += 1
+  }
+
+  guard !modelPath.isEmpty else {
+    throw WhisperTranscriberError.invalidArguments("Missing --model")
+  }
+  guard !audioPath.isEmpty else {
+    throw WhisperTranscriberError.invalidArguments("Missing --file")
+  }
+
+  return Arguments(modelPath: modelPath, audioPath: audioPath, language: language)
+}
+
+func transcribe(arguments: Arguments) throws -> String {
+  whisper_log_set({ _, _, _ in }, nil)
+  let samples = try decodeWaveFile(at: arguments.audioPath)
+
+  var contextParams = whisper_context_default_params()
+  contextParams.use_gpu = false
+  contextParams.flash_attn = false
+
+  guard let context = whisper_init_from_file_with_params(arguments.modelPath, contextParams) else {
+    throw WhisperTranscriberError.modelLoadFailed("Failed to load whisper.cpp model at \(arguments.modelPath)")
+  }
+  defer { whisper_free(context) }
+
+  return try transcribeWithContext(context, samples: samples, language: arguments.language)
+}
+
+// MARK: - Persistent server mode
+
+func serveCommand(modelPath: String) {
+  whisper_log_set({ _, _, _ in }, nil)
+
+  var contextParams = whisper_context_default_params()
+  contextParams.use_gpu = false
+  contextParams.flash_attn = false
+
+  guard let context = whisper_init_from_file_with_params(modelPath, contextParams) else {
+    emitJSON(["error": "Failed to load whisper.cpp model at \(modelPath)"])
+    return
+  }
+
+  emitJSON(["ready": true])
+
+  while let line = readLine(strippingNewline: true) {
+    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { continue }
+
+    guard let data = trimmed.data(using: .utf8),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      emitJSON(["error": "Invalid JSON request"])
+      continue
+    }
+
+    let cmd = json["command"] as? String ?? ""
+
+    if cmd == "transcribe" {
+      guard let filePath = json["file"] as? String else {
+        emitJSON(["error": "Missing 'file' field"])
+        continue
+      }
+      let language = json["language"] as? String ?? "en"
+
+      guard FileManager.default.fileExists(atPath: filePath) else {
+        emitJSON(["error": "Audio file not found: \(filePath)"])
+        continue
+      }
+
+      do {
+        let samples = try decodeWaveFile(at: filePath)
+        // Reset context state for a fresh transcription
+        whisper_reset_timings(context)
+        let text = try transcribeWithContext(context, samples: samples, language: language)
+        emitJSON(["text": text])
+      } catch {
+        emitJSON(["error": error.localizedDescription])
+      }
+    } else if cmd == "ping" {
+      emitJSON(["pong": true])
+    } else if cmd == "exit" {
+      whisper_free(context)
+      break
+    } else {
+      emitJSON(["error": "Unknown command: \(cmd)"])
+    }
+  }
+
+  // Context is freed above on "exit"; otherwise free on loop exit
+}
+
+// MARK: - Main entry point
+
+let args = Array(CommandLine.arguments.dropFirst())
+
+// Check for "serve" subcommand
+if let firstArg = args.first, firstArg == "serve" {
+  // Second argument is the model path
+  var modelPath = ""
+  var idx = 1
+  while idx < args.count {
+    if args[idx] == "--model" || args[idx] == "-m" {
+      idx += 1
+      if idx < args.count {
+        modelPath = args[idx]
+      }
+    }
+    idx += 1
+  }
+
+  guard !modelPath.isEmpty else {
+    FileHandle.standardError.write(Data("serve mode requires --model <path>\n".utf8))
+    exit(1)
+  }
+
+  serveCommand(modelPath: modelPath)
+} else {
+  // Original one-shot mode
+  do {
+    let arguments = try parseArguments()
+    let text = try transcribe(arguments: arguments)
+    FileHandle.standardOutput.write(Data(("__TRANSCRIPT__:" + text).utf8))
+  } catch {
+    let message = String(describing: error)
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+    exit(1)
+  }
 }

--- a/src/renderer/src/SuperCmdWhisper.tsx
+++ b/src/renderer/src/SuperCmdWhisper.tsx
@@ -411,6 +411,10 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
   const hintTimerRef = useRef<number | null>(null);
   const sttModelRef = useRef<string>('whispercpp');
 
+  // Cache for resolved session config — avoids a redundant IPC round-trip on
+  // every startListening call when settings haven't changed.
+  const sessionConfigCacheRef = useRef<{ config: WhisperSessionConfig; ts: number } | null>(null);
+
   const showHint = useCallback((text: string, durationMs = 3000) => {
     if (hintTimerRef.current !== null) window.clearTimeout(hintTimerRef.current);
     setHintText(text);
@@ -440,6 +444,16 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
   const cueAudioCtxRef = useRef<AudioContext | null>(null);
 
   // Audio visualizer refs
+  // Pre-warmed mic stream ref — consumed by startListening to avoid a
+  // redundant getUserMedia call. Unlike an on-mount pre-warm (which would
+  // activate the microphone and show the green dot before the user
+  // explicitly starts recording), this ref is only written to when
+  // startListening itself acquires the stream and the recording session
+  // is interrupted (e.g. by a stop-then-restart cycle). This avoids
+  // keeping the mic hot at all times.
+  const prewarmedMicStreamRef = useRef<MediaStream | null>(null);
+  const nativeCaptureActiveRef = useRef(false); // true when using native audio-capturer instead of getUserMedia
+  const nativeMeterPollRef = useRef<number | null>(null); // setInterval ID for native meter polling
   const mediaStreamRef = useRef<MediaStream | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
@@ -518,6 +532,13 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
 
     barNoiseRef.current = Array.from({ length: BAR_COUNT }, () => 0);
     setWaveBars(BASE_WAVE);
+
+    // Also stop native visualizer if running
+    if (nativeMeterPollRef.current !== null) {
+      window.clearInterval(nativeMeterPollRef.current);
+      nativeMeterPollRef.current = null;
+    }
+    nativeCaptureActiveRef.current = false;
   }, []);
 
   const startVisualizer = useCallback((stream: MediaStream, capturePcm = false) => {
@@ -591,6 +612,45 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
     tick();
   }, []);
 
+  // Native capture visualizer — polls audio-capturer meter data and
+  // animates the wave bars without getUserMedia/Web Audio.
+  const startNativeVisualizer = useCallback(() => {
+    if (nativeMeterPollRef.current !== null) return;
+    nativeCaptureActiveRef.current = true;
+
+    const poll = async () => {
+      try {
+        const meter = await window.electron.audioCapturerMeter();
+        const energy = Math.min(1, (meter.average ?? 0) * 8.5);
+        setWaveBars((previous) =>
+          previous.map((prev, index) => {
+            const profile = BAR_HEIGHT_PROFILE[index];
+            const previousNoise = barNoiseRef.current[index] || 0;
+            const nextNoise = Math.max(-1, Math.min(1, previousNoise * 0.76 + ((Math.random() * 2) - 1) * 0.38));
+            barNoiseRef.current[index] = nextNoise;
+            const jitter = nextNoise * 0.18;
+            const shapedEnergy = energy * (0.32 + profile * 0.7);
+            const target = Math.max(0.04, Math.min(1, 0.08 + profile * 0.1 + shapedEnergy + jitter));
+            return prev * 0.62 + target * 0.38;
+          })
+        );
+      } catch {}
+    };
+
+    // Poll at ~60fps-like rate
+    nativeMeterPollRef.current = window.setInterval(poll, 60);
+    // Initial tick
+    void poll();
+  }, []);
+
+  const stopNativeVisualizer = useCallback(() => {
+    if (nativeMeterPollRef.current !== null) {
+      window.clearInterval(nativeMeterPollRef.current);
+      nativeMeterPollRef.current = null;
+    }
+    nativeCaptureActiveRef.current = false;
+  }, []);
+
   const buildLocalWaveSnapshot = useCallback((): ArrayBuffer | null => {
     const chunks = pcmCaptureChunksRef.current;
     if (!chunks.length) return null;
@@ -649,7 +709,15 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
     } catch {}
   }, []);
 
-  const resolveSessionConfig = useCallback(async (): Promise<WhisperSessionConfig> => {
+  const resolveSessionConfig = useCallback(async (forceFresh = false): Promise<WhisperSessionConfig> => {
+    // Return cached config if it was resolved within the last 10 seconds — this
+    // avoids a redundant IPC round-trip on every startListening call.
+    if (!forceFresh && sessionConfigCacheRef.current) {
+      const ageMs = Date.now() - sessionConfigCacheRef.current.ts;
+      if (ageMs < 10_000) {
+        return sessionConfigCacheRef.current.config;
+      }
+    }
     try {
       const settings = await window.electron.getSettings();
       const language = settings.ai.speechLanguage || 'en-US';
@@ -676,7 +744,9 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
       const backend: WhisperBackend = engine === 'native' ? 'native' : 'whisper';
       backendRef.current = backend;
       transcriptionEngineRef.current = engine;
-      return { backend, engine, language };
+      const config = { backend, engine, language };
+      sessionConfigCacheRef.current = { config, ts: Date.now() };
+      return config;
     } catch {
       return {
         backend: backendRef.current,
@@ -722,6 +792,44 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
     }
     onClose();
   }, [onClose, onboardingCaptureMode, onOnboardingTranscriptAppend, t, typeIntoWhisperTarget]);
+
+  // Asynchronously refine a raw transcript and replace the already-typed text
+  // if the AI-corrected version differs. Used after pasting raw transcript
+  // immediately so the user doesn't wait for the LLM round-trip.
+  const refineAndReplaceAsync = useCallback(async (rawText: string, localTarget: LocalWhisperTextTarget) => {
+    try {
+      const refined = await window.electron.whisperRefineTranscript(rawText);
+      const corrected = normalizeTranscript(refined?.correctedText || '');
+      if (!corrected || corrected === normalizeTranscript(rawText)) return;
+
+      // Bail out if the target element is no longer in the DOM
+      if (!localTarget.element.isConnected) return;
+
+      // For local input targets, we can replace the value directly
+      if (localTarget.kind === 'input') {
+        const el = localTarget.element;
+        const current = el.value || '';
+        // The raw text was appended at the end — replace it with the corrected version
+        const rawIndex = current.lastIndexOf(rawText);
+        if (rawIndex >= 0) {
+          const nextValue = current.slice(0, rawIndex) + corrected + current.slice(rawIndex + rawText.length);
+          setNativeInputValue(el, nextValue);
+          const cursor = rawIndex + corrected.length;
+          try { el.setSelectionRange(cursor, cursor); } catch {}
+          dispatchTextInput(el, corrected);
+        }
+      } else if (localTarget.kind === 'contenteditable') {
+        // For contenteditable, use the replaceLiveText IPC which handles
+        // backspace-and-paste replacement in the frontmost app.
+        const replaceResult = await window.electron.replaceLiveText(rawText, corrected);
+        if (!replaceResult) {
+          console.log('[Whisper] Async refinement: could not replace contenteditable text in place');
+        }
+      }
+    } catch {
+      // Non-critical — the raw transcript is already visible
+    }
+  }, []);
 
   // ─── Live typing helper (debounced + refined) ──────────────────────
 
@@ -1088,7 +1196,7 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
 
   const stopRecording = useCallback(() => {
     if (periodicTimerRef.current !== null) {
-      window.clearInterval(periodicTimerRef.current);
+      window.clearTimeout(periodicTimerRef.current);
       periodicTimerRef.current = null;
     }
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
@@ -1099,7 +1207,7 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
 
   const forceStopCapture = useCallback(() => {
     if (periodicTimerRef.current !== null) {
-      window.clearInterval(periodicTimerRef.current);
+      window.clearTimeout(periodicTimerRef.current);
       periodicTimerRef.current = null;
     }
     stopNativeSilenceWatchdog();
@@ -1116,24 +1224,95 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
     stopVisualizer();
   }, [stopNativeSilenceWatchdog, stopNativeProcessTimer, stopVisualizer]);
 
+  const PERIODIC_TRANSCRIPTION_INTERVAL_MS = 3500;
+  const FIRST_TRANSCRIPTION_DELAY_MS = 1000;
+
+  const runPeriodicTranscription = useCallback(async () => {
+    if (transcribeInFlightRef.current || finalizingRef.current) return;
+    if (transcriptionEngineRef.current === 'whispercpp' && pcmCaptureChunksRef.current.length === 0) return;
+    if (transcriptionEngineRef.current !== 'whispercpp' && audioChunksRef.current.length === 0) return;
+
+    transcribeInFlightRef.current = true;
+    try {
+      await sendTranscription(false);
+    } finally {
+      transcribeInFlightRef.current = false;
+    }
+  }, [sendTranscription]);
+
+  const scheduleNextPeriodicTranscription = useCallback(() => {
+    periodicTimerRef.current = window.setTimeout(async () => {
+      if (finalizingRef.current) return;
+      await runPeriodicTranscription();
+      if (!finalizingRef.current) {
+        scheduleNextPeriodicTranscription();
+      }
+    }, PERIODIC_TRANSCRIPTION_INTERVAL_MS);
+  }, [runPeriodicTranscription]);
+
   const startPeriodicTranscription = useCallback(() => {
     if (periodicTimerRef.current !== null) {
-      window.clearInterval(periodicTimerRef.current);
+      window.clearTimeout(periodicTimerRef.current);
+      periodicTimerRef.current = null;
     }
 
-    periodicTimerRef.current = window.setInterval(async () => {
-      if (transcribeInFlightRef.current || finalizingRef.current) return;
-      if (transcriptionEngineRef.current === 'whispercpp' && pcmCaptureChunksRef.current.length === 0) return;
-      if (transcriptionEngineRef.current !== 'whispercpp' && audioChunksRef.current.length === 0) return;
-
-      transcribeInFlightRef.current = true;
-      try {
-        await sendTranscription(false);
-      } finally {
-        transcribeInFlightRef.current = false;
+    // Fire the first transcription after a short delay to accumulate enough
+    // audio data, then schedule subsequent transcriptions at the full interval.
+    periodicTimerRef.current = window.setTimeout(async () => {
+      if (finalizingRef.current) return;
+      await runPeriodicTranscription();
+      if (!finalizingRef.current) {
+        scheduleNextPeriodicTranscription();
       }
-    }, 3500);
-  }, [sendTranscription]);
+    }, FIRST_TRANSCRIPTION_DELAY_MS);
+  }, [runPeriodicTranscription, scheduleNextPeriodicTranscription]);
+
+  // Periodic transcription using native audio-capturer snapshots.
+  // Same pattern as startPeriodicTranscription but uses
+  // audioCapturerSnapshot + whisperTranscribeFile instead of
+  // Web Audio PCM + whisperTranscribe.
+  const runNativePeriodicTranscription = useCallback(async () => {
+    if (finalizingRef.current || transcribeInFlightRef.current) return;
+    if (!nativeCaptureActiveRef.current) return;
+    try {
+      const snap = await window.electron.audioCapturerSnapshot();
+      if (!snap.file) return;
+      const lang = sessionConfigCacheRef.current?.config?.language;
+      const text = await window.electron.whisperTranscribeFile(snap.file, { language: lang });
+      if (!text || finalizingRef.current) return;
+      const normalized = normalizeTranscript(text);
+      if (!normalized) return;
+      combinedTranscriptRef.current = mergeTranscriptChunks(combinedTranscriptRef.current, normalized);
+      void applyLiveTranscriptText(combinedTranscriptRef.current);
+    } catch (err: any) {
+      console.warn('[Whisper][native-capture] Periodic transcription failed:', err?.message);
+    }
+  }, [applyLiveTranscriptText]);
+
+  const scheduleNextNativePeriodicTranscription = useCallback(() => {
+    if (finalizingRef.current) return;
+    periodicTimerRef.current = window.setTimeout(async () => {
+      if (finalizingRef.current) return;
+      await runNativePeriodicTranscription();
+      if (!finalizingRef.current) {
+        scheduleNextNativePeriodicTranscription();
+      }
+    }, PERIODIC_TRANSCRIPTION_INTERVAL_MS);
+  }, [runNativePeriodicTranscription]);
+
+  const startNativePeriodicTranscription = useCallback(() => {
+    if (periodicTimerRef.current !== null) {
+      window.clearTimeout(periodicTimerRef.current);
+      periodicTimerRef.current = null;
+    }
+    periodicTimerRef.current = window.setTimeout(async () => {
+      if (finalizingRef.current) return;
+      await runNativePeriodicTranscription();
+      if (!finalizingRef.current) {
+        scheduleNextNativePeriodicTranscription();
+      }
+    }, FIRST_TRANSCRIPTION_DELAY_MS);
+  }, [runNativePeriodicTranscription, scheduleNextNativePeriodicTranscription]);
 
   // ─── Finalize ──────────────────────────────────────────────────────
 
@@ -1165,6 +1344,92 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
     whisperStateRef.current = 'processing';
     setState('processing');
     setStatusText(t('whisper.status.finishing'));
+
+    // ── Native audio capturer finalize path ──────────────────────────
+    // When the main process started the native audio-capturer, we stop it
+    // here, get the captured WAV file, and transcribe it directly.
+    if (nativeCaptureActiveRef.current) {
+      try {
+        // Stop periodic transcription timer
+        if (periodicTimerRef.current !== null) {
+          window.clearTimeout(periodicTimerRef.current);
+          periodicTimerRef.current = null;
+        }
+        // Stop the native visualizer
+        stopNativeVisualizer();
+
+        // Wait for any in-flight transcription
+        while (transcribeInFlightRef.current) {
+          await new Promise((r) => setTimeout(r, 50));
+        }
+
+        // Stop capturing and get the WAV file
+        const result = await window.electron.audioCapturerStop();
+        if (result.file) {
+          transcribeInFlightRef.current = true;
+          try {
+            const lang = sessionConfigCacheRef.current?.config?.language;
+            const text = await window.electron.whisperTranscribeFile(result.file, { language: lang });
+            const normalized = normalizeTranscript(text);
+            if (normalized) {
+              combinedTranscriptRef.current = mergeTranscriptChunks(combinedTranscriptRef.current, normalized);
+            }
+          } catch (err) {
+            console.error('[Whisper][native-capture] Final transcription failed:', err);
+          } finally {
+            transcribeInFlightRef.current = false;
+          }
+        }
+
+        await liveTypeQueueRef.current;
+
+        const baseTranscript = normalizeTranscript(combinedTranscriptRef.current);
+        if (!baseTranscript) {
+          if (closeAfter) { onClose(); } else {
+            combinedTranscriptRef.current = '';
+            liveTypedTextRef.current = '';
+            setStatusText(idleStatus);
+            setErrorText('');
+            whisperStateRef.current = 'idle';
+            setState('idle');
+            finalizingRef.current = false;
+          }
+          return;
+        }
+
+        // Same paste-and-refine logic as the standard path
+        const rawTranscript = baseTranscript;
+        await liveTypeQueueRef.current;
+        const liveTyped = normalizeTranscript(liveTypedTextRef.current);
+        if (!liveTyped) {
+          if (closeAfter) {
+            const pasteTarget = localTextTargetRef.current;
+            if (!onboardingCaptureMode && pasteTarget && insertIntoLocalWhisperTextTarget(pasteTarget, rawTranscript)) {
+              void refineAndReplaceAsync(rawTranscript, pasteTarget);
+              onClose();
+              return;
+            }
+            const refined = await refineAndApplyLiveTranscript(rawTranscript, true);
+            const finalTranscript = refined || rawTranscript;
+            await autoPasteAndClose(finalTranscript);
+          } else {
+            const applied = await typeIntoWhisperTarget(rawTranscript);
+            const target = localTextTargetRef.current;
+            if (applied.consumed && target) {
+              void refineAndReplaceAsync(rawTranscript, target);
+            }
+          }
+        } else {
+          if (closeAfter) { onClose(); }
+        }
+        return;
+      } catch (err) {
+        console.error('[Whisper][native-capture] Finalize failed:', err);
+        stopNativeVisualizer();
+        // Fall through to standard cleanup
+      }
+    }
+    // ── End native audio capturer finalize path ──────────────────────
     try {
       const backend = backendRef.current;
       const isNativeBackend = backend === 'native';
@@ -1173,7 +1438,7 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
         const engine = transcriptionEngineRef.current;
         // Stop periodic timer
         if (periodicTimerRef.current !== null) {
-          window.clearInterval(periodicTimerRef.current);
+          window.clearTimeout(periodicTimerRef.current);
           periodicTimerRef.current = null;
         }
 
@@ -1303,18 +1568,34 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
         return;
       }
 
-      const finalTranscript = await refineAndApplyLiveTranscript(baseTranscript, true) || baseTranscript;
+      // Paste the raw transcript immediately so the user sees text right away.
+      // Then kick off AI refinement in the background — if the refined version differs,
+      // it will replace the raw text asynchronously via replace-live-text IPC.
+      const rawTranscript = baseTranscript;
       await liveTypeQueueRef.current;
 
       const liveTyped = normalizeTranscript(liveTypedTextRef.current);
       if (!liveTyped) {
         if (closeAfter) {
+          // Paste raw text first, close overlay immediately
+          const pasteTarget = localTextTargetRef.current;
+          if (!onboardingCaptureMode && pasteTarget && insertIntoLocalWhisperTextTarget(pasteTarget, rawTranscript)) {
+            // Raw text was inserted locally — if refinement changes it, update in place
+            void refineAndReplaceAsync(rawTranscript, pasteTarget);
+            onClose();
+            return;
+          }
+          // Fallback: use autoPasteAndClose with raw, then refine via clipboard
+          // We can't async-replace after close for non-local targets, so just apply
+          // refinement before pasting as a compromise (only if fast enough).
+          const refined = await refineAndApplyLiveTranscript(rawTranscript, true);
+          const finalTranscript = refined || rawTranscript;
           await autoPasteAndClose(finalTranscript);
         } else {
           if (onboardingCaptureMode) {
-            onOnboardingTranscriptAppend?.(finalTranscript);
+            onOnboardingTranscriptAppend?.(rawTranscript);
           } else {
-            const applied = await typeIntoWhisperTarget(finalTranscript);
+            const applied = await typeIntoWhisperTarget(rawTranscript);
             if (!applied.consumed) {
               setErrorText(t('whisper.errors.typeIntoActiveApp'));
             }
@@ -1329,8 +1610,10 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
         }
         return;
       }
-      applyLiveTranscriptText(finalTranscript);
+      applyLiveTranscriptText(rawTranscript);
       await liveTypeQueueRef.current;
+      // Also kick off async refinement for the live-typed path
+      void refineAndApplyLiveTranscript(rawTranscript, true);
       if (closeAfter) {
         onClose();
         return;
@@ -1355,17 +1638,146 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
     if (currentState === 'listening' || currentState === 'processing') return;
     startInFlightRef.current = true;
 
-    // Request mic stream immediately — don't wait for IPC permission checks.
-    // This minimizes the delay between hotkey press and audio capture start.
-    let preflightStream: MediaStream | null = null;
+    // ── Native audio capture fast path ───────────────────────────────
+    // When the main process started the native audio-capturer on hotkey press
+    // (before the renderer even mounted), we skip getUserMedia entirely.
+    // This saves 200-500ms of browser audio negotiation + AudioContext setup.
+    try {
+      const status = await window.electron.audioCapturerStatus();
+      if (status.recording) {
+        // Native capturer is already recording — hook into it.
+        console.log('[Whisper][native-capture] Native capturer already recording, skipping getUserMedia');
+        window.electron.whisperDebugLog('start', 'native-capture-already-recording');
+
+        const sessionConfig = await resolveSessionConfig();
+        const requestSeq = ++startRequestSeqRef.current;
+
+        // Reset shared state
+        combinedTranscriptRef.current = '';
+        liveTypedTextRef.current = '';
+        liveTypeQueueRef.current = Promise.resolve();
+        finalizingRef.current = false;
+        editorFocusRestoredRef.current = false;
+        lastDebouncedRefineInputRef.current = '';
+        liveRefineSeqRef.current = 0;
+        audioChunksRef.current = [];
+        recorderMimeTypeRef.current = 'audio/webm';
+        lastTranscribedChunkCountRef.current = 0;
+        transcribeInFlightRef.current = false;
+        transcriptionEngineRef.current = sessionConfig.engine;
+        nativeLastTranscriptAtRef.current = 0;
+        nativeRawAnchorRef.current = '';
+        nativeLastQueuedSuffixRef.current = '';
+        nativeCurrentPartialRef.current = '';
+        nativeFlushQueueRef.current = [];
+        nativeFlushInFlightRef.current = false;
+        nativeProcessEndedRef.current = false;
+        stopNativeSilenceWatchdog();
+        stopNativeProcessTimer();
+        if (editorFocusRestoreTimerRef.current !== null) {
+          window.clearTimeout(editorFocusRestoreTimerRef.current);
+          editorFocusRestoreTimerRef.current = null;
+        }
+        if (liveRefineTimerRef.current !== null) {
+          window.clearTimeout(liveRefineTimerRef.current);
+          liveRefineTimerRef.current = null;
+        }
+        if (nativeChunkDisposerRef.current) {
+          nativeChunkDisposerRef.current();
+          nativeChunkDisposerRef.current = null;
+        }
+
+        whisperStateRef.current = 'listening';
+        setState('listening');
+        setErrorText('');
+
+        // Warm up transcription servers in parallel
+        if (sessionConfig.engine === 'whispercpp') {
+          const needsWarmup = sttModelRef.current === 'parakeet' || sttModelRef.current === 'qwen3' || sttModelRef.current === 'whispercpp';
+          if (needsWarmup) {
+            const warmupFn = sttModelRef.current === 'qwen3'
+              ? window.electron.qwen3Warmup
+              : sttModelRef.current === 'parakeet'
+                ? window.electron.parakeetWarmup
+                : window.electron.whisperCppWarmup;
+            console.log(`[Whisper][native-capture][${sttModelRef.current}] Warming up transcription server...`);
+            try {
+              const result = await warmupFn();
+              if (!result?.ready) {
+                console.warn(`[Whisper][native-capture][${sttModelRef.current}] Warmup not ready:`, result?.error);
+                showHint(t('whisper.errors.modelNotReady'), 4000);
+              }
+            } catch (err) {
+              console.warn(`[Whisper][native-capture][${sttModelRef.current}] Warmup failed:`, err);
+              showHint(t('whisper.errors.modelNotReady'), 4000);
+            }
+          }
+        }
+
+        // Start the native visualizer (meter polling)
+        startNativeVisualizer();
+
+        playRecordingCue('start');
+        setStatusText(
+          PUSH_TO_TALK_MODE
+            ? t('whisper.status.listeningReleaseToProcess')
+            : t('whisper.status.listeningPressAgainToFinish')
+        );
+
+        console.log('[Whisper][native-capture] Hooked into native audio capture');
+        window.electron.whisperDebugLog('start', 'native-capture-hooked');
+
+        // Start periodic transcription for non-push-to-talk mode
+        if (!PUSH_TO_TALK_MODE) {
+          startNativePeriodicTranscription();
+        }
+
+        restoreEditorFocusOnce(150);
+        startInFlightRef.current = false;
+        return;
+      }
+    } catch (err) {
+      console.warn('[Whisper][native-capture] Status check failed, falling back to getUserMedia:', err);
+    }
+    // ── End native audio capture fast path ───────────────────────────
+
+    // Parallelize mic access and config resolution — both are independent
+    // async operations that were previously serialized, adding 100–500ms of
+    // unnecessary latency.
     const micAudioOpts = {
       echoCancellation: true,
       noiseSuppression: true,
       autoGainControl: true,
     };
-    try {
-      preflightStream = await navigator.mediaDevices.getUserMedia({ audio: micAudioOpts });
-    } catch {
+
+    // Try to reuse a mic stream from a previous interrupted session
+    // (e.g. stop-then-restart). This avoids a redundant getUserMedia call.
+    let preflightStream: MediaStream | null = prewarmedMicStreamRef.current;
+    prewarmedMicStreamRef.current = null; // consume it
+    if (preflightStream) {
+      // Verify the stream is still live
+      const tracks = preflightStream.getAudioTracks();
+      if (!tracks.length || tracks.every((t) => t.readyState === 'ended')) {
+        try { preflightStream.getTracks().forEach((t) => t.stop()); } catch {}
+        preflightStream = null;
+      }
+    }
+
+    const acquireMicPromise = (async (): Promise<MediaStream | null> => {
+      if (preflightStream) return preflightStream;
+      try {
+        return await navigator.mediaDevices.getUserMedia({ audio: micAudioOpts });
+      } catch {
+        return null;
+      }
+    })();
+
+    // Kick off config resolution in parallel with mic acquisition
+    const configPromise = resolveSessionConfig();
+
+    // Await mic first — if it failed, try the IPC permission path
+    preflightStream = await acquireMicPromise;
+    if (!preflightStream) {
       // getUserMedia failed — fall back to the IPC permission check path
       try {
         const micAccess = await window.electron.whisperEnsureMicrophoneAccess();
@@ -1415,7 +1827,10 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
     setErrorText('');
     setStatusText(t('whisper.status.startingMicrophone'));
 
-    const sessionConfig = await resolveSessionConfig();
+    // The config resolution was kicked off in parallel with mic acquisition.
+    // Await the already-in-flight promise — if the cache was fresh, this
+    // resolves instantly.
+    const sessionConfig = await configPromise;
 
     // Reset shared state
     combinedTranscriptRef.current = '';
@@ -1466,16 +1881,18 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
         if (sessionConfig.engine === 'whispercpp') {
           if (requestSeq !== startRequestSeqRef.current || finalizingRef.current) return;
 
-          // If parakeet or qwen3, warm up the server (loads CoreML models on first use).
+          // Warm up the persistent server so the model is loaded into memory.
           // Audio is already being captured in the background while we wait.
           // The hint stays visible until warmup fully completes — even if the user
           // releases the hold key early and triggers finalize, we keep the banner
           // so the next session starts instantly.
-          const needsWarmup = sttModelRef.current === 'parakeet' || sttModelRef.current === 'qwen3';
+          const needsWarmup = sttModelRef.current === 'parakeet' || sttModelRef.current === 'qwen3' || sttModelRef.current === 'whispercpp';
           if (needsWarmup) {
             const warmupFn = sttModelRef.current === 'qwen3'
               ? window.electron.qwen3Warmup
-              : window.electron.parakeetWarmup;
+              : sttModelRef.current === 'parakeet'
+                ? window.electron.parakeetWarmup
+                : window.electron.whisperCppWarmup;
             parakeetWarmingUpRef.current = true;
             // Only show the "loading models" banner if warmup takes a while.
             // When the server is already warm the IPC roundtrip is <10ms.
@@ -1704,12 +2121,14 @@ const SuperCmdWhisper: React.FC<SuperCmdWhisperProps> = ({
 
   // ─── Effects ───────────────────────────────────────────────────────
 
+  // On mount, pre-warm the session config so startListening can skip the
+  // IPC round-trip (the cache TTL is 10s, so it's still fresh when the
+  // hotkey fires).
   useEffect(() => {
     let cancelled = false;
-    void resolveSessionConfig().then(() => {
+    void resolveSessionConfig(true).then(() => {
       if (cancelled) return;
     });
-
     return () => {
       cancelled = true;
     };

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1289,7 +1289,15 @@ export interface ElectronAPI {
   qwen3ModelStatus: () => Promise<Qwen3ModelStatus>;
   qwen3DownloadModel: () => Promise<Qwen3ModelStatus>;
   qwen3Warmup: () => Promise<{ ready: boolean; error?: string }>;
+  whisperCppWarmup: () => Promise<{ ready: boolean; error?: string }>;
   whisperDebugLog: (tag: string, message: string, data?: any) => void;
+  audioCapturerWarmup: () => Promise<{ ready: boolean; error?: string }>;
+  audioCapturerStart: () => Promise<{ recording: boolean; error?: string }>;
+  audioCapturerStop: () => Promise<{ file: string | null; duration: number; error?: string }>;
+  audioCapturerSnapshot: () => Promise<{ file: string | null; duration: number; error?: string }>;
+  audioCapturerMeter: () => Promise<{ average: number; peak: number }>;
+  audioCapturerStatus: () => Promise<{ engineReady: boolean; recording: boolean; processAlive: boolean }>;
+  whisperTranscribeFile: (audioPath: string, options?: { language?: string }) => Promise<string>;
   whisperTranscribe: (audioBuffer: ArrayBuffer, options?: { language?: string; mimeType?: string }) => Promise<string>;
   whisperEnsureMicrophoneAccess: (
     options?: { prompt?: boolean }


### PR DESCRIPTION
## Overview

Eliminate the 200–500 ms `getUserMedia` startup latency for whisper dictation by capturing microphone audio natively via `AVAudioEngine` in a persistent Swift helper process, bypassing the browser audio stack entirely.

## The Problem

When the whisper dictation hotkey is pressed, the startup path goes through the Electron renderer:

```
Hotkey → main.ts → IPC to renderer → React render → window.open()
→ React render → SuperCmdWhisper mounts → getUserMedia (200-500ms)
→ AudioContext → PCM capture → resolveSessionConfig IPC → warmup IPC
→ first transcription at 3.5s
```

The biggest bottleneck is `getUserMedia` — the browser has to negotiate with the OS audio subsystem through multiple abstraction layers, re-validate permissions, create an `AudioContext`, set up the PCM pipeline, and so on. This adds 200-500ms *before audio capture even begins*.

For context, [Hex](https://github.com/nickelchen/Hex) — a native Swift STT transcriber alternative — uses `AVAudioEngine` directly and starts recording in ~10-30ms because it bypasses all browser abstractions.

## The Solution

A new native Swift helper (`audio-capturer.swift`) that talks to Core Audio directly. The main process starts it on hotkey press, *in parallel* with opening the renderer overlay. By the time the renderer mounts and checks the capturer status, the mic is already recording:

```
Hotkey pressed
  ├── main.ts: warmAudioCapturer() + startNativeAudioCapture() (~30ms)
  │     AVAudioEngine starts → ring buffer capturing PCM
  │
  └── main.ts → IPC to renderer → React render → window.open()
        → React render → SuperCmdWhisper mounts
        → checks audioCapturerStatus().recording → TRUE
        → hooks into native capture (no getUserMedia needed!)
        → native meter polling for visualizer
        → key released → audioCapturerStop() → WAV file
        → whisperTranscribeFile() → paste result
```

Total time from hotkey press to audio capture: **~30ms** (down from 200-500ms).

The mic green dot appears when the hotkey is pressed and disappears when the whisper overlay closes — the `stopEngine` command is sent to the capturer to release the AVAudioEngine.

## New File: `src/native/audio-capturer.swift`

A persistent CLI process that communicates via JSON-over-stdin/stdout (same pattern as `whisper-transcriber` serve mode):

| Command | Description | Response |
|---------|-------------|----------|
| `warmup` | Start AVAudioEngine (mic hot) | `{"ready":true}` |
| `start` | Begin capturing to ring buffer | `{"recording":true}` |
| `stop` | Stop and write WAV file | `{"file":"...","duration":2}` |
| `snapshot` | Write ring buffer to WAV (keep recording) | `{"file":"...","duration":1}` |
| `stopEngine` | Stop AVAudioEngine (mic cold) | `{"stopped":true}` |
| `meter` | Current audio level | `{"meter":{"average":0.3,"peak":0.5}}` |
| `exit` | Clean shutdown | — |

Key design decisions:
- **Ring buffer**: 30 seconds of 16kHz mono PCM in memory — enables pre-roll capture and snapshots
- **WAV output**: 16-bit PCM at 16kHz, directly consumable by whisper.cpp server
- **AVAudioConverter**: Handles arbitrary input sample rates/channels → 16kHz mono

## Main Process Changes (`src/main/main.ts`)

- **`AudioCapturer` module**: Process lifecycle management (`warmAudioCapturer`, `killAudioCapturer`, `startNativeAudioCapture`, `stopNativeAudioCapture`, `takeNativeAudioSnapshot`), same pattern as the whisper.cpp server manager
- **Speak-toggle hotkey**: Starts native audio capture immediately on press (both standard and Fn-only paths)
- **New IPC handlers**: `audio-capturer-warmup`, `audio-capturer-start`, `audio-capturer-stop`, `audio-capturer-snapshot`, `audio-capturer-meter`, `audio-capturer-status`
- **`whisper-transcribe-file`**: Transcribes a WAV file by path — for whisper.cpp, sends the file path directly to the persistent server (avoids reading into Node buffer then writing again)
- **Cleanup**: `killAudioCapturer()` in `will-quit`; `stopEngine` command when whisper overlay closes

## Renderer Changes (`src/renderer/src/SuperCmdWhisper.tsx`)

- **Native capture fast path in `startListening`**: Checks `audioCapturerStatus()` — if the native capturer is already recording (started by main process on hotkey press), skips `getUserMedia` entirely
- **`startNativeVisualizer`/`stopNativeVisualizer`**: Polls `audioCapturerMeter()` for wave bar animation instead of Web Audio `AnalyserNode`
- **`startNativePeriodicTranscription`**: Uses `audioCapturerSnapshot()` + `whisperTranscribeFile()` for live partial transcriptions while the user is still speaking
- **Native capture finalize path in `finalizeAndClose`**: Stops the native capturer, gets the WAV file, transcribes it, and pastes the result with the same paste-and-refine logic
- **Full backward compatibility**: Falls back to `getUserMedia` path if native capturer isnt available or fails

## Prior Optimizations (Included in This PR)

These were implemented in earlier iterations and are part of this diff:

- **Persistent whisper.cpp server**: Model stays loaded in memory; `serve` subcommand with JSON-over-stdin/stdout protocol
- **Immediate first periodic transcription**: `setTimeout`-chain fires at 1s (vs 3.5s `setInterval`)
- **Non-blocking AI transcript refinement**: Raw transcript pasted immediately; AI refinement runs async and replaces in-place if different
- **Parallel getUserMedia + resolveSessionConfig**: Both run concurrently instead of serially
- **Session config caching**: 10s TTL avoids redundant IPC round-trips
- **Whisper.cpp server warmup**: Kicked off on component mount so the model is loaded by the time transcription runs

## Files Changed

| File | Change |
|------|--------|
| `src/native/audio-capturer.swift` | **New** — Native AVAudioEngine capture helper |
| `src/main/main.ts` | AudioCapturer module, IPC handlers, hotkey integration, `whisper-transcribe-file`, `whisper-transcriber` serve mode |
| `src/main/preload.ts` | Bridge for new IPCs |
| `src/renderer/types/electron.d.ts` | Type declarations |
| `src/renderer/src/SuperCmdWhisper.tsx` | Native capture fast path, visualizer, periodic transcription, finalize |
| `src/native/whisper-transcriber.swift` | Persistent `serve` subcommand |
| `scripts/build-native.mjs` | Added `audio-capturer` to build list |