### PR TITLE
fix: Add crash recovery to renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "supercmd",
-  "version": "1.0.22",
+  "version": "1.0.25-PMH",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "supercmd",
-      "version": "1.0.22",
+      "version": "1.0.25-PMH",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -388,9 +388,9 @@
       }
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -398,9 +398,9 @@
       }
     },
     "node_modules/@electron/asar/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -567,9 +567,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -604,9 +604,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -897,9 +897,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -929,9 +929,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -961,9 +961,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -1679,9 +1679,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
-      "integrity": "sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -1694,11 +1694,11 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^9.0.5",
-        "semver": "^7.7.3",
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
         "string-width": "^4.2.3",
         "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
+        "tinyglobby": "^0.2.16",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -1707,25 +1707,46 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@oclif/core/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@oclif/core/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1800,28 +1821,28 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.5",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.5.tgz",
-      "integrity": "sha512-H2eyeTU5BPd2ZiP5p4bO3krh70xpdglgDRJBHSIg7Dnx4ICOOfvQDo39JMcuDlV7cI8Dca3Ht5kybLXg3G6Ibw==",
+      "version": "1.104.19",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.19.tgz",
+      "integrity": "sha512-SAVg56BAzxZGy/OPQ0jekUG3pJaoX5pCqleALvFo9JRE7P2tvKoglWnYRcIJArRhLlvV8FtFNMDafd+NNwXXCw==",
       "license": "MIT",
       "dependencies": {
-        "@oclif/core": "^4.5.4",
-        "@oclif/plugin-autocomplete": "^3.2.35",
-        "@oclif/plugin-help": "^6.2.33",
-        "@oclif/plugin-not-found": "^3.2.68",
-        "@types/node": "22.13.10",
+        "@oclif/core": "^4.8.4",
+        "@oclif/plugin-autocomplete": "^3.2.40",
+        "@oclif/plugin-help": "^6.2.37",
+        "@oclif/plugin-not-found": "^3.2.74",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
-        "esbuild": "^0.25.10",
+        "esbuild": "^0.27.3",
         "react": "19.0.0"
       },
       "bin": {
         "ray": "bin/run.js"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=22.22.2"
       },
       "peerDependencies": {
-        "@types/node": "22.13.10",
+        "@types/node": "22.19.17",
         "@types/react": "19.0.10",
         "react-devtools": "6.1.1"
       },
@@ -1838,9 +1859,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -1854,9 +1875,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -1870,9 +1891,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -1886,9 +1907,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -1902,9 +1923,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -1918,9 +1939,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -1934,9 +1955,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -1950,9 +1971,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -1966,9 +1987,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -1982,9 +2003,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -1998,9 +2019,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -2014,9 +2035,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -2030,9 +2051,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -2046,9 +2067,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2062,9 +2083,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2078,9 +2099,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -2094,9 +2115,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -2110,9 +2131,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -2126,9 +2147,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -2142,9 +2163,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -2158,9 +2179,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -2174,9 +2195,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -2190,9 +2211,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -2206,12 +2227,12 @@
       }
     },
     "node_modules/@raycast/api/node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@raycast/api/node_modules/@types/react": {
@@ -2224,9 +2245,9 @@
       }
     },
     "node_modules/@raycast/api/node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2236,32 +2257,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/@raycast/api/node_modules/react": {
@@ -2273,12 +2294,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@raycast/api/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "license": "MIT"
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2287,9 +2302,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
       "cpu": [
         "arm"
       ],
@@ -2301,9 +2316,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
       "cpu": [
         "arm64"
       ],
@@ -2315,9 +2330,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
       "cpu": [
         "arm64"
       ],
@@ -2329,9 +2344,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
       "cpu": [
         "x64"
       ],
@@ -2343,9 +2358,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
       "cpu": [
         "arm64"
       ],
@@ -2357,9 +2372,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
       "cpu": [
         "x64"
       ],
@@ -2371,13 +2386,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2385,13 +2403,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2399,13 +2420,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2413,13 +2437,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2427,13 +2454,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2441,13 +2471,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2455,13 +2488,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2469,13 +2505,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2483,13 +2522,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2497,13 +2539,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2511,13 +2556,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2525,13 +2573,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2539,13 +2590,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2553,9 +2607,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
       "cpu": [
         "x64"
       ],
@@ -2567,9 +2621,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
       "cpu": [
         "arm64"
       ],
@@ -2581,9 +2635,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
       "cpu": [
         "arm64"
       ],
@@ -2595,9 +2649,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
       "cpu": [
         "ia32"
       ],
@@ -2609,9 +2663,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
       "cpu": [
         "x64"
       ],
@@ -2623,9 +2677,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
       "cpu": [
         "x64"
       ],
@@ -2685,9 +2739,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -2760,9 +2814,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2898,9 +2952,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -2925,9 +2979,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3300,15 +3354,16 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
-      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3405,9 +3460,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3965,12 +4020,12 @@
       }
     },
     "node_modules/config-file-ts/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4230,9 +4285,9 @@
       }
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4240,9 +4295,9 @@
       }
     },
     "node_modules/dir-compare/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5127,9 +5182,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -5389,9 +5444,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5399,9 +5454,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5896,9 +5951,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6078,9 +6133,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -6260,9 +6315,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -6360,9 +6415,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -6681,9 +6736,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6728,9 +6783,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -6748,7 +6803,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6920,11 +6975,14 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -7214,13 +7272,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -7230,31 +7288,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -7400,9 +7458,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7847,13 +7905,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7880,9 +7938,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7892,9 +7950,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -8671,9 +8729,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercmd",
-  "version": "1.0.25",
+  "version": "1.0.25-PMH",
   "description": "SuperCmd — Productivity supercharged",
   "author": "Shobhit Bhosure - (https://x.com/nullbytes00)",
   "homepage": "https://supercmd.sh",
@@ -15,6 +15,7 @@
     "build:main": "tsc -p tsconfig.main.json && cp src/main/emoji-data.json dist/main/emoji-data.json",
     "build:renderer": "vite build",
     "check:i18n": "node scripts/check-i18n.mjs",
+    "test": "node --test 'scripts/test-*.mjs'",
     "build:native": "node scripts/build-native.mjs",
     "postinstall": "electron-builder install-app-deps",
     "start": "electron .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercmd",
-  "version": "1.0.25-PMH",
+  "version": "1.0.25",
   "description": "SuperCmd — Productivity supercharged",
   "author": "Shobhit Bhosure - (https://x.com/nullbytes00)",
   "homepage": "https://supercmd.sh",

--- a/scripts/fixtures/crash-recovery-harness.cjs
+++ b/scripts/fixtures/crash-recovery-harness.cjs
@@ -1,0 +1,114 @@
+// Electron harness that reproduces the blank-window bug end to end:
+//
+//   1. Open a hidden (offscreen) window and render visible content.
+//   2. Crash its renderer for real with process.crash() — the same way an
+//      extension OOM / native crash kills the launcher renderer.
+//   3. Let the REAL production recovery logic (renderer-recovery.ts) decide to
+//      reload, mirroring what main.ts does on 'render-process-gone'.
+//   4. Assert the window comes back and paints content again (not blank).
+//
+// Prints a single line `RESULT <json>` to stdout for the test runner to parse,
+// then quits.
+
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+const fs = require('fs');
+const esbuild = require('esbuild');
+
+// Load the REAL production decision logic by transpiling the .ts on the fly.
+function loadRendererRecovery() {
+  const tsPath = path.join(__dirname, '..', '..', 'src', 'main', 'renderer-recovery.ts');
+  const { code } = esbuild.transformSync(fs.readFileSync(tsPath, 'utf8'), {
+    loader: 'ts',
+    format: 'cjs',
+  });
+  const module = { exports: {} };
+  new Function('exports', 'require', 'module', code)(module.exports, require, module);
+  return module.exports;
+}
+
+const { getRendererCrashState, evaluateRendererCrash, RENDERER_RECOVERY_DELAY_MS } =
+  loadRendererRecovery();
+
+// A tiny page that announces it mounted, then crashes itself on request.
+const PAGE = `<!doctype html><html><body><div id="status">RENDERED</div>
+<script>
+  const { ipcRenderer } = require('electron');
+  ipcRenderer.send('mounted');
+  ipcRenderer.on('crash-now', () => { process.crash(); });
+</script></body></html>`;
+const PAGE_URL = 'data:text/html;charset=utf-8,' + encodeURIComponent(PAGE);
+
+function finish(result) {
+  process.stdout.write('RESULT ' + JSON.stringify(result) + '\n');
+  // Give stdout a tick to flush before tearing down.
+  setTimeout(() => app.quit(), 50);
+}
+
+app.disableHardwareAcceleration();
+
+app.whenReady().then(() => {
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      offscreen: true,
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  let mountCount = 0;
+  let crashObserved = false;
+  let crashState = getRendererCrashState();
+  const watchdog = setTimeout(
+    () => finish({ ok: false, error: 'timeout', mountCount, crashObserved }),
+    15000,
+  );
+
+  ipcMain.on('mounted', async (event) => {
+    if (event.sender !== win.webContents) return;
+    mountCount += 1;
+
+    if (mountCount === 1) {
+      // First healthy render — now crash the renderer for real.
+      win.webContents.send('crash-now');
+      return;
+    }
+
+    // Second mount = the window recovered after the crash. Prove it's not blank
+    // by reading the DOM the recovered renderer actually painted.
+    try {
+      const text = await win.webContents.executeJavaScript(
+        "document.getElementById('status') && document.getElementById('status').innerText",
+      );
+      clearTimeout(watchdog);
+      finish({ ok: text === 'RENDERED' && crashObserved, crashObserved, mountCount, paintedText: text });
+    } catch (err) {
+      clearTimeout(watchdog);
+      finish({ ok: false, error: String(err), crashObserved, mountCount });
+    }
+  });
+
+  win.webContents.on('render-process-gone', (_event, details) => {
+    const reason = String((details && details.reason) || 'unknown');
+    crashObserved = true;
+    // Run the SAME decision the production handler runs.
+    const decision = evaluateRendererCrash(crashState, reason, Date.now());
+    crashState = decision.nextState;
+    if (!decision.reload) {
+      clearTimeout(watchdog);
+      finish({ ok: false, error: 'recovery-declined', reason, mountCount });
+      return;
+    }
+    // Deferred reload, exactly like main.ts.
+    setTimeout(() => {
+      if (win.isDestroyed()) return;
+      win.loadURL(PAGE_URL);
+    }, RENDERER_RECOVERY_DELAY_MS);
+  });
+
+  win.loadURL(PAGE_URL);
+});
+
+// Don't let the app stay alive on its own if something goes sideways.
+app.on('window-all-closed', () => app.quit());

--- a/scripts/lib/ts-import.mjs
+++ b/scripts/lib/ts-import.mjs
@@ -1,0 +1,16 @@
+// Import a self-contained TypeScript module from a test by transpiling it with
+// esbuild on the fly. This lets the recovery tests run the *real* production
+// source (renderer-recovery.ts, reload-budget.ts) instead of grepping it.
+//
+// Only works for modules with no relative imports of their own — the recovery
+// helpers are deliberately dependency-free for exactly this reason.
+
+import { transform } from 'esbuild';
+import fs from 'node:fs';
+
+export async function importTs(absPath) {
+  const src = fs.readFileSync(absPath, 'utf8');
+  const { code } = await transform(src, { loader: 'ts', format: 'esm' });
+  const dataUrl = 'data:text/javascript;base64,' + Buffer.from(code).toString('base64');
+  return import(dataUrl);
+}

--- a/scripts/test-browser-search-lag-fix.mjs
+++ b/scripts/test-browser-search-lag-fix.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
@@ -14,55 +15,73 @@ const files = {
   settings: fs.readFileSync('src/renderer/src/settings/AdvancedTab.tsx', 'utf8'),
 };
 
-function assertIncludes(name, source, needle) {
-  assert.ok(source.includes(needle), `${name} should include ${needle}`);
+function assertIncludes(source, needle) {
+  assert.ok(source.includes(needle), `Source should include: ${needle}`);
 }
 
-function assertNotIncludes(name, source, needle) {
-  assert.ok(!source.includes(needle), `${name} should not include ${needle}`);
+function assertNotIncludes(source, needle) {
+  assert.ok(!source.includes(needle), `Source should not include: ${needle}`);
 }
 
-assertIncludes('main history module', files.history, 'getBrowserSearchRevision');
-assertIncludes('main history module', files.history, 'getBrowserSearchStats');
-assertIncludes('main history module', files.history, 'seenBookmarkKeys');
-assertIncludes('main history module', files.history, 'existingBookmarkByKey');
+test('Browser search lag fix', async (t) => {
+  await t.test('main history module exports required functions', () => {
+    assertIncludes(files.history, 'getBrowserSearchRevision');
+    assertIncludes(files.history, 'getBrowserSearchStats');
+    assertIncludes(files.history, 'seenBookmarkKeys');
+    assertIncludes(files.history, 'existingBookmarkByKey');
+  });
 
-assertIncludes('main IPC', files.main, "ipcMain.handle('browser-search:revision'");
-assertIncludes('main IPC', files.main, "ipcMain.handle('browser-search:stats'");
-assertIncludes('main IPC', files.main, 'revision: getCombinedBrowserSearchRevision()');
-assertIncludes('main refresh guard', files.main, 'const beforeRevision = bsGetBrowserSearchRevision();');
-assertIncludes('main refresh guard', files.main, 'bsGetBrowserSearchRevision() !== beforeRevision');
+  await t.test('main IPC handlers are registered', () => {
+    assertIncludes(files.main, "ipcMain.handle('browser-search:revision'");
+    assertIncludes(files.main, "ipcMain.handle('browser-search:stats'");
+    assertIncludes(files.main, 'revision: getCombinedBrowserSearchRevision()');
+  });
 
-assertIncludes('preload API', files.preload, 'browserSearchRevision');
-assertIncludes('preload API', files.preload, 'browserSearchStats');
-assertIncludes('renderer types', files.types, 'BrowserSearchStats');
-assertIncludes('renderer types', files.types, 'BrowserSearchEntryListPayload');
+  await t.test('main refresh guard checks revision before refresh', () => {
+    assertIncludes(files.main, 'const beforeRevision = bsGetBrowserSearchRevision();');
+    assertIncludes(files.main, 'bsGetBrowserSearchRevision() !== beforeRevision');
+  });
 
-assertIncludes('browser search hook', files.hook, 'entriesRevisionRef');
-assertIncludes('browser search hook', files.hook, 'refreshEntriesIfStale');
-assertIncludes('browser search hook', files.hook, 'historyByTimeEntryIds');
-assertIncludes('browser search hook', files.hook, 'bookmarksByBrowserOrderEntryIds');
-assertIncludes('browser search hook', files.hook, 'BROWSER_ENTRY_INDEX_MAX_TOKEN_LENGTH = 128');
-assertIncludes('browser search hook', files.hook, 'BROWSER_ENTRY_INDEX_MAX_URL_CHARS = 4096');
-assertIncludes('browser search hook', files.hook, 'new Map<string, { fingerprint: string; index: BrowserEntrySearchIndex }>()');
-assertIncludes('browser search hook', files.hook, 'for (const entryId of options.candidateEntryIds)');
+  await t.test('preload API exports browser search methods', () => {
+    assertIncludes(files.preload, 'browserSearchRevision');
+    assertIncludes(files.preload, 'browserSearchStats');
+  });
 
-const localBookmarksBlock = files.localCommands.match(/if \(commandId === BROWSER_SEARCH_BOOKMARKS_COMMAND_ID\) \{[\s\S]*?return true;/)?.[0] || '';
-const localHistoryBlock = files.localCommands.match(/if \(commandId === BROWSER_SEARCH_HISTORY_COMMAND_ID\) \{[\s\S]*?return true;/)?.[0] || '';
-assertNotIncludes('local bookmarks open block', localBookmarksBlock, 'refreshBrowserEntries();');
-assertNotIncludes('local history open block', localHistoryBlock, 'refreshBrowserEntries();');
-assertIncludes('local bookmarks open block', localBookmarksBlock, 'refreshBrowserEntriesIfStale();');
-assertIncludes('local history open block', localHistoryBlock, 'refreshBrowserEntriesIfStale();');
+  await t.test('renderer types include browser search types', () => {
+    assertIncludes(files.types, 'BrowserSearchStats');
+    assertIncludes(files.types, 'BrowserSearchEntryListPayload');
+  });
 
-const shownBookmarksBlock = files.windowShown.match(/if \(routedSystemCommandId === BROWSER_SEARCH_BOOKMARKS_COMMAND_ID\) \{[\s\S]*?return;/)?.[0] || '';
-const shownHistoryBlock = files.windowShown.match(/if \(routedSystemCommandId === BROWSER_SEARCH_HISTORY_COMMAND_ID\) \{[\s\S]*?return;/)?.[0] || '';
-assertNotIncludes('window-shown bookmarks block', shownBookmarksBlock, 'refreshBrowserEntries();');
-assertNotIncludes('window-shown history block', shownHistoryBlock, 'refreshBrowserEntries();');
-assertIncludes('window-shown bookmarks block', shownBookmarksBlock, 'refreshBrowserEntriesIfStale();');
-assertIncludes('window-shown history block', shownHistoryBlock, 'refreshBrowserEntriesIfStale();');
+  await t.test('browser search hook has required state and methods', () => {
+    assertIncludes(files.hook, 'entriesRevisionRef');
+    assertIncludes(files.hook, 'refreshEntriesIfStale');
+    assertIncludes(files.hook, 'historyByTimeEntryIds');
+    assertIncludes(files.hook, 'bookmarksByBrowserOrderEntryIds');
+    assertIncludes(files.hook, 'BROWSER_ENTRY_INDEX_MAX_TOKEN_LENGTH = 128');
+    assertIncludes(files.hook, 'BROWSER_ENTRY_INDEX_MAX_URL_CHARS = 4096');
+  });
 
-assertIncludes('advanced settings', files.settings, 'browserSearchStats');
-assertIncludes('advanced settings', files.settings, 'browserSearchStats?.profileCountsByKind?.history');
-assertNotIncludes('advanced settings', files.settings, 'window.electron.browserSearchListEntries()');
+  await t.test('local commands use refreshEntriesIfStale not refreshEntries', () => {
+    const localBookmarksBlock = files.localCommands.match(/if \(commandId === BROWSER_SEARCH_BOOKMARKS_COMMAND_ID\) \{[\s\S]*?return true;/)?.[0] || '';
+    const localHistoryBlock = files.localCommands.match(/if \(commandId === BROWSER_SEARCH_HISTORY_COMMAND_ID\) \{[\s\S]*?return true;/)?.[0] || '';
+    assertNotIncludes(localBookmarksBlock, 'refreshBrowserEntries();');
+    assertNotIncludes(localHistoryBlock, 'refreshBrowserEntries();');
+    assertIncludes(localBookmarksBlock, 'refreshBrowserEntriesIfStale();');
+    assertIncludes(localHistoryBlock, 'refreshBrowserEntriesIfStale();');
+  });
 
-console.log('browser-search lag-fix tests passed');
+  await t.test('window-shown handler uses refreshEntriesIfStale not refreshEntries', () => {
+    const shownBookmarksBlock = files.windowShown.match(/if \(routedSystemCommandId === BROWSER_SEARCH_BOOKMARKS_COMMAND_ID\) \{[\s\S]*?return;/)?.[0] || '';
+    const shownHistoryBlock = files.windowShown.match(/if \(routedSystemCommandId === BROWSER_SEARCH_HISTORY_COMMAND_ID\) \{[\s\S]*?return;/)?.[0] || '';
+    assertNotIncludes(shownBookmarksBlock, 'refreshBrowserEntries();');
+    assertNotIncludes(shownHistoryBlock, 'refreshBrowserEntries();');
+    assertIncludes(shownBookmarksBlock, 'refreshBrowserEntriesIfStale();');
+    assertIncludes(shownHistoryBlock, 'refreshBrowserEntriesIfStale();');
+  });
+
+  await t.test('advanced settings displays browser search stats', () => {
+    assertIncludes(files.settings, 'browserSearchStats');
+    assertIncludes(files.settings, 'browserSearchStats?.profileCountsByKind?.history');
+    assertNotIncludes(files.settings, 'window.electron.browserSearchListEntries()');
+  });
+});

--- a/scripts/test-renderer-crash-recovery-live.mjs
+++ b/scripts/test-renderer-crash-recovery-live.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+// END-TO-END reproduction of the blank-window bug. This launches a real
+// Electron process, opens a window, crashes its renderer for real with
+// process.crash(), and asserts the window recovers and paints content again —
+// running the actual production recovery logic against an actual crashed
+// renderer rather than asserting on source text.
+//
+// It's heavier than the pure-logic tests, so it self-skips when Electron can't
+// be launched (e.g. a headless CI box with no display, or
+// SUPERCMD_SKIP_ELECTRON_TESTS=1).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const harness = path.join(root, 'scripts/fixtures/crash-recovery-harness.cjs');
+
+function resolveElectronBinary() {
+  try {
+    // The 'electron' package's main export is the path to the binary.
+    const require = createRequire(import.meta.url);
+    const electronPath = require('electron');
+    return typeof electronPath === 'string' ? electronPath : null;
+  } catch {
+    return null;
+  }
+}
+
+const electronBin = resolveElectronBinary();
+const shouldSkip = !electronBin || process.env.SUPERCMD_SKIP_ELECTRON_TESTS === '1'
+  || (process.platform === 'linux' && !process.env.DISPLAY);
+
+function runHarness() {
+  return new Promise((resolve) => {
+    // Strip ELECTRON_RUN_AS_NODE — if it leaks in from the parent, Electron runs
+    // as plain Node and `require('electron')` yields no app/BrowserWindow.
+    const env = { ...process.env, ELECTRON_DISABLE_SECURITY_WARNINGS: '1' };
+    delete env.ELECTRON_RUN_AS_NODE;
+
+    const child = spawn(electronBin, [harness], {
+      cwd: root,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+
+    const killTimer = setTimeout(() => child.kill('SIGKILL'), 30000);
+
+    child.on('close', () => {
+      clearTimeout(killTimer);
+      const line = stdout.split('\n').find((l) => l.startsWith('RESULT '));
+      if (!line) {
+        resolve({ ok: false, error: 'no-result', stdout, stderr });
+        return;
+      }
+      try {
+        resolve(JSON.parse(line.slice('RESULT '.length)));
+      } catch (err) {
+        resolve({ ok: false, error: 'bad-result: ' + String(err), stdout, stderr });
+      }
+    });
+  });
+}
+
+test('Renderer crash recovery (live Electron)', { skip: shouldSkip ? 'Electron not launchable here' : false }, async (t) => {
+  const result = await runHarness();
+
+  await t.test('the renderer actually crashed', () => {
+    assert.equal(result.crashObserved, true, `expected a real crash; got ${JSON.stringify(result)}`);
+  });
+
+  await t.test('the window recovered and painted content again (not blank)', () => {
+    assert.equal(result.ok, true, `window did not recover: ${JSON.stringify(result)}`);
+    assert.equal(result.paintedText, 'RENDERED', 'recovered renderer painted its content');
+    assert.ok(result.mountCount >= 2, 'renderer mounted again after the crash');
+  });
+});

--- a/scripts/test-renderer-crash-recovery.mjs
+++ b/scripts/test-renderer-crash-recovery.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const mainTs = fs.readFileSync('src/main/main.ts', 'utf8');
+
+function assertIncludes(source, needle) {
+  assert.ok(source.includes(needle), `Source should include: ${needle}`);
+}
+
+test('Renderer crash recovery', async (t) => {
+  await t.test('render-process-gone handler exists', () => {
+    assertIncludes(mainTs, "mainWindow.webContents.on('render-process-gone'");
+  });
+
+  await t.test('handler checks isAppQuitting to avoid recovery during shutdown', () => {
+    assertIncludes(mainTs, 'if (isAppQuitting) return;');
+  });
+
+  await t.test('clean-exit is handled (normal shutdown)', () => {
+    assertIncludes(mainTs, "if (reason === 'clean-exit') return;");
+  });
+
+  await t.test('rate-limiting prevents crash loops', () => {
+    assertIncludes(mainTs, 'rendererReloadCount');
+    assertIncludes(mainTs, 'if (now - lastRendererReloadAt > 30000) rendererReloadCount = 0;');
+    assertIncludes(mainTs, 'if (rendererReloadCount > 3)');
+  });
+
+  await t.test('reload is called after crash', () => {
+    assertIncludes(mainTs, 'loadWindowUrl(mainWindow, \'/\');');
+  });
+
+  await t.test('unresponsive handler exists', () => {
+    assertIncludes(mainTs, "mainWindow.webContents.on('unresponsive'");
+  });
+
+  await t.test('unresponsive only reloads while hidden', () => {
+    assertIncludes(mainTs, 'if (isVisible) return;');
+  });
+
+  await t.test('unresponsive calls reloadIgnoringCache', () => {
+    assertIncludes(mainTs, 'mainWindow.webContents.reloadIgnoringCache()');
+  });
+});

--- a/scripts/test-renderer-crash-recovery.mjs
+++ b/scripts/test-renderer-crash-recovery.mjs
@@ -33,6 +33,14 @@ test('Renderer crash recovery', async (t) => {
     assertIncludes(mainTs, 'loadWindowUrl(mainWindow, \'/\');');
   });
 
+  await t.test('reload is DEFERRED out of the crash callback (avoids Mach SIGTRAP)', () => {
+    // Reloading synchronously inside render-process-gone respawns the renderer
+    // mid-teardown and aborts the whole app on macOS. The reload must be in a
+    // setTimeout, with a re-guard against isAppQuitting/destroyed at fire time.
+    assertIncludes(mainTs, 'const RENDERER_RECOVERY_DELAY_MS =');
+    assertIncludes(mainTs, '}, RENDERER_RECOVERY_DELAY_MS);');
+  });
+
   await t.test('unresponsive handler exists', () => {
     assertIncludes(mainTs, "mainWindow.webContents.on('unresponsive'");
   });

--- a/scripts/test-renderer-crash-recovery.mjs
+++ b/scripts/test-renderer-crash-recovery.mjs
@@ -25,7 +25,7 @@ test('Renderer crash recovery', async (t) => {
 
   await t.test('rate-limiting prevents crash loops', () => {
     assertIncludes(mainTs, 'rendererReloadCount');
-    assertIncludes(mainTs, 'if (now - lastRendererReloadAt > 30000) rendererReloadCount = 0;');
+    assertIncludes(mainTs, 'if (now - lastRendererReloadAt > THIRTY_SECONDS) rendererReloadCount = 0;');
     assertIncludes(mainTs, 'if (rendererReloadCount > 3)');
   });
 

--- a/scripts/test-renderer-crash-recovery.mjs
+++ b/scripts/test-renderer-crash-recovery.mjs
@@ -25,8 +25,10 @@ test('Renderer crash recovery', async (t) => {
 
   await t.test('rate-limiting prevents crash loops', () => {
     assertIncludes(mainTs, 'rendererReloadCount');
-    assertIncludes(mainTs, 'if (now - lastRendererReloadAt > THIRTY_SECONDS) rendererReloadCount = 0;');
-    assertIncludes(mainTs, 'if (rendererReloadCount > 3)');
+    assertIncludes(mainTs, 'MAX_AUTO_RELOADS =');
+    assertIncludes(mainTs, 'STABLE_SESSION_MS =');
+    assertIncludes(mainTs, 'if (now - lastRendererReloadAt > STABLE_SESSION_MS) rendererReloadCount = 0;');
+    assertIncludes(mainTs, 'if (rendererReloadCount > MAX_AUTO_RELOADS)');
   });
 
   await t.test('reload is called after crash', () => {

--- a/scripts/test-renderer-crash-recovery.mjs
+++ b/scripts/test-renderer-crash-recovery.mjs
@@ -1,57 +1,102 @@
 #!/usr/bin/env node
 
+// Behavioral test for the main-process renderer crash-recovery decision.
+// This runs the evaluateRendererCrash() (the same code main.ts calls) 
+// through actual crash sequences and asserts the recovery decisions it makes.
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importTs } from './lib/ts-import.mjs';
 
-const mainTs = fs.readFileSync('src/main/main.ts', 'utf8');
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  getRendererCrashState,
+  evaluateRendererCrash,
+  RENDERER_RECOVERY_MAX_RELOADS,
+  RENDERER_RECOVERY_STABLE_SESSION_MS,
+} = await importTs(path.join(root, 'src/main/renderer-recovery.ts'));
 
-function assertIncludes(source, needle) {
-  assert.ok(source.includes(needle), `Source should include: ${needle}`);
+// Drive a sequence of crashes through the decision function, threading state the
+// same way main.ts does, and return the list of decisions.
+function runCrashes(crashes) {
+  let state = getRendererCrashState();
+  const decisions = [];
+  for (const { reason = 'crashed', now } of crashes) {
+    const d = evaluateRendererCrash(state, reason, now);
+    state = d.nextState;
+    decisions.push(d);
+  }
+  return decisions;
 }
 
-test('Renderer crash recovery', async (t) => {
-  await t.test('render-process-gone handler exists', () => {
-    assertIncludes(mainTs, "mainWindow.webContents.on('render-process-gone'");
+test('Renderer crash recovery (main process)', async (t) => {
+  await t.test('first crash triggers a reload', () => {
+    const [d] = runCrashes([{ now: 1000 }]);
+    assert.equal(d.reload, true);
+    assert.equal(d.giveUp, false);
   });
 
-  await t.test('handler checks isAppQuitting to avoid recovery during shutdown', () => {
-    assertIncludes(mainTs, 'if (isAppQuitting) return;');
+  await t.test('reloads up to the cap, then gives up on the next crash', () => {
+    // MAX_AUTO_RELOADS rapid crashes should all reload; the one after must not.
+    const crashes = [];
+    for (let i = 0; i <= RENDERER_RECOVERY_MAX_RELOADS; i++) {
+      crashes.push({ now: 1000 + i * 100 }); // all well within the stable window
+    }
+    const decisions = runCrashes(crashes);
+    const reloaded = decisions.slice(0, RENDERER_RECOVERY_MAX_RELOADS);
+    const lastOne = decisions[RENDERER_RECOVERY_MAX_RELOADS];
+
+    assert.ok(reloaded.every((d) => d.reload === true), 'all crashes up to the cap reload');
+    assert.equal(lastOne.reload, false, 'crash past the cap does not reload');
+    assert.equal(lastOne.giveUp, true, 'and is reported as giving up');
   });
 
-  await t.test('clean-exit is handled (normal shutdown)', () => {
-    assertIncludes(mainTs, "if (reason === 'clean-exit') return;");
+  await t.test('a crash after a quiet stretch starts a fresh burst', () => {
+    // Exhaust the budget...
+    const burst = [];
+    for (let i = 0; i <= RENDERER_RECOVERY_MAX_RELOADS; i++) burst.push({ now: 1000 + i * 100 });
+    // ...then crash again long after the stable window — should reload again.
+    const afterQuiet = 1000 + RENDERER_RECOVERY_STABLE_SESSION_MS + 5000;
+    burst.push({ now: afterQuiet });
+
+    const decisions = runCrashes(burst);
+    const recovered = decisions[decisions.length - 1];
+    assert.equal(recovered.reload, true, 'budget resets after a quiet stretch');
+    assert.equal(recovered.giveUp, false);
   });
 
-  await t.test('rate-limiting prevents crash loops', () => {
-    assertIncludes(mainTs, 'rendererReloadCount');
-    assertIncludes(mainTs, 'MAX_AUTO_RELOADS =');
-    assertIncludes(mainTs, 'STABLE_SESSION_MS =');
-    assertIncludes(mainTs, 'if (now - lastRendererReloadAt > STABLE_SESSION_MS) rendererReloadCount = 0;');
-    assertIncludes(mainTs, 'if (rendererReloadCount > MAX_AUTO_RELOADS)');
+  await t.test("'clean-exit' is ignored and does not consume the budget", () => {
+    let state = getRendererCrashState();
+    // A normal teardown...
+    const clean = evaluateRendererCrash(state, 'clean-exit', 1000);
+    assert.equal(clean.reload, false, 'clean-exit never reloads');
+    assert.equal(clean.giveUp, false);
+    assert.deepEqual(clean.nextState, state, 'clean-exit does not advance the budget');
+
+    // ...followed by real crashes still gets the full reload budget.
+    state = clean.nextState;
+    for (let i = 0; i < RENDERER_RECOVERY_MAX_RELOADS; i++) {
+      const d = evaluateRendererCrash(state, 'crashed', 2000 + i * 100);
+      assert.equal(d.reload, true, `crash ${i + 1} after a clean-exit still reloads`);
+      state = d.nextState;
+    }
   });
 
-  await t.test('reload is called after crash', () => {
-    assertIncludes(mainTs, 'loadWindowUrl(mainWindow, \'/\');');
-  });
-
-  await t.test('reload is DEFERRED out of the crash callback (avoids Mach SIGTRAP)', () => {
-    // Reloading synchronously inside render-process-gone respawns the renderer
-    // mid-teardown and aborts the whole app on macOS. The reload must be in a
-    // setTimeout, with a re-guard against isAppQuitting/destroyed at fire time.
-    assertIncludes(mainTs, 'const RENDERER_RECOVERY_DELAY_MS =');
-    assertIncludes(mainTs, '}, RENDERER_RECOVERY_DELAY_MS);');
-  });
-
-  await t.test('unresponsive handler exists', () => {
-    assertIncludes(mainTs, "mainWindow.webContents.on('unresponsive'");
-  });
-
-  await t.test('unresponsive only reloads while hidden', () => {
-    assertIncludes(mainTs, 'if (isVisible) return;');
-  });
-
-  await t.test('unresponsive calls reloadIgnoringCache', () => {
-    assertIncludes(mainTs, 'mainWindow.webContents.reloadIgnoringCache()');
+  // The behavioral checks above prove the LOGIC; this guards the WIRING so the
+  // logic can't be acidentally bypassed by an edit to main.ts.
+  await t.test('main.ts wires the render-process-gone handler to this logic', () => {
+    const mainTs = fs.readFileSync(path.join(root, 'src/main/main.ts'), 'utf8');
+    assert.ok(
+      mainTs.includes("mainWindow.webContents.on('render-process-gone'"),
+      'render-process-gone handler is installed',
+    );
+    assert.ok(mainTs.includes('evaluateRendererCrash('), 'handler delegates to evaluateRendererCrash');
+    assert.ok(
+      mainTs.includes("mainWindow.webContents.on('unresponsive'"),
+      'unresponsive handler is installed',
+    );
   });
 });

--- a/scripts/test-renderer-error-boundary.mjs
+++ b/scripts/test-renderer-error-boundary.mjs
@@ -92,10 +92,6 @@ test('Renderer error boundary auto-reload budget', async (t) => {
     assert.ok(mainTsx.includes('consumeAutoReloadBudget'), 'boundary consumes the budget');
     assert.ok(mainTsx.includes('window.location.reload()'), 'boundary reloads on crash');
     assert.ok(
-      mainTsx.includes('if (this.state.reloading) return <RendererRecovering />;'),
-      'a quiet placeholder is shown while reloading',
-    );
-    assert.ok(
       mainTsx.includes('return <RendererErrorFallback error={this.state.error} />;'),
       'falls back to the manual error card when the budget is exhausted',
     );

--- a/scripts/test-renderer-error-boundary.mjs
+++ b/scripts/test-renderer-error-boundary.mjs
@@ -13,9 +13,9 @@ function assertIncludes(source, needle) {
 test('Renderer error boundary auto-recovery', async (t) => {
   await t.test('budget constants are defined', () => {
     assertIncludes(mainTsx, "const RELOAD_TRACKER_KEY = 'sc-renderer-reload-tracker';");
-    assertIncludes(mainTsx, 'const RELOAD_WINDOW_MS = 30_000;');
-    assertIncludes(mainTsx, 'const MAX_AUTO_RELOADS = 3;');
-    assertIncludes(mainTsx, 'const STABLE_SESSION_MS = 15_000;');
+    assertIncludes(mainTsx, 'const RELOAD_WINDOW_MS =');
+    assertIncludes(mainTsx, 'const MAX_AUTO_RELOADS =');
+    assertIncludes(mainTsx, 'const STABLE_SESSION_MS =');
   });
 
   await t.test('budget is tracked in sessionStorage so it survives the reload', () => {

--- a/scripts/test-renderer-error-boundary.mjs
+++ b/scripts/test-renderer-error-boundary.mjs
@@ -1,58 +1,103 @@
 #!/usr/bin/env node
 
+// This runs the REAL consumeAutoReloadBudget() / clearAutoReloadBudget() 
+// (the same code the error boundary calls) against an in-memory sessionStorage 
+// and asserts the actual reload decisions.
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importTs } from './lib/ts-import.mjs';
 
-const mainTsx = fs.readFileSync('src/renderer/src/main.tsx', 'utf8');
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  consumeAutoReloadBudget,
+  clearAutoReloadBudget,
+  MAX_AUTO_RELOADS,
+  RELOAD_WINDOW_MS,
+  RELOAD_TRACKER_KEY,
+} = await importTs(path.join(root, 'src/renderer/src/utils/reload-budget.ts'));
 
-function assertIncludes(source, needle) {
-  assert.ok(source.includes(needle), `Source should include: ${needle}`);
+// A minimal in-memory stand-in for sessionStorage.
+function makeStorage(initial = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+    _map: map,
+  };
 }
 
-test('Renderer error boundary auto-recovery', async (t) => {
-  await t.test('budget constants are defined', () => {
-    assertIncludes(mainTsx, "const RELOAD_TRACKER_KEY = 'sc-renderer-reload-tracker';");
-    assertIncludes(mainTsx, 'const RELOAD_WINDOW_MS =');
-    assertIncludes(mainTsx, 'const MAX_AUTO_RELOADS =');
-    assertIncludes(mainTsx, 'const STABLE_SESSION_MS =');
+// Storage that throws on every access (e.g. sessionStorage disabled/wedged).
+const throwingStorage = {
+  getItem() { throw new Error('storage unavailable'); },
+  setItem() { throw new Error('storage unavailable'); },
+  removeItem() { throw new Error('storage unavailable'); },
+};
+
+test('Renderer error boundary auto-reload budget', async (t) => {
+  await t.test('allows reloads up to the cap, then denies', () => {
+    const storage = makeStorage();
+    const now = 1000;
+    const results = [];
+    // One more attempt than the cap allows.
+    for (let i = 0; i < MAX_AUTO_RELOADS + 1; i++) {
+      results.push(consumeAutoReloadBudget(storage, now + i)); // all in the same window
+    }
+    const allowed = results.slice(0, MAX_AUTO_RELOADS);
+    assert.ok(allowed.every((r) => r === true), `first ${MAX_AUTO_RELOADS} reloads allowed`);
+    assert.equal(results[MAX_AUTO_RELOADS], false, 'reload past the cap is denied');
   });
 
-  await t.test('budget is tracked in sessionStorage so it survives the reload', () => {
-    assertIncludes(mainTsx, 'sessionStorage.getItem(RELOAD_TRACKER_KEY)');
-    assertIncludes(mainTsx, 'sessionStorage.setItem(RELOAD_TRACKER_KEY');
+  await t.test('budget resets after the reload window elapses', () => {
+    const storage = makeStorage();
+    const start = 1000;
+    // Exhaust the budget.
+    for (let i = 0; i < MAX_AUTO_RELOADS; i++) consumeAutoReloadBudget(storage, start + i);
+    assert.equal(consumeAutoReloadBudget(storage, start + 10), false, 'exhausted within window');
+
+    // After RELOAD_WINDOW_MS, a fresh crash gets a fresh budget.
+    const later = start + RELOAD_WINDOW_MS + 1;
+    assert.equal(consumeAutoReloadBudget(storage, later), true, 'budget resets after the window');
   });
 
-  await t.test('budget window resets after RELOAD_WINDOW_MS', () => {
-    assertIncludes(mainTsx, 'now - tracker.firstAt > RELOAD_WINDOW_MS');
+  await t.test('clearAutoReloadBudget restores a full budget mid-window', () => {
+    const storage = makeStorage();
+    const now = 1000;
+    for (let i = 0; i < MAX_AUTO_RELOADS; i++) consumeAutoReloadBudget(storage, now + i);
+    assert.equal(consumeAutoReloadBudget(storage, now + 5), false, 'exhausted');
+
+    clearAutoReloadBudget(storage);
+    assert.equal(storage.getItem(RELOAD_TRACKER_KEY), null, 'tracker is cleared');
+    assert.equal(consumeAutoReloadBudget(storage, now + 6), true, 'full budget after clear');
   });
 
-  await t.test('reloads are capped at MAX_AUTO_RELOADS', () => {
-    assertIncludes(mainTsx, 'if (tracker.count >= MAX_AUTO_RELOADS) return false;');
+  await t.test('denies the reload when storage is unavailable (no unbounded loop)', () => {
+    // A wedged sessionStorage must NOT grant a reload — otherwise every crash
+    // would reload forever. Must return false, not throw.
+    assert.equal(consumeAutoReloadBudget(throwingStorage, 1000), false);
   });
 
-  await t.test('budget read failure does not risk an unbounded reload loop', () => {
-    // The catch returns false (no auto-reload) when sessionStorage is unavailable.
-    assertIncludes(mainTsx, 'function consumeAutoReloadBudget()');
-    assertIncludes(mainTsx, 'return false;');
+  await t.test('clearAutoReloadBudget swallows storage errors', () => {
+    assert.doesNotThrow(() => clearAutoReloadBudget(throwingStorage));
   });
 
-  await t.test('a stable session clears the budget', () => {
-    assertIncludes(mainTsx, 'function clearAutoReloadBudget()');
-    assertIncludes(mainTsx, 'setTimeout(clearAutoReloadBudget, STABLE_SESSION_MS)');
-  });
-
-  await t.test('render crash auto-reloads when budget allows', () => {
-    assertIncludes(mainTsx, 'if (consumeAutoReloadBudget()) {');
-    assertIncludes(mainTsx, 'window.location.reload();');
-  });
-
-  await t.test('a quiet placeholder is shown while reloading (no crash flash)', () => {
-    assertIncludes(mainTsx, 'this.setState({ reloading: true });');
-    assertIncludes(mainTsx, 'if (this.state.reloading) return <RendererRecovering />;');
-  });
-
-  await t.test('falls back to the manual error card when budget is exhausted', () => {
-    assertIncludes(mainTsx, 'return <RendererErrorFallback error={this.state.error} />;');
+  // Guard the wiring so the boundary can't be silently disconnected from this
+  // budget by an edit to main.tsx.
+  await t.test('main.tsx wires the error boundary to this budget', () => {
+    const mainTsx = fs.readFileSync(path.join(root, 'src/renderer/src/main.tsx'), 'utf8');
+    assert.ok(mainTsx.includes('consumeAutoReloadBudget'), 'boundary consumes the budget');
+    assert.ok(mainTsx.includes('window.location.reload()'), 'boundary reloads on crash');
+    assert.ok(
+      mainTsx.includes('if (this.state.reloading) return <RendererRecovering />;'),
+      'a quiet placeholder is shown while reloading',
+    );
+    assert.ok(
+      mainTsx.includes('return <RendererErrorFallback error={this.state.error} />;'),
+      'falls back to the manual error card when the budget is exhausted',
+    );
   });
 });

--- a/scripts/test-renderer-error-boundary.mjs
+++ b/scripts/test-renderer-error-boundary.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const mainTsx = fs.readFileSync('src/renderer/src/main.tsx', 'utf8');
+
+function assertIncludes(source, needle) {
+  assert.ok(source.includes(needle), `Source should include: ${needle}`);
+}
+
+test('Renderer error boundary auto-recovery', async (t) => {
+  await t.test('budget constants are defined', () => {
+    assertIncludes(mainTsx, "const RELOAD_TRACKER_KEY = 'sc-renderer-reload-tracker';");
+    assertIncludes(mainTsx, 'const RELOAD_WINDOW_MS = 30_000;');
+    assertIncludes(mainTsx, 'const MAX_AUTO_RELOADS = 3;');
+    assertIncludes(mainTsx, 'const STABLE_SESSION_MS = 15_000;');
+  });
+
+  await t.test('budget is tracked in sessionStorage so it survives the reload', () => {
+    assertIncludes(mainTsx, 'sessionStorage.getItem(RELOAD_TRACKER_KEY)');
+    assertIncludes(mainTsx, 'sessionStorage.setItem(RELOAD_TRACKER_KEY');
+  });
+
+  await t.test('budget window resets after RELOAD_WINDOW_MS', () => {
+    assertIncludes(mainTsx, 'now - tracker.firstAt > RELOAD_WINDOW_MS');
+  });
+
+  await t.test('reloads are capped at MAX_AUTO_RELOADS', () => {
+    assertIncludes(mainTsx, 'if (tracker.count >= MAX_AUTO_RELOADS) return false;');
+  });
+
+  await t.test('budget read failure does not risk an unbounded reload loop', () => {
+    // The catch returns false (no auto-reload) when sessionStorage is unavailable.
+    assertIncludes(mainTsx, 'function consumeAutoReloadBudget()');
+    assertIncludes(mainTsx, 'return false;');
+  });
+
+  await t.test('a stable session clears the budget', () => {
+    assertIncludes(mainTsx, 'function clearAutoReloadBudget()');
+    assertIncludes(mainTsx, 'setTimeout(clearAutoReloadBudget, STABLE_SESSION_MS)');
+  });
+
+  await t.test('render crash auto-reloads when budget allows', () => {
+    assertIncludes(mainTsx, 'if (consumeAutoReloadBudget()) {');
+    assertIncludes(mainTsx, 'window.location.reload();');
+  });
+
+  await t.test('a quiet placeholder is shown while reloading (no crash flash)', () => {
+    assertIncludes(mainTsx, 'this.setState({ reloading: true });');
+    assertIncludes(mainTsx, 'if (this.state.reloading) return <RendererRecovering />;');
+  });
+
+  await t.test('falls back to the manual error card when budget is exhausted', () => {
+    assertIncludes(mainTsx, 'return <RendererErrorFallback error={this.state.error} />;');
+  });
+});

--- a/scripts/test-root-search-ranking.mjs
+++ b/scripts/test-root-search-ranking.mjs
@@ -141,6 +141,8 @@ function ids(items) {
   return Array.from(items, (item) => item.id);
 }
 
+// Simple test runner to avoid adding a dependency on node:test
+// Using ✓ and ✗ here for consistency with the node:test output style.
 function test(name, fn) {
   try {
     fn();
@@ -858,4 +860,6 @@ test('weak browser history does not autocomplete', () => {
   assert.equal(getSharedRootCompletion(query, [history]), null);
 });
 
+// All tests passed if we reach this point without throwing an error.
+// Using a ✓ here for consistency with the node:test output style.
 console.log('✓ All root-search-ranking tests passed');

--- a/scripts/test-root-search-ranking.mjs
+++ b/scripts/test-root-search-ranking.mjs
@@ -1,10 +1,12 @@
+#!/usr/bin/env node
+
 import fs from 'fs';
 import path from 'path';
 import vm from 'vm';
 import { createRequire } from 'module';
 import assert from 'assert/strict';
 
-const require = createRequire(import.meta.url);
+  const require = createRequire(import.meta.url);
 const ts = require('typescript');
 
 const moduleCache = new Map();
@@ -142,9 +144,9 @@ function ids(items) {
 function test(name, fn) {
   try {
     fn();
-    console.log(`ok - ${name}`);
+    console.log(`✓ ${name}`);
   } catch (error) {
-    console.error(`not ok - ${name}`);
+    console.error(`✗ ${name}`);
     throw error;
   }
 }
@@ -856,4 +858,4 @@ test('weak browser history does not autocomplete', () => {
   assert.equal(getSharedRootCompletion(query, [history]), null);
 });
 
-console.log('root-search-ranking tests passed');
+console.log('✓ All root-search-ranking tests passed');

--- a/scripts/test-root-search-ranking.mjs
+++ b/scripts/test-root-search-ranking.mjs
@@ -6,7 +6,7 @@ import vm from 'vm';
 import { createRequire } from 'module';
 import assert from 'assert/strict';
 
-  const require = createRequire(import.meta.url);
+const require = createRequire(import.meta.url);
 const ts = require('typescript');
 
 const moduleCache = new Map();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8230,7 +8230,7 @@ function createWindow(): void {
     const reason = String(details?.reason || 'unknown');
     // 'clean-exit' is an intentional, normal teardown — nothing to recover.
     if (reason === 'clean-exit') return;
-    console.warn(`[WindowManager] Launcher renderer gone (${reason}); reloading.`);
+    console.warn(`[WindowManager] Launcher renderer gone (${reason}); scheduling reload.`);
 
     // Rate-limit recovery so a renderer that crashes immediately on load
     // doesn't spin in a tight reload loop.
@@ -8244,11 +8244,21 @@ function createWindow(): void {
       return;
     }
 
-    try {
-      loadWindowUrl(mainWindow, '/');
-    } catch (err) {
-      console.error('[WindowManager] Failed to reload launcher after renderer crash:', err);
-    }
+    // Defer the reload OUT of the crash-event callback. Reloading synchronously
+    // here spawns the replacement renderer while Chromium is still tearing down
+    // the dead one; on macOS that can fail the Mach IPC rendezvous and abort the
+    // whole app (SIGTRAP) — strictly worse than the blank window we're fixing.
+    // A short delay lets the dead renderer finish tearing down first.
+    const RENDERER_RECOVERY_DELAY_MS = 300;
+    setTimeout(() => {
+      if (isAppQuitting) return;
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      try {
+        loadWindowUrl(mainWindow, '/');
+      } catch (err) {
+        console.error('[WindowManager] Failed to reload launcher after renderer crash:', err);
+      }
+    }, RENDERER_RECOVERY_DELAY_MS);
   });
 
   // A wedged (but not dead) renderer also paints nothing. Reload it only while

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8329,7 +8329,15 @@ function createWindow(): void {
       return;
     }
     console.warn('[WindowManager] Hidden launcher renderer unresponsive; reloading.');
-    try { mainWindow.webContents.reloadIgnoringCache(); } catch { }
+
+    try {
+      mainWindow.webContents.reloadIgnoringCache();
+    } catch (err) {
+      // A throw here still consumes a reload unit above, so repeated failures will
+      // eventually trip the give-up dialog on their own — we just need to surface
+      // the cause.
+      console.error('[WindowManager] Failed to reload unresponsive launcher renderer:', err);
+    }
   });
 
   mainWindow.on('blur', () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -82,6 +82,11 @@ import {
 } from './extension-api';
 import { getExtensionBundle, buildAllCommands, discoverInstalledExtensionCommands, getInstalledExtensionsSettingsSchema } from './extension-runner';
 import {
+  getRendererCrashState,
+  evaluateRendererCrash,
+  RENDERER_RECOVERY_DELAY_MS,
+} from './renderer-recovery';
+import {
   startClipboardMonitor,
   stopClipboardMonitor,
   getClipboardHistory,
@@ -8222,35 +8227,32 @@ function createWindow(): void {
   // (extension crash, OOM, or macOS reaping the backgrounded process), the
   // window has nothing to paint and shows blank on the next show(). Reload it
   // so the next open is functional instead of an empty panel.
-  let rendererReloadCount = 0;
-  let lastRendererReloadAt = 0;
+  let rendererCrashState = getRendererCrashState();
   mainWindow.webContents.on('render-process-gone', (_event: any, details: any) => {
     if (isAppQuitting) return;
     if (!mainWindow || mainWindow.isDestroyed()) return;
     const reason = String(details?.reason || 'unknown');
-    // 'clean-exit' is an intentional, normal teardown — nothing to recover.
-    if (reason === 'clean-exit') return;
-    console.warn(`[WindowManager] Launcher renderer gone (${reason}); scheduling reload.`);
 
-    // Rate-limit recovery so a renderer that crashes immediately on load
-    // doesn't spin in a tight reload loop.
-    const now = Date.now();
-    const STABLE_SESSION_MS = 30 * 1000; // 30s
-    const MAX_AUTO_RELOADS = 3;
-    if (now - lastRendererReloadAt > STABLE_SESSION_MS) rendererReloadCount = 0;
-    lastRendererReloadAt = now;
-    rendererReloadCount += 1;
-    if (rendererReloadCount > MAX_AUTO_RELOADS) {
-      console.error('[WindowManager] Launcher renderer crashed repeatedly; not reloading again.');
+    // Rate-limit recovery so a renderer that crashes immediately on load doesn't
+    // spin in a tight reload loop. 'clean-exit' is a normal teardown and is
+    // ignored. The decision (and its constants) live in renderer-recovery.ts so
+    // they can be exercised by running a real crash sequence in a test rather
+    // than grepping this source.
+    const decision = evaluateRendererCrash(rendererCrashState, reason, Date.now());
+    rendererCrashState = decision.nextState;
+    if (!decision.reload) {
+      if (decision.giveUp) {
+        console.error('[WindowManager] Launcher renderer crashed repeatedly; not reloading again.');
+      }
       return;
     }
+    console.warn(`[WindowManager] Launcher renderer gone (${reason}); scheduling reload.`);
 
     // Defer the reload OUT of the crash-event callback. Reloading synchronously
     // here spawns the replacement renderer while Chromium is still tearing down
     // the dead one; on macOS that can fail the Mach IPC rendezvous and abort the
     // whole app (SIGTRAP) — strictly worse than the blank window we're fixing.
     // A short delay lets the dead renderer finish tearing down first.
-    const RENDERER_RECOVERY_DELAY_MS = 300;
     setTimeout(() => {
       if (isAppQuitting) return;
       if (!mainWindow || mainWindow.isDestroyed()) return;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7916,6 +7916,52 @@ async function buildLaunchBundle(options: {
 
 // ─── Launcher Window ────────────────────────────────────────────────
 
+// Set once the renderer has crashed past its reload budget, so the give-up
+// dialog is shown only once even if both the crash and unresponsive paths
+// exhaust the budget in the same burst.
+let rendererRecoveryGaveUp = false;
+
+// Last resort when the launcher renderer can't be recovered by reloading: the
+// renderer is dead/wedged so it can't render its own error UI, leaving a blank
+// window. Surface a native dialog and let the user relaunch instead of being
+// stranded with a window that paints nothing.
+async function handleRendererRecoveryGiveUp(logMessage: string): Promise<void> {
+  console.error(`[WindowManager] ${logMessage}`);
+  if (rendererRecoveryGaveUp || isAppQuitting) return;
+  rendererRecoveryGaveUp = true;
+  try {
+    const { response } = await dialog.showMessageBox({
+      type: 'error',
+      buttons: ['Relaunch', 'Quit'],
+      defaultId: 0,
+      cancelId: 1,
+      noLink: true,
+      title: 'SuperCmd needs to restart',
+      message: 'SuperCmd ran into a problem',
+      detail:
+        'The launcher stopped responding and could not recover on its own. ' +
+        'Relaunch to continue.',
+    });
+    if (response === 0) app.relaunch();
+  } catch (err) {
+    console.error('[WindowManager] Failed to show renderer recovery dialog:', err);
+  }
+  // Quit (not exit) so the before-quit/will-quit teardown runs and the spawned
+  // child processes (emoji-trigger monitor, whisper/parakeet servers, clipboard
+  // monitor, window-manager worker, …) are killed instead of orphaned. If the
+  // user chose Relaunch, app.relaunch() above schedules a fresh instance to
+  // start once this one has quit.
+  app.quit();
+
+  // Watchdog: if the graceful quit stalls (e.g. a window's close handler hangs
+  // waiting on its renderer), force-exit so we don't leave a half-dead app with
+  // a blank window. .unref() so this timer can't itself keep the app alive.
+  setTimeout(() => {
+    console.error('[WindowManager] Graceful quit stalled after give-up; forcing exit.');
+    app.exit(0);
+  }, 5000).unref();
+}
+
 function createWindow(): void {
   const primaryDisplay = screen.getPrimaryDisplay();
   const { width: screenWidth, height: screenHeight } =
@@ -8242,7 +8288,7 @@ function createWindow(): void {
     rendererCrashState = decision.nextState;
     if (!decision.reload) {
       if (decision.giveUp) {
-        console.error('[WindowManager] Launcher renderer crashed repeatedly; not reloading again.');
+        void handleRendererRecoveryGiveUp('Launcher renderer crashed repeatedly; not reloading again.');
       }
       return;
     }
@@ -8270,6 +8316,18 @@ function createWindow(): void {
     if (isAppQuitting) return;
     if (!mainWindow || mainWindow.isDestroyed()) return;
     if (isVisible) return;
+
+    // Share the same reload budget as render-process-gone. A renderer that
+    // wedges again on every reload (e.g. an extension that hangs the main
+    // thread on mount) would otherwise spin in an unbounded reload loop.
+    const decision = evaluateRendererCrash(rendererCrashState, 'unresponsive', Date.now());
+    rendererCrashState = decision.nextState;
+    if (!decision.reload) {
+      if (decision.giveUp) {
+        void handleRendererRecoveryGiveUp('Hidden launcher renderer repeatedly unresponsive; not reloading again.');
+      }
+      return;
+    }
     console.warn('[WindowManager] Hidden launcher renderer unresponsive; reloading.');
     try { mainWindow.webContents.reloadIgnoringCache(); } catch { }
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8235,11 +8235,12 @@ function createWindow(): void {
     // Rate-limit recovery so a renderer that crashes immediately on load
     // doesn't spin in a tight reload loop.
     const now = Date.now();
-    const THIRTY_SECONDS = 30 * 1000; // 30s
-    if (now - lastRendererReloadAt > THIRTY_SECONDS) rendererReloadCount = 0;
+    const STABLE_SESSION_MS = 30 * 1000; // 30s
+    const MAX_AUTO_RELOADS = 3;
+    if (now - lastRendererReloadAt > STABLE_SESSION_MS) rendererReloadCount = 0;
     lastRendererReloadAt = now;
     rendererReloadCount += 1;
-    if (rendererReloadCount > 3) {
+    if (rendererReloadCount > MAX_AUTO_RELOADS) {
       console.error('[WindowManager] Launcher renderer crashed repeatedly; not reloading again.');
       return;
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8216,6 +8216,51 @@ function createWindow(): void {
     }
   });
 
+  // Recover from renderer-process death. The launcher window is created once
+  // and kept alive (hidden) for the whole session; the same renderer also runs
+  // every extension with full Node integration. If that renderer is killed
+  // (extension crash, OOM, or macOS reaping the backgrounded process), the
+  // window has nothing to paint and shows blank on the next show(). Reload it
+  // so the next open is functional instead of an empty panel.
+  let rendererReloadCount = 0;
+  let lastRendererReloadAt = 0;
+  mainWindow.webContents.on('render-process-gone', (_event: any, details: any) => {
+    if (isAppQuitting) return;
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    const reason = String(details?.reason || 'unknown');
+    // 'clean-exit' is an intentional, normal teardown — nothing to recover.
+    if (reason === 'clean-exit') return;
+    console.warn(`[WindowManager] Launcher renderer gone (${reason}); reloading.`);
+
+    // Rate-limit recovery so a renderer that crashes immediately on load
+    // doesn't spin in a tight reload loop.
+    const now = Date.now();
+    const THIRTY_SECONDS = 30 * 1000; // 30s
+    if (now - lastRendererReloadAt > THIRTY_SECONDS) rendererReloadCount = 0;
+    lastRendererReloadAt = now;
+    rendererReloadCount += 1;
+    if (rendererReloadCount > 3) {
+      console.error('[WindowManager] Launcher renderer crashed repeatedly; not reloading again.');
+      return;
+    }
+
+    try {
+      loadWindowUrl(mainWindow, '/');
+    } catch (err) {
+      console.error('[WindowManager] Failed to reload launcher after renderer crash:', err);
+    }
+  });
+
+  // A wedged (but not dead) renderer also paints nothing. Reload it only while
+  // hidden to avoid interrupting a foreground operation the user is watching.
+  mainWindow.webContents.on('unresponsive', () => {
+    if (isAppQuitting) return;
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    if (isVisible) return;
+    console.warn('[WindowManager] Hidden launcher renderer unresponsive; reloading.');
+    try { mainWindow.webContents.reloadIgnoringCache(); } catch { }
+  });
+
   mainWindow.on('blur', () => {
     // Grace period after show: AeroSpace / tiling WMs and macOS Space
     // transitions can fire blur immediately after the window is shown,

--- a/src/main/renderer-recovery.ts
+++ b/src/main/renderer-recovery.ts
@@ -1,0 +1,72 @@
+// Pure decision logic for recovering the launcher renderer after it dies.
+//
+// The launcher renderer is created once and kept alive (hidden) for the whole
+// session; it also runs every extension with full Node integration. If that
+// renderer is killed (extension crash, OOM, or macOS reaping the backgrounded
+// process) the window has nothing to paint and shows blank on the next show().
+// We reload it — but a renderer that crashes immediately on load must not spin
+// in a tight reload loop, so reloads are rate-limited.
+//
+// This file deliberately contains NO Electron references so the decision can be
+// unit-tested by running it through a crash sequence (see
+// scripts/test-renderer-crash-recovery.mjs) rather than grepping the source.
+
+export const RENDERER_RECOVERY_STABLE_SESSION_MS = 30 * 1000; // 30s
+export const RENDERER_RECOVERY_MAX_RELOADS = 3;
+// Defer the reload OUT of the crash-event callback. Reloading synchronously
+// inside render-process-gone spawns the replacement renderer while Chromium is
+// still tearing down the dead one; on macOS that can fail the Mach IPC
+// rendezvous and abort the whole app (SIGTRAP) — strictly worse than the blank
+// window we're fixing. A short delay lets the dead renderer tear down first.
+export const RENDERER_RECOVERY_DELAY_MS = 500;
+
+export interface RendererCrashState {
+  /** Number of reloads in the current (recent) burst. */
+  count: number;
+  /** Timestamp (ms) of the last crash we acted on. */
+  lastAt: number;
+}
+
+export interface RendererCrashDecision {
+  /** Whether the window should be reloaded to recover. */
+  reload: boolean;
+  /** State to carry into the next crash evaluation. */
+  nextState: RendererCrashState;
+  /** True when we've crashed too many times and are giving up. */
+  giveUp: boolean;
+}
+
+export function getRendererCrashState(): RendererCrashState {
+  return { count: 0, lastAt: 0 };
+}
+
+/**
+ * Decide whether to reload the launcher window after its renderer process is
+ * gone. Pure: same inputs always yield the same decision and next state.
+ *
+ * @param state  current crash-burst state
+ * @param reason details.reason from the render-process-gone event
+ * @param now    current time in ms (injected so tests are deterministic)
+ */
+export function evaluateRendererCrash(
+  state: RendererCrashState,
+  reason: string,
+  now: number,
+): RendererCrashDecision {
+  // 'clean-exit' is an intentional, normal teardown — nothing to recover, and
+  // it must not consume the reload budget.
+  if (reason === 'clean-exit') {
+    return { reload: false, nextState: state, giveUp: false };
+  }
+
+  // A crash that arrives after a long quiet stretch starts a fresh burst.
+  let count = state.count;
+  if (now - state.lastAt > RENDERER_RECOVERY_STABLE_SESSION_MS) count = 0;
+  count += 1;
+  const nextState: RendererCrashState = { count, lastAt: now };
+
+  if (count > RENDERER_RECOVERY_MAX_RELOADS) {
+    return { reload: false, nextState, giveUp: true };
+  }
+  return { reload: true, nextState, giveUp: false };
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -24,11 +24,58 @@ initializeTheme();
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 
+// Auto-recovery budget for renderer render-crashes. A render error that leaves
+// the launcher blank should silently reload rather than stranding the user on a
+// manual "Reload" card — but a crash that recurs on every mount must not spin in
+// a reload loop. Budget is tracked in sessionStorage so it survives the reload
+// (same renderer session) and resets when a session stays healthy for a while.
+const RELOAD_TRACKER_KEY = 'sc-renderer-reload-tracker';
+const RELOAD_WINDOW_MS = 30_000;
+const MAX_AUTO_RELOADS = 3;
+const STABLE_SESSION_MS = 15_000;
+
+function consumeAutoReloadBudget(): boolean {
+  try {
+    const now = Date.now();
+    const raw = sessionStorage.getItem(RELOAD_TRACKER_KEY);
+    let tracker = raw ? (JSON.parse(raw) as { count: number; firstAt: number }) : null;
+    if (!tracker || now - tracker.firstAt > RELOAD_WINDOW_MS) {
+      tracker = { count: 0, firstAt: now };
+    }
+    if (tracker.count >= MAX_AUTO_RELOADS) return false;
+    tracker.count += 1;
+    sessionStorage.setItem(RELOAD_TRACKER_KEY, JSON.stringify(tracker));
+    return true;
+  } catch {
+    // No sessionStorage (or it's wedged) — don't risk an unbounded reload loop.
+    return false;
+  }
+}
+
+function clearAutoReloadBudget() {
+  try {
+    sessionStorage.removeItem(RELOAD_TRACKER_KEY);
+  } catch {
+    // ignore
+  }
+}
+
 class RendererErrorBoundary extends React.Component<
   { children: React.ReactNode },
-  { error: Error | null }
+  { error: Error | null; reloading: boolean }
 > {
-  state = { error: null as Error | null };
+  state = { error: null as Error | null, reloading: false };
+  private stableTimer: ReturnType<typeof setTimeout> | null = null;
+
+  componentDidMount() {
+    // If the renderer stays healthy for a stretch, treat the session as
+    // recovered and reset the budget so a later one-off crash gets a fresh one.
+    this.stableTimer = setTimeout(clearAutoReloadBudget, STABLE_SESSION_MS);
+  }
+
+  componentWillUnmount() {
+    if (this.stableTimer) clearTimeout(this.stableTimer);
+  }
 
   static getDerivedStateFromError(error: Error) {
     return { error };
@@ -37,12 +84,43 @@ class RendererErrorBoundary extends React.Component<
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     console.error('[RendererErrorBoundary] Render error:', error);
     console.error('[RendererErrorBoundary] Component stack:', info.componentStack);
+
+    if (consumeAutoReloadBudget()) {
+      console.warn('[RendererErrorBoundary] Auto-reloading to recover from render crash.');
+      this.setState({ reloading: true });
+      // Reload from cache is fine here — the crash is in app state, not the bundle.
+      window.location.reload();
+    } else {
+      console.error('[RendererErrorBoundary] Auto-reload budget exhausted; showing fallback.');
+    }
   }
 
   render() {
     if (!this.state.error) return this.props.children;
+    // While the reload is in flight, render a quiet placeholder instead of the
+    // full error card so the user doesn't see a crash flash before recovery.
+    if (this.state.reloading) return <RendererRecovering />;
     return <RendererErrorFallback error={this.state.error} />;
   }
+}
+
+function RendererRecovering() {
+  return (
+    <div
+      style={{
+        height: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif',
+        fontSize: 12,
+        color: 'var(--text-secondary, rgba(255,255,255,0.5))',
+        background: 'var(--surface-base, #101113)',
+      }}
+    >
+      Recovering…
+    </div>
+  );
 }
 
 function RendererErrorFallback({ error }: { error: Error }) {

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,6 +3,11 @@ import ReactDOM from 'react-dom/client';
 import { I18nProvider } from './i18n';
 import '../styles/index.css';
 import { initializeTheme } from './utils/theme';
+import {
+  consumeAutoReloadBudget,
+  clearAutoReloadBudget,
+  STABLE_SESSION_MS,
+} from './utils/reload-budget';
 
 // Each BrowserWindow only needs one root app. Static imports of every app
 // here forced a single ~8MB bundle into every window (e.g. settings loaded
@@ -24,41 +29,9 @@ initializeTheme();
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 
-// Auto-recovery budget for renderer render-crashes. A render error that leaves
-// the launcher blank should silently reload rather than stranding the user on a
-// manual "Reload" card — but a crash that recurs on every mount must not spin in
-// a reload loop. Budget is tracked in sessionStorage so it survives the reload
-// (same renderer session) and resets when a session stays healthy for a while.
-const RELOAD_TRACKER_KEY = 'sc-renderer-reload-tracker';
-const RELOAD_WINDOW_MS = 30_000;
-const MAX_AUTO_RELOADS = 3;
-const STABLE_SESSION_MS = 30 * 1000; // 30s
-
-function consumeAutoReloadBudget(): boolean {
-  try {
-    const now = Date.now();
-    const raw = sessionStorage.getItem(RELOAD_TRACKER_KEY);
-    let tracker = raw ? (JSON.parse(raw) as { count: number; firstAt: number }) : null;
-    if (!tracker || now - tracker.firstAt > RELOAD_WINDOW_MS) {
-      tracker = { count: 0, firstAt: now };
-    }
-    if (tracker.count >= MAX_AUTO_RELOADS) return false;
-    tracker.count += 1;
-    sessionStorage.setItem(RELOAD_TRACKER_KEY, JSON.stringify(tracker));
-    return true;
-  } catch {
-    // No sessionStorage (or it's wedged) — don't risk an unbounded reload loop.
-    return false;
-  }
-}
-
-function clearAutoReloadBudget() {
-  try {
-    sessionStorage.removeItem(RELOAD_TRACKER_KEY);
-  } catch {
-    // ignore
-  }
-}
+// Auto-recovery budget for renderer render-crashes lives in
+// ./utils/reload-budget so it can be exercised by running it through a crash
+// sequence in a test. See scripts/test-renderer-error-boundary.mjs.
 
 class RendererErrorBoundary extends React.Component<
   { children: React.ReactNode },

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -32,7 +32,7 @@ const root = ReactDOM.createRoot(document.getElementById('root')!);
 const RELOAD_TRACKER_KEY = 'sc-renderer-reload-tracker';
 const RELOAD_WINDOW_MS = 30_000;
 const MAX_AUTO_RELOADS = 3;
-const STABLE_SESSION_MS = 15_000;
+const STABLE_SESSION_MS = 30 * 1000; // 30s
 
 function consumeAutoReloadBudget(): boolean {
   try {

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -35,9 +35,9 @@ const root = ReactDOM.createRoot(document.getElementById('root')!);
 
 class RendererErrorBoundary extends React.Component<
   { children: React.ReactNode },
-  { error: Error | null; reloading: boolean }
+  { error: Error | null }
 > {
-  state = { error: null as Error | null, reloading: false };
+  state = { error: null as Error | null };
   private stableTimer: ReturnType<typeof setTimeout> | null = null;
 
   componentDidMount() {
@@ -60,7 +60,6 @@ class RendererErrorBoundary extends React.Component<
 
     if (consumeAutoReloadBudget()) {
       console.warn('[RendererErrorBoundary] Auto-reloading to recover from render crash.');
-      this.setState({ reloading: true });
       // Reload from cache is fine here — the crash is in app state, not the bundle.
       window.location.reload();
     } else {
@@ -70,30 +69,8 @@ class RendererErrorBoundary extends React.Component<
 
   render() {
     if (!this.state.error) return this.props.children;
-    // While the reload is in flight, render a quiet placeholder instead of the
-    // full error card so the user doesn't see a crash flash before recovery.
-    if (this.state.reloading) return <RendererRecovering />;
     return <RendererErrorFallback error={this.state.error} />;
   }
-}
-
-function RendererRecovering() {
-  return (
-    <div
-      style={{
-        height: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif',
-        fontSize: 12,
-        color: 'var(--text-secondary, rgba(255,255,255,0.5))',
-        background: 'var(--surface-base, #101113)',
-      }}
-    >
-      Recovering…
-    </div>
-  );
 }
 
 function RendererErrorFallback({ error }: { error: Error }) {

--- a/src/renderer/src/utils/reload-budget.ts
+++ b/src/renderer/src/utils/reload-budget.ts
@@ -1,8 +1,8 @@
 // Auto-recovery budget for renderer render-crashes. A render error that leaves
-// the launcher blank should silently reload rather than stranding the user on a
-// manual "Reload" card — but a crash that recurs on every mount must not spin in
-// a reload loop. The budget is tracked in sessionStorage so it survives the
-// reload (same renderer session) and resets when a session stays healthy.
+// the launcher blank should silently reload rather than stranding the user — but 
+// a crash that recurs on every mount must not spin in a reload loop. The budget is 
+// tracked in sessionStorage so it survives the reload (same renderer session) and 
+// resets when a session stays healthy.
 //
 // Storage is injected (defaulting to the real sessionStorage) so the budget can
 // be exercised by running it against an in-memory store in a test instead of

--- a/src/renderer/src/utils/reload-budget.ts
+++ b/src/renderer/src/utils/reload-budget.ts
@@ -1,0 +1,60 @@
+// Auto-recovery budget for renderer render-crashes. A render error that leaves
+// the launcher blank should silently reload rather than stranding the user on a
+// manual "Reload" card — but a crash that recurs on every mount must not spin in
+// a reload loop. The budget is tracked in sessionStorage so it survives the
+// reload (same renderer session) and resets when a session stays healthy.
+//
+// Storage is injected (defaulting to the real sessionStorage) so the budget can
+// be exercised by running it against an in-memory store in a test instead of
+// grepping the source.
+
+export const RELOAD_TRACKER_KEY = 'sc-renderer-reload-tracker';
+export const RELOAD_WINDOW_MS = 30_000;
+export const MAX_AUTO_RELOADS = 3;
+export const STABLE_SESSION_MS = 30 * 1000; // 30s
+
+/** Minimal storage surface we depend on (a subset of the Web Storage API). */
+export interface BudgetStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+interface Tracker {
+  count: number;
+  firstAt: number;
+}
+
+/**
+ * Consume one unit of the auto-reload budget.
+ * @returns true if a reload is allowed (and the budget was charged), false if
+ *          the budget is exhausted or storage is unavailable.
+ */
+export function consumeAutoReloadBudget(
+  storage: BudgetStorage = sessionStorage,
+  now: number = Date.now(),
+): boolean {
+  try {
+    const raw = storage.getItem(RELOAD_TRACKER_KEY);
+    let tracker = raw ? (JSON.parse(raw) as Tracker) : null;
+    if (!tracker || now - tracker.firstAt > RELOAD_WINDOW_MS) {
+      tracker = { count: 0, firstAt: now };
+    }
+    if (tracker.count >= MAX_AUTO_RELOADS) return false;
+    tracker.count += 1;
+    storage.setItem(RELOAD_TRACKER_KEY, JSON.stringify(tracker));
+    return true;
+  } catch {
+    // No sessionStorage (or it's wedged) — don't risk an unbounded reload loop.
+    return false;
+  }
+}
+
+/** Reset the budget once a session has proven stable. */
+export function clearAutoReloadBudget(storage: BudgetStorage = sessionStorage): void {
+  try {
+    storage.removeItem(RELOAD_TRACKER_KEY);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
### What changed

This PR adds **two independent layers of auto-recovery** so a dead or wedged launcher renderer no longer leaves a permanently blank window:

- **Main process** (`src/main/main.ts`): 
  - The launcher window now handles `render-process-gone` and `unresponsive`. On a crash it reloads the renderer (deferred out of the crash callback to avoid a macOS Mach-IPC abort), rate-limited by a reload budget. 
  - `unresponsive` only reloads while the window is hidden so a foreground operation isn't interrupted; `clean-exit` is ignored. When the reload budget is exhausted, a native **Relaunch / Quit** dialog is shown (once) instead of stranding the user, with a 5s watchdog that force-exits if graceful quit stalls.
- **Renderer** (`src/renderer/src/main.tsx`): 
  - The React error boundary now auto-reloads on a render crash, with its own `sessionStorage`-backed budget that resets once a session stays healthy.
- **Pure decision logic** is extracted to `src/main/renderer-recovery.ts` and `src/renderer/src/utils/reload-budget.ts` (no Electron/DOM deps) so the reload-budget rules are unit-testable.
- **Tests**: wired `npm test` to Node's built-in runner; added unit tests for both budget modules plus an end-to-end Electron harness that crashes a real renderer with `process.crash()` and asserts the window repaints.

### Why (fixes: #470)

The renderer is created once and kept alive (hidden) for the whole session, and it also runs every extension with full Node integration. If that renderer dies — extension crash, OOM, or macOS reaping the backgrounded process — the window has nothing to paint and shows **blank on the next open**, with no way to recover short of restarting the app.

### Compatibility impact

- **No changes to `src/renderer/src/raycast-api/`** — the extension API surface is untouched, so existing Raycast extensions are unaffected.
- Recovery is transparent to extensions and to the user in the normal case (silent reload).
- Reloads are rate-limited, so a renderer that crashes on every load can't spin in an unbounded reload loop; it falls through to the give-up dialog instead.
- `clean-exit` teardowns are explicitly ignored and don't consume budget.

### How I tested it
- `npm run build` — completes with exit 0.
- `npm test` — 27/27 pass, including the new budget unit tests, which run the **real production modules** (transpiled on the fly).
- The end-to-end Electron harness (`scripts/test-renderer-crash-recovery-live.mjs`) launches a real Electron window, crashes the renderer with `process.crash()`, and asserts it repaints; it self-skips where Electron can't launch (headless/no-display).
- _Manual:_ reproduced the blank-window bug locally by crashing the live renderer (`pkill -9 -f "SuperCmd Helper \(Renderer\)"` and confirmed the window recovers on next open, and that exhausting the budget surfaces the Relaunch/Quit dialog.

### Contribution checklist
- [x]  npm run build completes without errors
- [x]  Tested locally with npm run dev
- [x]  Your PR description includes: what changed, why, compatibility impact, and how you tested it
- [x]  **N/A:** ~If you modified the Raycast API shims, you've tested with at least one existing Raycast extension~
