### PR TITLE
fix(build): bundle both macOS architectures of esbuild's native binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build:renderer": "vite build",
     "check:i18n": "node scripts/check-i18n.mjs",
     "build:native": "node scripts/build-native.mjs",
-    "postinstall": "electron-builder install-app-deps",
+    "ensure:cross-arch-esbuild": "node scripts/ensure-cross-arch-esbuild.mjs",
+    "postinstall": "node scripts/ensure-cross-arch-esbuild.mjs && electron-builder install-app-deps",
     "start": "electron .",
     "package": "cross-env NODE_ENV=production npm run build && electron-builder",
     "package:unsigned": "cross-env NODE_ENV=production CSC_IDENTITY_AUTO_DISCOVERY=false npm run build && electron-builder --mac dmg -c.mac.identity=null -c.mac.notarize=false"
@@ -40,6 +41,8 @@
   },
   "dependencies": {
     "@aptabase/electron": "^0.3.1",
+    "@esbuild/darwin-arm64": "0.19.12",
+    "@esbuild/darwin-x64": "0.19.12",
     "@phosphor-icons/react": "^2.1.10",
     "@raycast/api": "^1.104.5",
     "electron-builder-notarize": "^1.5.2",

--- a/scripts/ensure-cross-arch-esbuild.mjs
+++ b/scripts/ensure-cross-arch-esbuild.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Ensure every `esbuild` instance in node_modules ships native binaries for
+ * both macOS architectures (darwin-x64 + darwin-arm64).
+ *
+ * Why:
+ *   esbuild ships its native binary via `optionalDependencies` that resolve
+ *   based on the *current* host platform. When SuperCmd is built on Apple
+ *   Silicon, only `@esbuild/darwin-arm64` ends up in node_modules; the same
+ *   node_modules is then packed into both the x64 and arm64 DMGs by
+ *   electron-builder, so the x64 DMG ships an unusable arm64 binary and every
+ *   extension whose on-demand build invokes esbuild fails at runtime with:
+ *
+ *     "You installed esbuild for another platform than the one you're
+ *      currently using. … the '@esbuild/darwin-arm64' package is present but
+ *      this platform needs the '@esbuild/darwin-x64' package instead."
+ *
+ *   The top-level esbuild is pinned in package.json, but @raycast/api nests
+ *   its own copy at a different version, which `npm install` populates
+ *   identically. This script walks every esbuild folder it finds and runs
+ *   `npm pack` for the missing platform package at the matching version,
+ *   then drops it next to the existing one.
+ *
+ * Idempotent. Safe to run repeatedly. No-op outside macOS.
+ */
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+if (process.platform !== 'darwin') {
+  process.exit(0);
+}
+
+const REQUIRED_PLATFORMS = ['darwin-x64', 'darwin-arm64'];
+const ROOT = resolve(process.cwd());
+
+function findEsbuildDirs(start) {
+  const results = [];
+  function walk(dir) {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const full = join(dir, entry.name);
+      if (entry.name === 'esbuild' && dirname(full).endsWith('node_modules')) {
+        if (existsSync(join(full, 'package.json'))) results.push(full);
+      } else if (entry.name === 'node_modules' || entry.name.startsWith('@')) {
+        walk(full);
+      } else if (existsSync(join(full, 'node_modules'))) {
+        walk(join(full, 'node_modules'));
+      }
+    }
+  }
+  walk(join(start, 'node_modules'));
+  return results;
+}
+
+function ensurePlatform(esbuildDir, platform) {
+  const platformRoot = join(dirname(esbuildDir), '@esbuild', platform);
+  if (existsSync(join(platformRoot, 'bin', 'esbuild'))) return false;
+
+  const pkg = JSON.parse(readFileSync(join(esbuildDir, 'package.json'), 'utf8'));
+  const version = pkg.version;
+  console.log(`  → installing @esbuild/${platform}@${version} for ${esbuildDir}`);
+
+  const work = mkdtempSync(join(tmpdir(), 'sc-esbuild-'));
+  try {
+    execSync(`npm pack @esbuild/${platform}@${version}`, { cwd: work, stdio: 'inherit' });
+    const tarball = readdirSync(work).find((f) => f.endsWith('.tgz'));
+    if (!tarball) throw new Error(`npm pack produced no tarball for @esbuild/${platform}@${version}`);
+    execSync(`tar -xzf ${tarball}`, { cwd: work, stdio: 'inherit' });
+    const extracted = join(work, 'package');
+    if (!existsSync(extracted)) throw new Error(`unexpected tarball layout: ${tarball}`);
+    if (!existsSync(dirname(platformRoot))) {
+      execSync(`mkdir -p ${JSON.stringify(dirname(platformRoot))}`);
+    }
+    if (existsSync(platformRoot)) rmSync(platformRoot, { recursive: true, force: true });
+    renameSync(extracted, platformRoot);
+    return true;
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+const dirs = findEsbuildDirs(ROOT);
+if (dirs.length === 0) {
+  console.log('ensure-cross-arch-esbuild: no esbuild installations found, skipping.');
+  process.exit(0);
+}
+
+let added = 0;
+for (const dir of dirs) {
+  for (const platform of REQUIRED_PLATFORMS) {
+    if (ensurePlatform(dir, platform)) added++;
+  }
+}
+
+if (added === 0) {
+  console.log('ensure-cross-arch-esbuild: all esbuild instances already have both macOS binaries.');
+} else {
+  console.log(`ensure-cross-arch-esbuild: added ${added} missing platform package(s).`);
+}


### PR DESCRIPTION
Closes #462

## Problem

esbuild ships its native binary via `optionalDependencies` (`@esbuild/darwin-x64`, `@esbuild/darwin-arm64`, …) — npm only installs the one matching the **build host's** architecture. The published x64 SuperCmd DMG is built on an Apple Silicon machine, so `node_modules/@esbuild/` contains only `darwin-arm64`. electron-builder packs that same `node_modules/` into both DMGs, so the x64 DMG ships an arm64 binary that it can't execute.

Every extension whose on-demand build invokes esbuild then fails on Intel/Rosetta Macs with the misleading message:

```
You installed esbuild for another platform than the one you're currently using.
…
Specifically the "@esbuild/darwin-arm64" package is present but this platform
needs the "@esbuild/darwin-x64" package instead.
```

The same problem exists for the nested esbuild copy under `@raycast/api` (a different version: 0.25.12 vs the top-level 0.19.12).

Confirmed by inspecting a packaged 1.0.25 build:

```
$ file SuperCmd.app/Contents/MacOS/SuperCmd
… Mach-O 64-bit executable x86_64

$ ls app.asar.unpacked/node_modules/@esbuild
darwin-arm64

$ ls app.asar.unpacked/node_modules/@raycast/api/node_modules/@esbuild
darwin-arm64
```

## Fix

Two-part, both small:

1. **Pin both platform packages explicitly in `package.json`** so npm always installs them for the top-level esbuild regardless of the build host:

   ```json
   "@esbuild/darwin-arm64": "0.19.12",
   "@esbuild/darwin-x64": "0.19.12",
   ```

2. **Add `scripts/ensure-cross-arch-esbuild.mjs`** (run from `postinstall`) which walks every `esbuild` folder it finds in `node_modules` (handles nested copies like `@raycast/api/node_modules/esbuild` at their own version) and `npm pack`s the missing `@esbuild/darwin-*` sibling at the matching version. Idempotent, runs only on macOS, no-op when nothing is missing.

The script handles future esbuild version drift (e.g. when `@raycast/api` bumps its esbuild dependency) without needing a corresponding `package.json` change.

## Verification

Reproduced the original failure with SuperCmd 1.0.25 on macOS 13.6 x86_64 (issue #462).

Local smoke test of the script:

```
# top-level esbuild 0.19.12 + nested @raycast/api/node_modules/esbuild 0.25.12,
# host arch x64 → only darwin-x64 installed.

$ node scripts/ensure-cross-arch-esbuild.mjs
  → installing @esbuild/darwin-arm64@0.25.12 for …/@raycast/api/node_modules/esbuild
  → installing @esbuild/darwin-arm64@0.19.12 for …/node_modules/esbuild
ensure-cross-arch-esbuild: added 2 missing platform package(s).

$ file node_modules/@esbuild/darwin-x64/bin/esbuild
… Mach-O 64-bit executable x86_64
$ file node_modules/@esbuild/darwin-arm64/bin/esbuild
… Mach-O 64-bit executable arm64

# re-run is a no-op:
$ node scripts/ensure-cross-arch-esbuild.mjs
ensure-cross-arch-esbuild: all esbuild instances already have both macOS binaries.
```

## Alternatives considered

- **Build x64 and arm64 in separate CI jobs (Intel + Apple Silicon runners).** Cleanest but doubles CI cost and requires CI changes; this PR is contained to two files and doesn't touch the release pipeline.
- **Bumping the top-level esbuild to `^0.25.x`** to deduplicate with `@raycast/api`'s copy. Reduces the number of esbuild instances but is a larger functional change and doesn't itself fix the cross-arch problem.