### PR TITLE
feat(window): add Maximize Width and Maximize Height commands

### DIFF
--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -1401,6 +1401,18 @@ async function discoverAndBuildCommands(): Promise<CommandInfo[]> {
       category: 'system',
     },
     {
+      id: 'system-window-management-maximize-width',
+      title: 'Window: Maximize Width',
+      keywords: ['window', 'management', 'maximize', 'width', 'horizontal', 'fill', 'stretch'],
+      category: 'system',
+    },
+    {
+      id: 'system-window-management-maximize-height',
+      title: 'Window: Maximize Height',
+      keywords: ['window', 'management', 'maximize', 'height', 'vertical', 'fill', 'stretch'],
+      category: 'system',
+    },
+    {
       id: 'system-window-management-top-left',
       title: 'Window: Top Left',
       keywords: ['window', 'management', 'top', 'left', 'quadrant'],

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3228,6 +3228,8 @@ const WINDOW_MANAGEMENT_PRESET_COMMAND_IDS = new Set<string>([
   'system-window-management-center',
   'system-window-management-center-80',
   'system-window-management-fill',
+  'system-window-management-maximize-width',
+  'system-window-management-maximize-height',
   'system-window-management-top-left',
   'system-window-management-top-right',
   'system-window-management-bottom-left',
@@ -3291,6 +3293,8 @@ const WINDOW_MANAGEMENT_LAYOUT_COMMAND_IDS = new Set<string>([
   'system-window-management-center',
   'system-window-management-center-80',
   'system-window-management-fill',
+  'system-window-management-maximize-width',
+  'system-window-management-maximize-height',
   'system-window-management-top-left',
   'system-window-management-top-right',
   'system-window-management-bottom-left',
@@ -3799,7 +3803,8 @@ function sortNodeWindowsForLayout(windows: NodeWindowInfo[]): NodeWindowInfo[] {
 
 function computeWindowManagementLayoutBounds(
   commandId: string,
-  area: { x: number; y: number; width: number; height: number }
+  area: { x: number; y: number; width: number; height: number },
+  windowBounds?: NodeWindowBounds | null
 ): NodeWindowBounds | null {
   const normalized = String(commandId || '').trim();
   const halfWidthLeft = Math.max(1, Math.floor(area.width / 2));
@@ -3855,6 +3860,36 @@ function computeWindowManagementLayoutBounds(
         width: area.width,
         height: area.height,
       };
+    case 'system-window-management-maximize-width': {
+      // Span the full work-area width, keep the current vertical position/height.
+      if (!windowBounds) return null;
+      const height = clampWindowManagementFineTuneValue(
+        Math.round(windowBounds.height),
+        WINDOW_MANAGEMENT_FINE_TUNE_MIN_HEIGHT,
+        area.height
+      );
+      const y = clampWindowManagementFineTuneValue(
+        Math.round(windowBounds.y),
+        area.y,
+        areaBottom - height
+      );
+      return { x: area.x, y, width: area.width, height };
+    }
+    case 'system-window-management-maximize-height': {
+      // Span the full work-area height, keep the current horizontal position/width.
+      if (!windowBounds) return null;
+      const width = clampWindowManagementFineTuneValue(
+        Math.round(windowBounds.width),
+        WINDOW_MANAGEMENT_FINE_TUNE_MIN_WIDTH,
+        area.width
+      );
+      const x = clampWindowManagementFineTuneValue(
+        Math.round(windowBounds.x),
+        area.x,
+        areaRight - width
+      );
+      return { x, y: area.y, width, height: area.height };
+    }
     case 'system-window-management-center': {
       const width = clampWindowManagementFineTuneValue(
         Math.round(area.width * 0.6),
@@ -4279,7 +4314,7 @@ async function executeWindowManagementLayoutCommand(
       return await queueWindowMutations(entries);
     }
 
-    const next = computeWindowManagementLayoutBounds(normalized, area);
+    const next = computeWindowManagementLayoutBounds(normalized, area, target.bounds);
     if (!next) return false;
     return await queueWindowMutations([
       {

--- a/src/native/window-adjust.swift
+++ b/src/native/window-adjust.swift
@@ -10,6 +10,8 @@ private enum AdjustAction: String {
   case center = "center"
   case center80 = "center-80"
   case fill = "fill"
+  case maximizeWidth = "maximize-width"
+  case maximizeHeight = "maximize-height"
   case topLeft = "top-left"
   case topRight = "top-right"
   case bottomLeft = "bottom-left"
@@ -564,6 +566,26 @@ private func adjustedFrame(_ base: WindowFrame, action: AdjustAction, forcedArea
         x: area.origin.x,
         y: area.origin.y,
         width: max(minWidth, round(area.width)),
+        height: max(minHeight, round(area.height))
+      )
+    }
+  case .maximizeWidth:
+    if let area {
+      // Span the full work-area width, keep the current vertical position/height.
+      next = WindowFrame(
+        x: area.origin.x,
+        y: base.y,
+        width: max(minWidth, round(area.width)),
+        height: base.height
+      )
+    }
+  case .maximizeHeight:
+    if let area {
+      // Span the full work-area height, keep the current horizontal position/width.
+      next = WindowFrame(
+        x: base.x,
+        y: area.origin.y,
+        width: base.width,
         height: max(minHeight, round(area.height))
       )
     }

--- a/src/renderer/src/WindowManagerPanel.tsx
+++ b/src/renderer/src/WindowManagerPanel.tsx
@@ -49,6 +49,8 @@ type PresetId =
   | 'center'
   | 'center-80'
   | 'fill'
+  | 'maximize-width'
+  | 'maximize-height'
   | 'auto-organize'
   | 'increase-size-10'
   | 'decrease-size-10'
@@ -89,6 +91,8 @@ export const WINDOW_MANAGEMENT_PRESET_COMMANDS: WindowManagementPresetCommand[] 
   { commandId: 'system-window-management-center', presetId: 'center' },
   { commandId: 'system-window-management-center-80', presetId: 'center-80' },
   { commandId: 'system-window-management-fill', presetId: 'fill' },
+  { commandId: 'system-window-management-maximize-width', presetId: 'maximize-width' },
+  { commandId: 'system-window-management-maximize-height', presetId: 'maximize-height' },
   { commandId: 'system-window-management-top-left', presetId: 'top-left' },
   { commandId: 'system-window-management-top-right', presetId: 'top-right' },
   { commandId: 'system-window-management-bottom-left', presetId: 'bottom-left' },
@@ -143,6 +147,8 @@ const PRESETS: Array<{ id: PresetId; label: string; subtitle: string }> = [
   { id: 'center', label: 'Center', subtitle: 'Current window' },
   { id: 'center-80', label: 'Almost Maximize', subtitle: 'Current window' },
   { id: 'fill', label: 'Maximize', subtitle: 'Current window' },
+  { id: 'maximize-width', label: 'Maximize Width', subtitle: 'Current window' },
+  { id: 'maximize-height', label: 'Maximize Height', subtitle: 'Current window' },
   { id: 'top-left', label: 'Top Left', subtitle: 'Current window' },
   { id: 'top-right', label: 'Top Right', subtitle: 'Current window' },
   { id: 'bottom-right', label: 'Bottom Right', subtitle: 'Current window' },
@@ -183,6 +189,7 @@ const PRESETS: Array<{ id: PresetId; label: string; subtitle: string }> = [
 ];
 
 const MULTI_WINDOW_PRESETS = new Set<PresetId>(['auto-organize']);
+const DIMENSION_MAXIMIZE_PRESETS = new Set<PresetId>(['maximize-width', 'maximize-height']);
 const SHIFT_ENTER_ONLY_PRESETS = new Set<PresetId>([
   'increase-size-10',
   'decrease-size-10',
@@ -302,6 +309,12 @@ function renderPresetIcon(id: PresetId): JSX.Element {
     case 'fill':
       cells.push({ x: 1, y: 1, w: 18, h: 12 });
       break;
+    case 'maximize-width':
+      cells.push({ x: 1, y: 4, w: 18, h: 6 });
+      break;
+    case 'maximize-height':
+      cells.push({ x: 7, y: 1, w: 6, h: 12 });
+      break;
     case 'center':
       cells.push({ x: 4, y: 3, w: 12, h: 8 });
       break;
@@ -379,6 +392,29 @@ function getWindowRect(win: ManagedWindow | null | undefined): Rect | null {
     width: Math.max(1, Math.round(width)),
     height: Math.max(1, Math.round(height)),
   };
+}
+
+function applyMaximizeDimensionPreset(presetId: PresetId, target: ManagedWindow, area: ScreenArea): Rect | null {
+  if (!DIMENSION_MAXIMIZE_PRESETS.has(presetId)) return null;
+  const base = getWindowRect(target);
+  if (!base) return null;
+
+  const areaRight = area.left + area.width;
+  const areaBottom = area.top + area.height;
+  let next: Rect;
+  if (presetId === 'maximize-width') {
+    // Span the full work-area width, keep the current vertical position/height.
+    next = { x: area.left, y: base.y, width: area.width, height: base.height };
+  } else {
+    // Span the full work-area height, keep the current horizontal position/width.
+    next = { x: base.x, y: area.top, width: base.width, height: area.height };
+  }
+
+  next.width = clamp(Math.round(next.width), MIN_WINDOW_WIDTH, area.width);
+  next.height = clamp(Math.round(next.height), MIN_WINDOW_HEIGHT, area.height);
+  next.x = clamp(Math.round(next.x), area.left, areaRight - next.width);
+  next.y = clamp(Math.round(next.y), area.top, areaBottom - next.height);
+  return next;
 }
 
 function applyFineTunePreset(presetId: PresetId, target: ManagedWindow, area: ScreenArea): Rect | null {
@@ -1311,6 +1347,11 @@ export async function executeWindowManagementPreset(presetId: PresetId): Promise
           moves = buildAutoOrganizeLayout(layoutTargets, layoutArea);
         } else {
           moves = buildAutoLayout(layoutTargets, layoutArea);
+        }
+      } else if (DIMENSION_MAXIMIZE_PRESETS.has(presetId) && target) {
+        const adjusted = applyMaximizeDimensionPreset(presetId, target, layoutArea);
+        if (adjusted) {
+          moves = [{ id: target.id, bounds: rectToBounds(adjusted) }];
         }
       } else {
         const region = getPresetRegion(presetId, layoutArea);

--- a/src/renderer/src/utils/command-helpers.tsx
+++ b/src/renderer/src/utils/command-helpers.tsx
@@ -546,6 +546,8 @@ type WindowManagementGlyphId =
   | 'center'
   | 'center-80'
   | 'fill'
+  | 'maximize-width'
+  | 'maximize-height'
   | 'top-left'
   | 'top-right'
   | 'bottom-left'
@@ -595,6 +597,8 @@ const WINDOW_MANAGEMENT_GLYPH_SUFFIXES = new Set<WindowManagementGlyphId>([
   'center',
   'center-80',
   'fill',
+  'maximize-width',
+  'maximize-height',
   'top-left',
   'top-right',
   'bottom-left',
@@ -775,6 +779,12 @@ function renderWindowManagementGlyph(glyphId: WindowManagementGlyphId): JSX.Elem
       break;
     case 'fill':
       cells.push({ x: 1, y: 1, w: 18, h: 12 });
+      break;
+    case 'maximize-width':
+      cells.push({ x: 1, y: 4, w: 18, h: 6 });
+      break;
+    case 'maximize-height':
+      cells.push({ x: 7, y: 1, w: 6, h: 12 });
       break;
     case 'center':
       cells.push({ x: 4, y: 3, w: 12, h: 8 });


### PR DESCRIPTION
## What

Adds two Window Management commands that mirror Raycast's built-in set:

- **Window: Maximize Width** — spans the window to the full work-area width, keeping its current vertical position and height.
- **Window: Maximize Height** — spans the window to the full work-area height, keeping its current horizontal position and width.

SuperCmd already ships `Window: Maximize` and `Window: Almost Maximize`; these two were the only pieces of Raycast's core maximize set still missing.

## Why

Raycast's Window Management offers `Maximize`, `Maximize Width`, and `Maximize Height` side by side. SuperCmd had `Maximize` but not the width/height variants, so users coming from Raycast couldn't reproduce a common workflow (e.g. snap a window to full width while keeping its height). The behavior is well-defined and inexpensive to implement, so it closes a small but visible parity gap.

**Raycast (reference):**

<!-- SCREENSHOT: Raycast launcher showing Maximize / Maximize Width / Maximize Height -->
<img width="750" height="474" alt="Screenshot 2026-05-31 at 10 19 27" src="https://github.com/user-attachments/assets/97ec8cd0-8623-44a1-af28-feb7c95aa4d7" />

## Changes

| File | Purpose |
|---|---|
| `src/native/window-adjust.swift` | Add `maximize-width` / `maximize-height` actions to the `AdjustAction` enum and `adjustedFrame()` (native fast path) |
| `src/main/main.ts` | Register the two command ids in the preset/layout sets; extend `computeWindowManagementLayoutBounds()` to take the target window's current bounds and compute the new geometry (JS fallback path) |
| `src/main/commands.ts` | Register `Window: Maximize Width` / `Window: Maximize Height` in the launcher command catalog |
| `src/renderer/src/WindowManagerPanel.tsx` | Add the presets to the `PresetId` type, command mapping, panel preset list, preview icons, and `applyMaximizeDimensionPreset()` computation |
| `src/renderer/src/utils/command-helpers.tsx` | Add the two presets to the launcher glyph set so they render the same window icon as the rest of the `Window:` commands |

## How it works

Unlike most presets (which map to an absolute region of the screen), these two depend on the window's **current** bounds — they only stretch one axis and leave the other untouched.

- **Native path** (`window-adjust.swift`): reads the focused window frame and, for `maximize-width`, sets `x = area.left`, `width = area.width` while keeping the current `y`/`height` (and vice-versa for `maximize-height`). The existing post-switch clamping keeps the window inside the work area.
- **JS fallback** (`computeWindowManagementLayoutBounds`): now receives `target.bounds` and applies the same logic, clamped with the existing `clampWindowManagementFineTuneValue` helper.
- **Panel runtime** (`applyMaximizeDimensionPreset`): mirrors the geometry for when the command is run from the visible Window Management panel.

Both commands flow through the same dispatch as the existing layout commands (native preferred, JS fallback), so hotkeys, the launcher, and the panel all work.

## How I tested

- `npm run build` completes without errors (main `tsc`, renderer `vite build`, and `build:native` including the Swift helper).
- Ran locally with `npm run dev`:
  - `Window: Maximize Width` stretches the active window to full width, vertical position/height preserved.
  - `Window: Maximize Height` stretches it to full height, horizontal position/width preserved.
  - Both appear in the launcher search and in the Window Management panel, with the correct window glyph (matching `Window: Maximize`).

**SuperCmd (after):**

<!-- SCREENSHOT: SuperCmd launcher showing Maximize Width / Maximize Height with the correct window icon -->
<img width="760" height="480" alt="Screenshot 2026-05-31 at 11 12 17" src="https://github.com/user-attachments/assets/3c5e3c8c-6740-4736-8eaf-1a514d2a2602" />

## Compatibility

- No changes to the Raycast API shims (`src/renderer/src/raycast-api/`) — zero risk to extension compatibility.
- Additive only: existing window-management commands and hotkeys are untouched.
- No default hotkeys are assigned to the new commands (matching Raycast, which ships them unbound).
