### PR TITLE
fix: recognize Safari PWA apps (CFBundlePackageType AAPL) in app discovery

### DIFF
--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -1012,7 +1012,7 @@ async function discoverApplications(): Promise<CommandInfo[]> {
           const packageType = String(info.CFBundlePackageType || '').trim();
           const isFinder = appPath === finderPath;
           const isAllowedType =
-            !packageType || packageType === 'APPL' || packageType === 'XPC!';
+            !packageType || packageType === 'APPL' || packageType === 'XPC!' || packageType === 'AAPL';
           if (!isAllowedType && !isFinder) return null;
           if (info.LSBackgroundOnly === true) return null;
         }


### PR DESCRIPTION
## What changed
Allow `CFBundlePackageType = AAPL` in the app discovery filter in `src/main/commands.ts`.

## Why
Safari PWAs added via the "Add to Dock" feature use `CFBundlePackageType = AAPL` (template application) instead of the standard `APPL`. The discovery filter only allowed `APPL` and `XPC!`, so Safari web apps were not indexed. They only appeared in file search, not the application search.

## Compatibility impact
No impact on Raycast extensions - this is main-process app discovery only.

## How tested
Ran `npm run dev` locally. My two installed PWAs with `AAPL` package type now appear in the application search results.