### PR TITLE
fix(browser-search): restore frecency function removed in #434

### DIFF
--- a/src/renderer/src/hooks/useBrowserSearch.ts
+++ b/src/renderer/src/hooks/useBrowserSearch.ts
@@ -421,6 +421,12 @@ function extractHost(url: string): string {
   }
 }
 
+function frecency(entry: BrowserSearchEntry): number {
+  const ageDays = Math.max(0, (Date.now() - entry.lastUsedAt) / (24 * 60 * 60 * 1000));
+  const recencyFactor = 1 / (1 + Math.log10(1 + ageDays));
+  return entry.useCount * recencyFactor;
+}
+
 function getLegacyCompletion(rawInput: string, entries: BrowserSearchEntry[]): BrowserSearchAutocomplete | null {
   const input = rawInput;
   if (!input.trim()) return null;


### PR DESCRIPTION
## Problem

Commit 8992618 (PR #434 — "combine browser and root search improvements") deleted the `frecency()` helper function but kept two call sites in the new `getLegacyCompletion()` function, causing a `ReferenceError: frecency is not defined` at runtime when the legacy completion path is hit (i.e. when `alphaChromiumRootSearchEnabled` is off).

## Fix

Restore the accidentally deleted `frecency(entry: BrowserSearchEntry)` function:

```ts
function frecency(entry: BrowserSearchEntry): number {
  const ageDays = Math.max(0, (Date.now() - entry.lastUsedAt) / (24 * 60 * 60 * 1000));
  const recencyFactor = 1 / (1 + Math.log10(1 + ageDays));
  return entry.useCount * recencyFactor;
}
```

This is the exact implementation that was removed — no logic changes.

## Testing

- TypeScript compiles without errors
- The legacy browser search autocomplete path no longer throws `ReferenceError`