### PR TITLE
feat: add {link} placeholder for rich-text hyperlink snippets

### DIFF
--- a/src/main/snippet-store.ts
+++ b/src/main/snippet-store.ts
@@ -317,6 +317,14 @@ export function resolveSnippetPlaceholdersWithCursor(
       return crypto.randomUUID();
     }
 
+    if (trimmed.toLowerCase().startsWith('link')) {
+      const textMatch = trimmed.match(/text\s*=\s*"([^"]*)"/i);
+      const urlMatch  = trimmed.match(/url\s*=\s*"([^"]*)"/i);
+      if (textMatch && urlMatch) {
+        return `__SUPERCMD_LINK__${textMatch[1]}__SUPERCMD_HREF__${urlMatch[1]}__SUPERCMD_ENDLINK__`;
+      }
+    }
+
     // Unknown placeholder — leave as-is
     return match;
   });
@@ -334,6 +342,63 @@ export function resolveSnippetPlaceholdersWithCursor(
 export function resolveSnippetPlaceholders(content: string, dynamicValues?: Record<string, string>): string {
   return resolveSnippetPlaceholdersWithCursor(content, dynamicValues).text;
 }
+// ─── Rich Text (HTML) rendering ─────────────────────────────────────────────
+
+const LINK_TOKEN_RE = /__SUPERCMD_LINK__(.*?)__SUPERCMD_HREF__(.*?)__SUPERCMD_ENDLINK__/g;
+
+/**
+ * Returns true when the resolved snippet content contains at least one
+ * hyperlink token — meaning we should write HTML to the clipboard instead
+ * of plain text so rich-text apps (Outlook, etc.) receive a clickable link.
+ */
+export function snippetHasRichContent(resolvedText: string): boolean {
+  LINK_TOKEN_RE.lastIndex = 0;
+  return LINK_TOKEN_RE.test(resolvedText);
+}
+
+/**
+ * Converts internal link tokens into an HTML string for clipboard.writeHTML().
+ * Plain text portions are HTML-escaped.
+ * Also returns a plain-text fallback (tokens become "Display Text (url)").
+ */
+export function snippetToHTML(resolvedText: string): { html: string; plainText: string } {
+  LINK_TOKEN_RE.lastIndex = 0;
+  let html = '';
+  let plainText = '';
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = LINK_TOKEN_RE.exec(resolvedText)) !== null) {
+    const before = resolvedText.slice(lastIndex, match.index);
+    const display = match[1];
+    const href = match[2];
+    html += escapeHtml(before);
+    plainText += before;
+    html += `<a href="${escapeAttr(href)}">${escapeHtml(display)}</a>`;
+    plainText += `${display} (${href})`;
+    lastIndex = LINK_TOKEN_RE.lastIndex;
+  }
+
+  const tail = resolvedText.slice(lastIndex);
+  html += escapeHtml(tail);
+  plainText += tail;
+
+  return { html: `<html><body>${html}</body></html>`, plainText };
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function escapeAttr(str: string): string {
+  return str.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+
 
 function formatDate(date: Date, format: string): string {
   const pad = (n: number) => String(n).padStart(2, '0');
@@ -353,7 +418,12 @@ export function copySnippetToClipboard(id: string): boolean {
   if (!snippet) return false;
 
   const resolved = resolveSnippetPlaceholders(snippet.content);
-  clipboard.writeText(resolved);
+  if (snippetHasRichContent(resolved)) {
+    const { html, plainText } = snippetToHTML(resolved);
+    clipboard.write({ html, text: plainText });
+  } else {
+    clipboard.writeText(resolved);
+  }
   return true;
 }
 
@@ -361,7 +431,12 @@ export function copySnippetToClipboardResolved(id: string, dynamicValues?: Recor
   const snippet = getSnippetById(id);
   if (!snippet) return false;
   const resolved = resolveSnippetPlaceholders(snippet.content, dynamicValues);
-  clipboard.writeText(resolved);
+  if (snippetHasRichContent(resolved)) {
+    const { html, plainText } = snippetToHTML(resolved);
+    clipboard.write({ html, text: plainText });
+  } else {
+    clipboard.writeText(resolved);
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary

Adds a `{link text="Display Text" url="https://..."}` placeholder to snippets so that rich-text applications (Outlook, Apple Mail, etc.) receive a proper clickable hyperlink when a snippet is expanded.

## Problem

SuperCmd snippets currently only write plain text to the clipboard. When users want to share a booking link (e.g. an Outlook calendar link) with display text like "My Calendar", they have no way to produce a clickable hyperlink — the full raw URL is always pasted.

## Solution

- Adds a new `{link text="..." url="..."}` placeholder token that follows the same `{token key="value"}` convention already used by `{argument name="..."}`.
- - When a snippet containing `{link}` tokens is expanded, SuperCmd calls `clipboard.write({ html, text })` instead of `clipboard.writeText()`, writing both an HTML version (with `<a href>` tags) and a plain-text fallback simultaneously.
- - Rich-text apps (Outlook, Word, etc.) pick up the `text/html` clipboard flavor and paste a proper hyperlink. Plain-text apps fall back to `Display Text (url)` format automatically.
- - Existing plain-text snippets are **completely unaffected** — the code path only changes when a link token is detected.
## Changes

**`src/main/snippet-store.ts`** only — no Swift changes, no new dependencies:
- Link token handler inside `resolveSnippetPlaceholdersWithCursor()`
- - New exported helpers: `snippetHasRichContent()`, `snippetToHTML()`
- - Updated `copySnippetToClipboard()` and `copySnippetToClipboardResolved()` to use `clipboard.write({ html, text })` when rich content is detected
## Usage Example

Snippet content:
```
Book time with me: {link text="My Calendar" url="https://outlook.office.com/bookwithme/..."}
```

When expanded in Outlook, pastes as: **My Calendar** (clickable hyperlink)
When expanded in a plain-text field, pastes as: `Book time with me: My Calendar (https://outlook.office.com/bookwithme/...)`

## Notes

- The UI change to add an "Insert Link" button to the snippet form is intentionally left as a follow-up to keep this PR minimal and easy to review. The `{link}` token can be typed manually in the content field today.
- - `SnippetManager.tsx` does not need changes for the core functionality — that is a UX improvement only.