### PR TITLE
fix(extension-runner): symlink assetsPath to avoid spaces breaking execSync in extensions

### DIFF
--- a/src/main/extension-runner.ts
+++ b/src/main/extension-runner.ts
@@ -1304,7 +1304,23 @@ export async function getExtensionBundle(
   } catch {}
 
   // Compute paths
-  const assetsPath = path.join(extPath, 'assets');
+  const rawAssetsPath = path.join(extPath, 'assets');
+  // Some extensions run `chmod +x ${assetsPath}/...` via execSync without quoting the path.
+  // If assetsPath contains spaces (e.g. "Application Support"), the shell splits on them and
+  // the command fails. Work around this by exposing a symlink at a space-free /tmp path.
+  let assetsPath = rawAssetsPath;
+  if (rawAssetsPath.includes(' ') && fs.existsSync(rawAssetsPath)) {
+    const symlinkDir = path.join(os.tmpdir(), 'supercmd-assets');
+    const symlinkPath = path.join(symlinkDir, normalizedExtName);
+    try {
+      fs.mkdirSync(symlinkDir, { recursive: true });
+      if (fs.existsSync(symlinkPath)) fs.unlinkSync(symlinkPath);
+      fs.symlinkSync(rawAssetsPath, symlinkPath);
+      assetsPath = symlinkPath;
+    } catch {
+      // Symlink failed (permissions, etc.) — fall back to the original path
+    }
+  }
   const supportPath = path.join(app.getPath('userData'), 'extension-support', normalizedExtName);
 
   // Ensure support directory exists


### PR DESCRIPTION
## Summary

- Extensions like `sips` (Image Modification) call `chmod +x ${assetsPath}/...` via `execSync` without quoting the path
- `assetsPath` includes `Application Support` which contains a space, causing the shell to split the argument and fail with `Command failed: chmod +x /Users/.../Application`
- Fix: when `assetsPath` contains spaces, create a space-free symlink at `/tmp/supercmd-assets/<extname>` pointing to the real assets directory and expose that as `assetsPath`

## Root Cause

```
// Extension code (cannot be modified)
execSync(`chmod +x ${environment.assetsPath}/webp/arm/cwebp`);
// expands to (unquoted, space in path):
// chmod +x /Users/.../Application Support/SuperCmd/extensions/sips/assets/webp/arm/cwebp
// shell sees "Application" and "Support/..." as separate args → ENOENT
```

## Test Plan

Tested locally via `npm run dev`:

- [x] Open SuperCmd → run **Convert Images** command from Image Modification extension
- [x] Select an image and choose **WEBP** format
- [x] Confirmed conversion succeeds without "Command failed: chmod +x" error