### PR TITLE
perf(cache): sweep expired withCache entries

### DIFF
--- a/scripts/test-with-cache-expiry.mjs
+++ b/scripts/test-with-cache-expiry.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+function loadPlatformRuntimeWithObservedMaps() {
+  const filePath = path.resolve('src/renderer/src/raycast-api/platform-runtime.ts');
+  const source = fs.readFileSync(filePath, 'utf8');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    },
+    fileName: filePath,
+  });
+
+  const observedMaps = [];
+  class ObservableMap extends Map {
+    constructor(...args) {
+      super(...args);
+      observedMaps.push(this);
+    }
+  }
+
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require,
+    console,
+    Date,
+    Error,
+    JSON,
+    Map: ObservableMap,
+    Promise,
+    window: {},
+  };
+
+  vm.runInNewContext(transpiled.outputText, sandbox, { filename: filePath });
+  return { exports: module.exports, observedMaps };
+}
+
+test('withCache sweeps expired unique keys when maxAge is configured', async () => {
+  const originalNow = Date.now;
+  const uniqueKeyCount = 1_000;
+  let now = 1_000;
+  let calls = 0;
+
+  Date.now = () => now;
+  try {
+    const { exports, observedMaps } = loadPlatformRuntimeWithObservedMaps();
+    const cached = exports.withCache(async (key) => {
+      calls += 1;
+      return `value:${key}:${calls}`;
+    }, { maxAge: 10 });
+
+    for (let index = 0; index < uniqueKeyCount; index += 1) {
+      await cached(`expired-${index}`);
+      now += 11;
+    }
+
+    await cached('latest');
+
+    const retainedSize = observedMaps[0]?.size;
+    console.log(`[withCache metric] retained entries after unique expired inserts: ${retainedSize}`);
+    assert.equal(retainedSize, 1);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test('withCache recomputes and replaces an expired hit', async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  let calls = 0;
+
+  Date.now = () => now;
+  try {
+    const { exports, observedMaps } = loadPlatformRuntimeWithObservedMaps();
+    const cached = exports.withCache(async (key) => {
+      calls += 1;
+      return { key, calls };
+    }, { maxAge: 10 });
+
+    assert.deepEqual(await cached('same-key'), { key: 'same-key', calls: 1 });
+    now += 11;
+    assert.deepEqual(await cached('same-key'), { key: 'same-key', calls: 2 });
+    assert.equal(observedMaps[0]?.size, 1);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test('withCache retains non-expiring entries until clearCache is called', async () => {
+  const { exports, observedMaps } = loadPlatformRuntimeWithObservedMaps();
+  let calls = 0;
+  const cached = exports.withCache(async (key) => {
+    calls += 1;
+    return `value:${key}:${calls}`;
+  });
+
+  assert.equal(await cached('a'), 'value:a:1');
+  assert.equal(await cached('b'), 'value:b:2');
+  assert.equal(await cached('a'), 'value:a:1');
+  assert.equal(observedMaps[0]?.size, 2);
+  assert.equal(calls, 2);
+
+  cached.clearCache();
+  assert.equal(observedMaps[0]?.size, 0);
+});

--- a/src/renderer/src/raycast-api/platform-runtime.ts
+++ b/src/renderer/src/raycast-api/platform-runtime.ts
@@ -144,18 +144,34 @@ export function withCache<Fn extends (...args: any[]) => Promise<any>>(
   const wrapped = (async (...args: any[]) => {
     const key = JSON.stringify(args);
     const cached = cacheStore.get(key);
+    const maxAge = options?.maxAge;
 
     if (cached) {
-      const isExpired = options?.maxAge != null && (Date.now() - cached.timestamp) > options.maxAge;
-      const isValid = options?.validate ? options.validate(cached.data) : true;
+      const isExpired = maxAge != null && (Date.now() - cached.timestamp) > maxAge;
 
-      if (!isExpired && isValid) {
-        return cached.data;
+      if (isExpired) {
+        cacheStore.delete(key);
+      } else {
+        const isValid = options?.validate ? options.validate(cached.data) : true;
+
+        if (isValid) {
+          return cached.data;
+        }
       }
     }
 
     const result = await fn(...args);
-    cacheStore.set(key, { data: result, timestamp: Date.now() });
+    const timestamp = Date.now();
+
+    if (maxAge != null) {
+      for (const [cacheKey, entry] of cacheStore) {
+        if ((timestamp - entry.timestamp) > maxAge) {
+          cacheStore.delete(cacheKey);
+        }
+      }
+    }
+
+    cacheStore.set(key, { data: result, timestamp });
     return result;
   }) as Fn & { clearCache: () => void };
 
@@ -165,4 +181,3 @@ export function withCache<Fn extends (...args: any[]) => Promise<any>>(
 
   return wrapped;
 }
-


### PR DESCRIPTION
## Summary
- Sweep expired `withCache` entries before inserting a fresh result when `maxAge` is configured.
- Delete an expired cache hit before recomputing the value for that key.
- Add focused regression coverage for expired unique keys, expired-hit recompute, and non-expiring cache behavior.

## Root Cause
`withCache` only checked expiry when a key was reused. Long-lived extension sessions that generated many one-off keys could leave expired entries in the internal `Map` forever because no later lookup touched those keys.

## Before / After Evidence
- Before the fix, the new focused test failed with `[withCache baseline] retained expired unique entries: 1001` after 1,000 expired unique keys plus one latest key.
- After the fix, the same scenario passes with `[withCache metric] retained entries after unique expired inserts: 1`.

## Validation
- `node --test scripts/test-with-cache-expiry.mjs`
- `pnpm test`
- `pnpm run check:i18n`
- `pnpm run build:renderer`
- Codex LSP diagnostics on `src/renderer/src/raycast-api/platform-runtime.ts`: no diagnostics
- Codex LSP references for `withCache`: export plus re-export sites only

## Notes / Risks
- `pnpm exec tsc -p tsconfig.renderer.json --noEmit` still fails on existing renderer type errors unrelated to this change, including `App.tsx`, `CameraExtension.tsx`, `LiquidGlassSurface.tsx`, launcher hooks, and other Raycast runtime type issues.
- Sweep cost is O(cache size) only on cache misses/inserts with `maxAge` configured. Non-expiring caches do not run the sweep.
