### PR TITLE
fix(canvas): Excalidraw-compatible JSON export + fix shift shortcuts in Search Canvases

### DIFF
--- a/src/main/canvas-store.ts
+++ b/src/main/canvas-store.ts
@@ -321,7 +321,18 @@ export async function exportCanvas(
   if (result.canceled || !result.filePath) return false;
 
   const scene = getScene(id);
-  fs.writeFileSync(result.filePath, JSON.stringify(scene, null, 2), 'utf-8');
+  // Wrap the raw scene in the official Excalidraw file format so the export
+  // can be opened on excalidraw.com (which requires the `type`/`version`/`source`
+  // header — without it the file is rejected as invalid).
+  const exportData = {
+    type: 'excalidraw',
+    version: 2,
+    source: 'https://supercmd.sh',
+    elements: scene.elements,
+    appState: scene.appState,
+    files: scene.files,
+  };
+  fs.writeFileSync(result.filePath, JSON.stringify(exportData, null, 2), 'utf-8');
   return true;
 }
 

--- a/src/renderer/src/CanvasSearchInline.tsx
+++ b/src/renderer/src/CanvasSearchInline.tsx
@@ -313,9 +313,21 @@ const CanvasSearchInline: React.FC<CanvasSearchInlineProps> = ({ onClose }) => {
         return;
       }
 
-      if (e.key === 'd' && e.metaKey && selectedCanvas) {
+      if (e.key === 'd' && e.metaKey && e.shiftKey && selectedCanvas) {
+        e.preventDefault();
+        navigator.clipboard.writeText(`supercmd://canvas/${selectedCanvas.id}`);
+        return;
+      }
+
+      if (e.key === 'd' && e.metaKey && !e.shiftKey && selectedCanvas) {
         e.preventDefault();
         window.electron.canvasDuplicate(selectedCanvas.id).then(() => loadCanvases());
+        return;
+      }
+
+      if (e.key === 'e' && e.metaKey && e.shiftKey && selectedCanvas) {
+        e.preventDefault();
+        window.electron.canvasExport(selectedCanvas.id, 'json');
         return;
       }
 


### PR DESCRIPTION
## Summary

Fixes two issues in the built-in Excalidraw **Canvas** feature, surfaced from **Search Canvases**.

### 1. "Export as JSON" produces a file that won't open on excalidraw.com
`exportCanvas` wrote the raw scene (`{ elements, appState, files }`) directly to disk. excalidraw.com's importer rejects this because it requires the official Excalidraw file header (`type` / `version` / `source`). The save dialog filter is already labeled **"Excalidraw JSON"**, so Excalidraw-compatibility was the intended behavior — the export was just missing the wrapper.

Now the export wraps the scene:
```json
{
  "type": "excalidraw",
  "version": 2,
  "source": "https://supercmd.sh",
  "elements": [...],
  "appState": {...},
  "files": {...}
}
```
The resulting file opens correctly on excalidraw.com. Round-trip import is unaffected — `getScene` reads `elements`/`appState`/`files` and ignores the extra header keys.

### 2. Shift-modified shortcuts in Search Canvases were broken
- **⇧⌘D (Copy Deeplink)** triggered **Duplicate** instead — the `⌘D` keydown handler didn't exclude the shift modifier, so it matched `⇧⌘D` first and returned. Added `!e.shiftKey` to the duplicate handler and a dedicated `⇧⌘D` → Copy Deeplink handler.
- **⇧⌘E (Export as JSON)** did nothing — no keydown handler existed for `e` at all (only the action-panel entry). Added a `⇧⌘E` handler.

## Verification

Verified manually on a signed build of this branch (packaged via GitHub Actions, installed as a real `.app`, not just a dev run):

- [x] Search Canvases → select a canvas → **⇧⌘E** (and Export as JSON from ⌘K) → the saved file opens successfully on excalidraw.com
- [x] **⌘D** duplicates the canvas
- [x] **⇧⌘D** copies the `supercmd://canvas/<id>` deeplink and does **not** duplicate
- [x] Existing pin / delete shortcuts unaffected