### PR TITLE
fix: hide launcher window after hotkey-triggered silent script commands

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -14,7 +14,7 @@ import type {
   IndexedFileSearchResult,
   BrowserSearchSource,
   BrowserSearchResultGroupSetting,
-} from '../types/electron'
+} from '../types/electron';
 import ExtensionView from './ExtensionView';
 import ClipboardManager from './ClipboardManager';
 import SnippetManager from './SnippetManager';

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -14,7 +14,7 @@ import type {
   IndexedFileSearchResult,
   BrowserSearchSource,
   BrowserSearchResultGroupSetting,
-} from '../types/electron';
+} from '../types/electron'
 import ExtensionView from './ExtensionView';
 import ClipboardManager from './ClipboardManager';
 import SnippetManager from './SnippetManager';
@@ -997,6 +997,10 @@ const App: React.FC = () => {
         }
         if (result.mode === 'inline') {
           await fetchCommands();
+        } else {
+                    // Silent/default mode: hide the launcher window so focus returns to the user's active app.
+                    // Mirrors the behaviour of useLauncherCommandExecution (background:false path).
+                    void window.electron.hideWindow();
         }
       })();
     };


### PR DESCRIPTION
## Problem

When a script command with `@raycast.mode silent` is triggered via a hotkey, the SuperCmd launcher window opens and steals focus from the user's active app. Any keystrokes the script sends via `System Events` land in SuperCmd's AI input field instead of the intended target app.

## Root Cause

The `onRunScript` handler in `App.tsx` (the `sc-run-script-command` event listener, used by the hotkey path) was missing a `hideWindow()` call for the silent/default case.

The handler already handles:
- `result.needsArguments` → opens setup view and returns ✅
- - `result.mode === 'fullOutput'` → opens output view and returns ✅  
- - `result.mode === 'inline'` → refreshes commands ✅
But after the `inline` check, the function fell through with no window management — leaving the launcher window visible and focused.

## Fix

Added an `else` branch after `mode === 'inline'` that calls `window.electron.hideWindow()`, which mirrors the existing behaviour in `useLauncherCommandExecution.ts` (lines 158–159):

```typescript
if (result.mode === 'inline') {
  await fetchCommands();
} else {
  // Silent/default mode: hide the launcher window so focus returns to the user's active app.
  // Mirrors the behaviour of useLauncherCommandExecution (background:false path).
  void window.electron.hideWindow();
}
```

## Reproduction

1. Create a script command with `@raycast.mode silent` that sends keystrokes to another app via `System Events`
2. 2. Assign a hotkey to the command in Settings → Extensions
3. 3. Trigger the hotkey — the launcher window appears and intercepts the keystrokes
## Testing

After this fix, triggering a silent script command via hotkey should:
- Execute the script without showing the launcher window
- - Return focus immediately to the previously active app