### PR TITLE
perf(search): remove root ranking diagnostics

### DIFF
--- a/src/renderer/src/hooks/useLauncherCommandModel.ts
+++ b/src/renderer/src/hooks/useLauncherCommandModel.ts
@@ -857,41 +857,6 @@ export function useLauncherCommandModel({
     queryFileSectionCommands,
   } = rootSearchSectionAssembly;
 
-  // TEMP DIAGNOSTIC (SC-RANK2): pinpoint whether the internal>browser comparator
-  // is actually running, and whether Search Notes / Create Note are candidates.
-  // Remove once the override bug is confirmed fixed.
-  useEffect(() => {
-    if (!hasSearchQuery) return;
-    try {
-      const idOf = (c: any) => String(c?.command?.id || c?.stableKey || '');
-      const sn = commandCandidates.find((c) => idOf(c).includes('search-notes'));
-      const cn = commandCandidates.find((c) => idOf(c).includes('create-note'));
-      const internalCount = rootRankedCandidates.filter((c) => !c.isOrganicBrowserResult).length;
-      const browserCount = rootRankedCandidates.filter((c) => c.isOrganicBrowserResult).length;
-      const firstBrowserIdx = rootRankedCandidates.findIndex((c) => c.isOrganicBrowserResult);
-      const snIdx = rootRankedCandidates.findIndex((c) => idOf(c).includes('search-notes'));
-      const cnIdx = rootRankedCandidates.findIndex((c) => idOf(c).includes('create-note'));
-      const describe = (c: any, idx: number) => c
-        ? { score: Math.round(c.finalScore), matchKind: c.matchKind, organic: c.isOrganicBrowserResult, rankIdx: idx }
-        : 'NOT_A_CANDIDATE';
-      (window as any).electron?.whisperDebugLog?.('SC-RANK2', `q="${searchQuery}"`, {
-        cmdCands: commandCandidates.length,
-        browserCands: browserCandidates.length,
-        rootTotal: rootRankedCandidates.length,
-        internalCount,
-        browserCount,
-        // If the comparator works, firstBrowserIdx === internalCount (all internal first).
-        firstBrowserIdx,
-        comparatorWorking: firstBrowserIdx === -1 || firstBrowserIdx >= internalCount,
-        searchNotes: describe(sn, snIdx),
-        createNote: describe(cn, cnIdx),
-        RESULTS: queryResultCommands.map((c) => c.title),
-      });
-    } catch (e) {
-      (window as any).electron?.whisperDebugLog?.('SC-RANK2', 'ERR', String(e));
-    }
-  }, [hasSearchQuery, searchQuery, rootRankedCandidates, queryResultCommands, commandCandidates, browserCandidates]);
-
   const displayCommands = useMemo(() => {
     if (rootBangState.mode === 'selecting') return rootSearchSectionAssembly.displayCommands;
     if (rootBangState.mode === 'active') return rootSearchSectionAssembly.displayCommands;

--- a/src/renderer/src/utils/root-search-ranking.ts
+++ b/src/renderer/src/utils/root-search-ranking.ts
@@ -94,11 +94,6 @@ const SEARCH_SEPARATOR_REGEX = /[^\p{L}\p{N}]+/gu;
 const COMBINING_MARK_REGEX = /\p{M}/gu;
 const DAY = 24 * 60 * 60 * 1000;
 
-// Build liveness stamp — confirms the running renderer has the internal>browser
-// precedence fix. Grep the bundle (dist/renderer/assets/*.js) for this string,
-// or look for it in the DevTools console at startup. Remove once verified.
-try { console.info('[SC-RANK build 2026-06-19c internal>browser precedence ACTIVE]'); } catch {}
-
 export const ROOT_SEARCH_RESULTS_LIMIT = 8;
 export const ROOT_SEARCH_PROMOTION_SCORE = 700;
 


### PR DESCRIPTION
## What changed
- Removed the temporary `SC-RANK2` diagnostic effect from the root search command model.
- Removed the root search ranking startup/liveness `console.info` stamp.

## Why
- The diagnostic effect ran as the root search query/ranked candidates changed, scanning candidates and sending `window.electron.whisperDebugLog` IPC from the per-keystroke ranking path.
- The startup stamp was only for verifying an earlier ranking fix and should not run in production startup paths.

Before evidence:
- `node scripts/test-root-search-ranking.mjs`: passed after hydrating dependencies; emitted the startup liveness log.
- Debug-path measurement: `{"phase":"before","scRank2Tags":3,"rootSearchWhisperDebugLogCallsites":2,"tempDiagnosticEffects":1,"startupLivenessLogs":1}`.

After evidence:
- Debug-path measurement: `{"phase":"after","scRank2Tags":0,"rootSearchWhisperDebugLogCallsites":0,"tempDiagnosticEffects":0,"startupLivenessLogs":0}`.

## Compatibility impact
- Ranking scores, result ordering, section assembly, and user-facing behavior are unchanged.
- No user-facing strings were added, renamed, or removed, so no locale files changed.
- Debug-only `SC-RANK2` IPC/log output is no longer available from the root search hot path.

## How tested
- `node scripts/test-root-search-ranking.mjs` before the fix: pass.
- `node scripts/test-root-search-ranking.mjs` after the fix: pass.
- Codex LSP diagnostics:
  - `src/renderer/src/utils/root-search-ranking.ts`: no diagnostics.
  - `src/renderer/src/hooks/useLauncherCommandModel.ts`: reports existing `BrowserSearchSource` typing diagnostics around profile browser IDs outside this diff.
- `pnpm exec tsc -p tsconfig.renderer.json --noEmit --pretty false`: fails on existing repo-wide TypeScript diagnostics, including the hook profile typing diagnostics above plus unrelated files such as `App.tsx`, `CameraExtension.tsx`, `LiquidGlassSurface.tsx`, and Raycast runtime modules.
