### PR TITLE
feat(whisper): custom vocabulary biasing for local whisper.cpp

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1256,6 +1256,7 @@ async function transcribeAudioWithWhisperCpp(opts: {
   audioBuffer: Buffer;
   language?: string;
   mimeType?: string;
+  initialPrompt?: string;
 }): Promise<string> {
   const mimeType = String(opts.mimeType || 'audio/wav').toLowerCase();
   if (mimeType && !mimeType.includes('wav')) {
@@ -1284,6 +1285,7 @@ async function transcribeAudioWithWhisperCpp(opts: {
       command: 'transcribe',
       file: audioPath,
       language,
+      initial_prompt: (opts.initialPrompt || '').trim(),
     });
 
     return result.text || '';
@@ -17900,6 +17902,7 @@ if let tiff = image?.tiffRepresentation {
               audioBuffer,
               language,
               mimeType,
+              initialPrompt: s.ai.speechVocabulary,
             })
           : provider === 'elevenlabs'
             ? await transcribeAudioWithElevenLabs({

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -52,6 +52,7 @@ export interface AISettings {
   speechCorrectionModel: string;
   speechToTextModel: string;
   speechLanguage: string;
+  speechVocabulary: string;
   textToSpeechModel: string;
   edgeTtsVoice: string;
   speechCorrectionEnabled: boolean;
@@ -308,6 +309,7 @@ const DEFAULT_AI_SETTINGS: AISettings = {
   speechCorrectionModel: '',
   speechToTextModel: 'whispercpp',
   speechLanguage: 'en-US',
+  speechVocabulary: '',
   textToSpeechModel: 'edge-tts',
   edgeTtsVoice: 'en-US-EricNeural',
   speechCorrectionEnabled: false,

--- a/src/native/whisper-transcriber.swift
+++ b/src/native/whisper-transcriber.swift
@@ -176,7 +176,7 @@ func decodeWaveFile(at path: String) throws -> [Float] {
 
 // MARK: - Transcription with pre-loaded context
 
-func transcribeWithContext(_ context: OpaquePointer, samples: [Float], language: String) throws -> String {
+func transcribeWithContext(_ context: OpaquePointer, samples: [Float], language: String, initialPrompt: String = "") throws -> String {
   var params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY)
   params.print_realtime = false
   params.print_progress = false
@@ -188,8 +188,11 @@ func transcribeWithContext(_ context: OpaquePointer, samples: [Float], language:
   params.n_threads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
 
   let normalizedLanguage = language.isEmpty ? "en" : language
-  return try normalizedLanguage.withCString { languageCString -> String in
-    params.language = languageCString
+
+  // Run whisper_full while holding valid C string pointers for both the
+  // language and (optional) initial prompt. The prompt biases recognition
+  // toward user-provided vocabulary (whisper.cpp truncates it to fit).
+  func runTranscription() throws -> String {
     let result = samples.withUnsafeBufferPointer { buffer in
       whisper_full(context, params, buffer.baseAddress, Int32(buffer.count))
     }
@@ -203,6 +206,18 @@ func transcribeWithContext(_ context: OpaquePointer, samples: [Float], language:
       text += String(cString: whisper_full_get_segment_text(context, index))
     }
     return text.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  return try normalizedLanguage.withCString { languageCString -> String in
+    params.language = languageCString
+    let trimmedPrompt = initialPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedPrompt.isEmpty else {
+      return try runTranscription()
+    }
+    return try trimmedPrompt.withCString { promptCString -> String in
+      params.initial_prompt = promptCString
+      return try runTranscription()
+    }
   }
 }
 
@@ -303,6 +318,7 @@ func serveCommand(modelPath: String) {
         continue
       }
       let language = json["language"] as? String ?? "en"
+      let initialPrompt = json["initial_prompt"] as? String ?? ""
 
       guard FileManager.default.fileExists(atPath: filePath) else {
         emitJSON(["error": "Audio file not found: \(filePath)"])
@@ -313,7 +329,7 @@ func serveCommand(modelPath: String) {
         let samples = try decodeWaveFile(at: filePath)
         // Reset context state for a fresh transcription
         whisper_reset_timings(context)
-        let text = try transcribeWithContext(context, samples: samples, language: language)
+        let text = try transcribeWithContext(context, samples: samples, language: language, initialPrompt: initialPrompt)
         emitJSON(["text": text])
       } catch {
         emitJSON(["error": error.localizedDescription])

--- a/src/renderer/src/i18n/locales/de.json
+++ b/src/renderer/src/i18n/locales/de.json
@@ -375,6 +375,12 @@
         "elevenlabsWarning": "ElevenLabs-STT ausgewaehlt. {action} den ElevenLabs-API-Schluessel unter API Keys.",
         "elevenlabsReady": "ElevenLabs-STT ausgewaehlt. Die Cloud-Transkription verwendet deinen ElevenLabs-Schluessel.",
         "recognitionLanguage": "Recognition Language",
+        "vocabulary": {
+          "label": "Eigenes Vokabular",
+          "placeholder": "Kotlin, Electron, Raycast, SuperCmd…",
+          "hint": "Optional. Listen Sie ungewöhnliche Wörter, Namen oder Fachbegriffe (durch Komma oder Zeilenumbruch getrennt) auf, um die Erkennung zur richtigen Schreibweise zu lenken.",
+          "tokenWarning": "Etwa {count} Token. Whisper verwendet nur ungefähr die ersten 224 – Wörter darüber hinaus werden ignoriert."
+        },
         "providerInfo": {
           "parakeet": "Offline on-device transcription via Parakeet TDT v3. Runs on Apple Neural Engine. Requires model warmup on first use. Download the model below before using dictation.",
           "qwen3": "Offline on-device transcription via Qwen3 ASR. Supports 30+ languages, requires macOS 15+, and warms up on first use.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -375,6 +375,12 @@
         "elevenlabsWarning": "ElevenLabs STT selected. {action} ElevenLabs API key in API Keys.",
         "elevenlabsReady": "ElevenLabs STT selected. Cloud transcription will use your ElevenLabs key.",
         "recognitionLanguage": "Recognition Language",
+        "vocabulary": {
+          "label": "Custom Vocabulary",
+          "placeholder": "Kotlin, Electron, Raycast, SuperCmd…",
+          "hint": "Optional. List uncommon words, names, or technical terms (comma or newline separated) to bias recognition toward the correct spelling.",
+          "tokenWarning": "About {count} tokens. Whisper only uses roughly the first 224 — extra words past that are ignored."
+        },
         "providerInfo": {
           "parakeet": "Offline on-device transcription via Parakeet TDT v3. Runs on Apple Neural Engine. Requires model warmup on first use. Download the model below before using dictation.",
           "qwen3": "Offline on-device transcription via Qwen3 ASR. Supports 30+ languages, requires macOS 15+, and warms up on first use.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -375,6 +375,12 @@
         "elevenlabsWarning": "Se ha seleccionado ElevenLabs STT. {action} la clave API de ElevenLabs en API Keys.",
         "elevenlabsReady": "Se ha seleccionado ElevenLabs STT. La transcripcion en la nube usara tu clave de ElevenLabs.",
         "recognitionLanguage": "Recognition Language",
+        "vocabulary": {
+          "label": "Vocabulario personalizado",
+          "placeholder": "Kotlin, Electron, Raycast, SuperCmd…",
+          "hint": "Opcional. Enumera palabras poco comunes, nombres o términos técnicos (separados por comas o saltos de línea) para orientar el reconocimiento hacia la ortografía correcta.",
+          "tokenWarning": "Unos {count} tokens. Whisper solo usa aproximadamente los primeros 224; las palabras que excedan ese límite se ignoran."
+        },
         "providerInfo": {
           "parakeet": "Offline on-device transcription via Parakeet TDT v3. Runs on Apple Neural Engine. Requires model warmup on first use. Download the model below before using dictation.",
           "qwen3": "Offline on-device transcription via Qwen3 ASR. Supports 30+ languages, requires macOS 15+, and warms up on first use.",

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -375,6 +375,12 @@
         "elevenlabsWarning": "STT ElevenLabs selectionne. {action} la cle API ElevenLabs dans API Keys.",
         "elevenlabsReady": "STT ElevenLabs selectionne. La transcription cloud utilisera votre cle ElevenLabs.",
         "recognitionLanguage": "Recognition Language",
+        "vocabulary": {
+          "label": "Vocabulaire personnalisé",
+          "placeholder": "Kotlin, Electron, Raycast, SuperCmd…",
+          "hint": "Facultatif. Indiquez des mots rares, des noms ou des termes techniques (séparés par des virgules ou des retours à la ligne) pour orienter la reconnaissance vers la bonne orthographe.",
+          "tokenWarning": "Environ {count} jetons. Whisper n'utilise qu'environ les 224 premiers — les mots au-delà sont ignorés."
+        },
         "providerInfo": {
           "parakeet": "Offline on-device transcription via Parakeet TDT v3. Runs on Apple Neural Engine. Requires model warmup on first use. Download the model below before using dictation.",
           "qwen3": "Offline on-device transcription via Qwen3 ASR. Supports 30+ languages, requires macOS 15+, and warms up on first use.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -375,6 +375,12 @@
         "elevenlabsWarning": "ElevenLabs STT が選択されています。API キーに ElevenLabs API キーを{action}してください。",
         "elevenlabsReady": "ElevenLabs STT が選択されています。クラウド文字起こしに ElevenLabs キーを使用します。",
         "recognitionLanguage": "認識言語",
+        "vocabulary": {
+          "label": "カスタム語彙",
+          "placeholder": "Kotlin、Electron、Raycast、SuperCmd…",
+          "hint": "任意。認識を正しい表記に近づけるため、珍しい単語・名前・専門用語をカンマまたは改行で区切って入力します。",
+          "tokenWarning": "約 {count} トークン。Whisper は先頭の約 224 トークンしか使用しないため、それを超える単語は無視されます。"
+        },
         "providerInfo": {
           "parakeet": "Parakeet TDT v3 によるオフラインのオンデバイス文字起こし。Apple Neural Engine 上で実行されます。初回使用時にモデルのウォームアップが必要です。ディクテーションを使用する前に下からモデルをダウンロードしてください。",
           "qwen3": "Qwen3 ASR によるオフラインのオンデバイス文字起こし。30 以上の言語をサポート、macOS 15 以上が必要、初回使用時にウォームアップします。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -375,6 +375,12 @@
         "elevenlabsWarning": "ElevenLabs STT가 선택되었습니다. API 키에서 ElevenLabs API 키를 {action}하세요.",
         "elevenlabsReady": "ElevenLabs STT가 선택되었습니다. 클라우드 전사에 ElevenLabs 키가 사용됩니다.",
         "recognitionLanguage": "인식 언어",
+        "vocabulary": {
+          "label": "사용자 지정 어휘",
+          "placeholder": "Kotlin, Electron, Raycast, SuperCmd…",
+          "hint": "선택 사항. 인식을 올바른 철자로 유도하려면 잘 쓰이지 않는 단어, 이름, 전문 용어를 쉼표나 줄바꿈으로 구분하여 입력하세요.",
+          "tokenWarning": "약 {count}개 토큰. Whisper는 대략 처음 224개만 사용하므로 그 이후의 단어는 무시됩니다."
+        },
         "providerInfo": {
           "parakeet": "Parakeet TDT v3를 통한 오프라인 기기 내 전사. Apple Neural Engine에서 실행됩니다. 처음 사용할 때 모델 준비가 필요합니다. 받아쓰기를 사용하기 전에 아래 모델을 다운로드하세요.",
           "qwen3": "Qwen3 ASR을 통한 오프라인 온디바이스 전사. 30개 이상의 언어를 지원하고 macOS 15 이상이 필요하며 처음 사용할 때 예열됩니다.",

--- a/src/renderer/src/i18n/locales/ru.json
+++ b/src/renderer/src/i18n/locales/ru.json
@@ -375,6 +375,12 @@
         "elevenlabsWarning": "ElevenLabs STT selected. {action} ElevenLabs API key in API Keys.",
         "elevenlabsReady": "ElevenLabs STT selected. Cloud transcription will use your ElevenLabs key.",
         "recognitionLanguage": "Recognition Language",
+        "vocabulary": {
+          "label": "Пользовательский словарь",
+          "placeholder": "Kotlin, Electron, Raycast, SuperCmd…",
+          "hint": "Необязательно. Перечислите редкие слова, имена или технические термины (через запятую или с новой строки), чтобы направить распознавание к правильному написанию.",
+          "tokenWarning": "Примерно {count} токенов. Whisper использует лишь около первых 224 — слова сверх этого игнорируются."
+        },
         "providerInfo": {
           "parakeet": "Offline on-device transcription via Parakeet TDT v3. Runs on Apple Neural Engine. Requires model warmup on first use. Download the model below before using dictation.",
           "qwen3": "Offline on-device transcription via Qwen3 ASR. Supports 30+ languages, requires macOS 15+, and warms up on first use.",

--- a/src/renderer/src/i18n/locales/zh-Hans.json
+++ b/src/renderer/src/i18n/locales/zh-Hans.json
@@ -375,6 +375,12 @@
         "elevenlabsWarning": "已选择 ElevenLabs 语音转文字。请在 API 密钥中{action} ElevenLabs API 密钥。",
         "elevenlabsReady": "已选择 ElevenLabs 语音转文字。云端转录将使用你的 ElevenLabs 密钥。",
         "recognitionLanguage": "识别语言",
+        "vocabulary": {
+          "label": "自定义词汇",
+          "placeholder": "Kotlin、Electron、Raycast、SuperCmd…",
+          "hint": "可选。列出不常见的词语、名称或技术术语（用逗号或换行分隔），以引导识别采用正确的拼写。",
+          "tokenWarning": "约 {count} 个 token。Whisper 大约只使用前 224 个，超出部分将被忽略。"
+        },
         "providerInfo": {
           "parakeet": "通过 Parakeet TDT v3 在设备离线转录，运行于 Apple Neural Engine。首次使用前需要预热模型，请先下载后再开始听写。",
           "qwen3": "通过 Qwen3 ASR 在设备离线转录，支持 30+ 种语言，需要 macOS 15+，首次使用前会预热模型。",

--- a/src/renderer/src/i18n/locales/zh-Hant.json
+++ b/src/renderer/src/i18n/locales/zh-Hant.json
@@ -375,6 +375,12 @@
         "elevenlabsWarning": "已選擇 ElevenLabs 語音轉文字。請在 API 金鑰中{action} ElevenLabs API 金鑰。",
         "elevenlabsReady": "已選擇 ElevenLabs 語音轉文字。雲端轉錄將使用您的 ElevenLabs 金鑰。",
         "recognitionLanguage": "辨識語言",
+        "vocabulary": {
+          "label": "自訂詞彙",
+          "placeholder": "Kotlin、Electron、Raycast、SuperCmd…",
+          "hint": "選填。列出不常見的詞語、名稱或技術術語（以逗號或換行分隔），以引導辨識採用正確的拼寫。",
+          "tokenWarning": "約 {count} 個 token。Whisper 大約只使用前 224 個，超出部分會被忽略。"
+        },
         "providerInfo": {
           "parakeet": "透過 Parakeet TDT v3 在裝置離線轉錄，運行於 Apple Neural Engine。首次使用前需要預熱模型，請先下載後再開始聽寫。",
           "qwen3": "透過 Qwen3 ASR 在裝置離線轉錄，支援 30+ 種語言，需要 macOS 15+，首次使用前會預熱模型。",

--- a/src/renderer/src/settings/AITab.tsx
+++ b/src/renderer/src/settings/AITab.tsx
@@ -1463,6 +1463,32 @@ const AITab: React.FC = () => {
                 </div>
               )}
 
+              {whisperModelValue === 'whispercpp' && (
+                <div>
+                  <label className="text-[0.75rem] text-[var(--text-muted)] mb-1 block">{t('settings.ai.whisper.vocabulary.label')}</label>
+                  <textarea
+                    value={ai.speechVocabulary || ''}
+                    onChange={(e) => updateAI({ speechVocabulary: e.target.value })}
+                    placeholder={t('settings.ai.whisper.vocabulary.placeholder')}
+                    rows={4}
+                    className="sc-input resize-none w-full"
+                  />
+                  <p className="text-[0.6875rem] text-[var(--text-muted)] mt-1">{t('settings.ai.whisper.vocabulary.hint')}</p>
+                  {(() => {
+                    const vocab = (ai.speechVocabulary || '').trim();
+                    if (!vocab) return null;
+                    // whisper.cpp caps the initial prompt at ~224 tokens; estimate ~4 chars/token.
+                    const tokenEstimate = Math.ceil(vocab.length / 4);
+                    if (tokenEstimate <= 200) return null;
+                    return (
+                      <p className="text-[0.6875rem] text-[color:var(--status-warning)] mt-1">
+                        {t('settings.ai.whisper.vocabulary.tokenWarning', { count: tokenEstimate })}
+                      </p>
+                    );
+                  })()}
+                </div>
+              )}
+
               {whisperModelValue === 'native' && (
                 <div className="bg-sky-500/10 border border-sky-500/20 rounded-md px-2.5 py-2">
                   <p className="text-[0.6875rem] text-sky-300">

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -108,6 +108,7 @@
   --accent-soft: rgba(47, 107, 255, 0.18);
   --status-success: #2f9a64;
   --status-success-soft: rgba(47, 154, 100, 0.24);
+  --status-warning: #b3771a;
   --status-danger: #d94b4b;
   --status-danger-faded: #d27c7c;
   --status-danger-soft: rgba(217, 75, 75, 0.22);
@@ -227,6 +228,7 @@
   --accent-soft: rgba(78, 162, 255, 0.22);
   --status-success: #48c78e;
   --status-success-soft: rgba(72, 199, 142, 0.3);
+  --status-warning: #e0a83d;
   --status-danger: #ff6363;
   --status-danger-faded: #ffd9d9;
   --status-danger-soft: rgba(255, 99, 99, 0.3);

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -218,6 +218,7 @@ export interface AISettings {
   speechCorrectionModel: string;
   speechToTextModel: string;
   speechLanguage: string;
+  speechVocabulary: string;
   textToSpeechModel: string;
   edgeTtsVoice: string;
   speechCorrectionEnabled: boolean;


### PR DESCRIPTION
## What

Adds a **Custom Vocabulary** field to **Settings → AI → Whisper** that feeds whisper.cpp's native `initial_prompt` parameter. This biases recognition toward user-provided terms (e.g. `Kotlin`, `Electron`, `Raycast`) that the local `ggml-base` model frequently mis-transcribes.

Same mechanism Superwhisper uses for its vocabulary feature. Scoped to the local `whispercpp` provider — cloud providers are out of scope for this PR.

## Why

Technical terms and proper nouns are often spelled wrong by the base model. Until now the `initial_prompt` field of `whisper_full_params` was left empty, even though the bundled whisper.cpp already supports it. This wires up the existing capability and exposes it in the UI.

## Changes

- **Swift** (`whisper-transcriber.swift`): thread `initialPrompt` into `transcribeWithContext` via nested `withCString` (keeps the C pointer valid for the whole `whisper_full` call); parse `initial_prompt` in the persistent server loop.
- **Main** (`main.ts`): read `s.ai.speechVocabulary` in the `whisper-transcribe` IPC handler and forward it through `transcribeAudioWithWhisperCpp` (no renderer/preload changes needed — vocabulary comes from settings).
- **Settings** (`settings-store.ts`, `electron.d.ts`): new `speechVocabulary` string field (default `""`).
- **UI** (`AITab.tsx`, `index.css`): vocabulary textarea in the whispercpp block with a soft ~224-token warning + counter (no hard limit; whisper.cpp truncates internally). Adds a `--status-warning` theme token (light + dark).
- **i18n**: `settings.ai.whisper.vocabulary.*` keys added to `en.json` and translated across all 9 locales (parity verified: 0 missing / 0 extra).

## Notes

- `initial_prompt` is a probabilistic bias, not a hard dictionary — it favors the listed spellings but doesn't guarantee them. Capped at ~224 tokens by whisper.cpp.
- Backward compatible: empty vocabulary → prompt not set → identical behavior to before.

## Verification

- `swiftc` compile of the transcriber: ✅ exit 0
- `tsc` main process: ✅ clean
- `tsc` renderer: ✅ no new errors introduced
- i18n structural parity across 9 locales: ✅ `missing: 0, extra: 0`
- **End-to-end functional test**: ran the persistent server against `ggml-base` with the same audio twice. Without prompt: `"...in Kotlin, in delectron every day"`. With `initial_prompt: "Kotlin, Electron, Raycast, SuperCmd"`: the mis-transcription `delectron` was corrected to `Electron`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)