### PR TITLE
fix(tray): use SVG file for menu bar icon — sharper and consistent across builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,16 @@
       "!dist/native/**/*.dSYM/**",
       "package.json"
     ],
+    "extraResources": [
+      {
+        "from": "supercmd.svg",
+        "to": "supercmd.svg"
+      },
+      {
+        "from": "supercmd.png",
+        "to": "supercmd.png"
+      }
+    ],
     "directories": {
       "output": "out"
     },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7385,7 +7385,12 @@ function isInvisibleTrayIcon(icon: any): boolean {
 
 function loadAppTrayIcon(): any {
   const fs = require('fs');
+  // SVG via createFromPath is handled by macOS NSImage natively → resolution-independent.
+  // PNG is the fallback for environments where SVG loading fails.
   const candidates = [
+    path.join(process.cwd(), 'supercmd.svg'),
+    path.join(app.getAppPath(), 'supercmd.svg'),
+    path.join(process.resourcesPath || '', 'supercmd.svg'),
     path.join(process.cwd(), 'supercmd.png'),
     path.join(app.getAppPath(), 'supercmd.png'),
     path.join(process.resourcesPath || '', 'supercmd.png'),
@@ -7399,7 +7404,7 @@ function loadAppTrayIcon(): any {
       if (!icon || icon.isEmpty()) return null;
       const resized = icon.resize({ width: 18, height: 18 });
       if (!resized || resized.isEmpty()) return null;
-      // Use template rendering on macOS so the icon adapts to light/dark menu bar.
+      // Template image adapts automatically to light/dark menu bar on macOS.
       if (process.platform === 'darwin') {
         try { resized.setTemplateImage(true); } catch {}
       }
@@ -7409,17 +7414,17 @@ function loadAppTrayIcon(): any {
     }
   };
 
-  const defaultTemplateIcon = buildDefaultMacTrayTemplateIcon();
-  if (defaultTemplateIcon) {
-    return defaultTemplateIcon;
-  }
-
   for (const candidate of candidates) {
     try {
       if (!candidate || !fs.existsSync(candidate)) continue;
       const trayImage = tryBuildTrayImage(nativeImage.createFromPath(candidate));
       if (trayImage) return trayImage;
     } catch {}
+  }
+
+  const defaultTemplateIcon = buildDefaultMacTrayTemplateIcon();
+  if (defaultTemplateIcon) {
+    return defaultTemplateIcon;
   }
 
   if (process.platform === 'darwin') {


### PR DESCRIPTION
## What changed

In the packaged app (v1.0.25 and earlier), the menu bar showed a **⌘ text label** instead of a proper icon — a silent fallback that only fires when icon loading completely fails. After this fix, SuperCmd shows a clean `supercmd.svg` icon that automatically adapts to light and dark menu bars.

## Before vs After

### Before — packaged app showed ⌘ text in menu bar
<img width="144" height="30" alt="before" src="https://github.com/user-attachments/assets/5401218b-a748-4d4a-bb3f-b9bcfda9e43b" />

### After — proper SVG icon, crisp on all displays, adapts to light/dark
<img width="153" height="30" alt="after" src="https://github.com/user-attachments/assets/53210b35-af70-4c7b-b369-cc77eb2a6e59" />

---

## Root cause

Three issues combined to silently fall through to the ⌘ text fallback:

**1. SVG data URL doesn't work in Electron's main process**

`buildDefaultMacTrayTemplateIcon()` called `nativeImage.createFromDataURL()` with a `data:image/svg+xml` URL. The main process has no Chromium renderer, so SVG data URLs produce an empty or nearly-transparent image.

**2. Icon files were not bundled**

`supercmd.svg` and `supercmd.png` exist in the project root and are found via `process.cwd()` in dev, but neither was listed in electron-builder's `extraResources`. In production all file-path candidates fail.

**3. ⌘ text fallback fires**

`isInvisibleTrayIcon()` inspects the pixel alpha values of the resulting bitmap. When the icon is empty or transparent, it returns `true`, which causes:
```ts
appTray = new Tray(nativeImage.createEmpty());
appTray.setTitle('⌘');   // ← what users see in the menu bar
```

## Fix

- Add `supercmd.svg` and `supercmd.png` to `extraResources` in `package.json` → both land at `process.resourcesPath` in the packaged app
- Reorder `loadAppTrayIcon()` candidate list to try SVG first:
  `supercmd.svg` → `supercmd.png` → icns fallbacks → inline SVG → dock icon
- `nativeImage.createFromPath()` with an SVG file is handled natively by macOS NSImage → **resolution-independent** (crisp on Retina), reliable in both dev and production, and correctly passes `isInvisibleTrayIcon()`

## Why this is a better user experience

| | Before | After |
|---|---|---|
| Menu bar shows | ⌘ text label (fallback) | Proper `supercmd.svg` icon |
| Rendering | N/A — text | Native SVG via NSImage, crisp on Retina |
| Light/Dark menu bar | ❌ Text doesn't adapt well | ✅ Template image, adapts automatically |
| Dev vs Production | ❌ Different (icon vs text) | ✅ Same icon in both |

## Test plan

- [x] Before/after screenshots added above
- [x] Build packaged app and verify menu bar shows icon (not ⌘ text)
- [x] Check icon on light menu bar
- [x] Check icon on dark menu bar
- [x] Check on Retina display (crispness)