### PR TITLE
perf(icons): cache local asset existence checks

### DIFF
--- a/scripts/test-icon-asset-cache.mjs
+++ b/scripts/test-icon-asset-cache.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+import { performance } from 'node:perf_hooks';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+function createIconRuntimeHarness() {
+  const moduleCache = new Map();
+  const existingPaths = new Set();
+  let statCalls = 0;
+
+  const windowStub = {
+    electron: {
+      statSync(filePath) {
+        statCalls += 1;
+        const exists = existingPaths.has(filePath);
+        return {
+          exists,
+          isDirectory: false,
+          isFile: exists,
+          size: exists ? 123 : 0,
+        };
+      },
+    },
+  };
+
+  function loadTsModule(filePath) {
+    const resolvedPath = path.resolve(filePath);
+    if (moduleCache.has(resolvedPath)) return moduleCache.get(resolvedPath).exports;
+
+    const source = fs.readFileSync(resolvedPath, 'utf8');
+    const transpiled = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+        jsx: ts.JsxEmit.React,
+        esModuleInterop: true,
+        importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+      },
+      fileName: resolvedPath,
+    });
+
+    const module = { exports: {} };
+    moduleCache.set(resolvedPath, module);
+
+    const localRequire = (request) => {
+      if (request.startsWith('.')) {
+        const candidate = path.resolve(path.dirname(resolvedPath), request);
+        for (const suffix of ['', '.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.tsx']) {
+          const nextPath = `${candidate}${suffix}`;
+          if (fs.existsSync(nextPath) && fs.statSync(nextPath).isFile()) {
+            if (nextPath.endsWith('.ts') || nextPath.endsWith('.tsx')) return loadTsModule(nextPath);
+            return require(nextPath);
+          }
+        }
+      }
+      return require(request);
+    };
+
+    const sandbox = {
+      module,
+      exports: module.exports,
+      require: localRequire,
+      console,
+      URL,
+      window: windowStub,
+      document: {
+        documentElement: {
+          classList: {
+            contains: () => false,
+          },
+        },
+      },
+    };
+
+    vm.runInNewContext(transpiled.outputText, sandbox, { filename: resolvedPath });
+    return module.exports;
+  }
+
+  return {
+    assets: loadTsModule('src/renderer/src/raycast-api/icon-runtime-assets.tsx'),
+    config: loadTsModule('src/renderer/src/raycast-api/icon-runtime-config.ts'),
+    addExistingPath(filePath) {
+      existingPaths.add(filePath);
+    },
+    get statCalls() {
+      return statCalls;
+    },
+  };
+}
+
+test('icon asset existence cache', async (t) => {
+  await t.test('caches positive extension-relative asset checks by local path', () => {
+    const harness = createIconRuntimeHarness();
+    const assetsPath = '/tmp/supercmd-assets';
+    const iconPath = `${assetsPath}/icon.png`;
+    const expectedUrl = harness.assets.toScAssetUrl(iconPath);
+    harness.addExistingPath(iconPath);
+
+    for (let i = 0; i < 5; i += 1) {
+      assert.equal(harness.assets.resolveIconSrc('icon.png', assetsPath), expectedUrl);
+    }
+
+    assert.equal(harness.statCalls, 1);
+  });
+
+  await t.test('shares positive cache entries across sc-asset and absolute path resolution', () => {
+    const harness = createIconRuntimeHarness();
+    const iconPath = '/tmp/supercmd-assets/shared icon.png';
+    const expectedUrl = harness.assets.toScAssetUrl(iconPath);
+    harness.addExistingPath(iconPath);
+
+    assert.equal(harness.assets.resolveIconSrc(expectedUrl), expectedUrl);
+    assert.equal(harness.assets.resolveIconSrc(iconPath), expectedUrl);
+
+    assert.equal(harness.statCalls, 1);
+  });
+
+  await t.test('does not cache misses so newly available assets resolve later', () => {
+    const harness = createIconRuntimeHarness();
+    const assetsPath = '/tmp/supercmd-assets';
+    const iconPath = `${assetsPath}/late.png`;
+    const expectedUrl = harness.assets.toScAssetUrl(iconPath);
+
+    assert.equal(harness.assets.resolveIconSrc('late.png', assetsPath), '');
+    harness.addExistingPath(iconPath);
+    assert.equal(harness.assets.resolveIconSrc('late.png', assetsPath), expectedUrl);
+
+    assert.equal(harness.statCalls, 2);
+  });
+
+  await t.test('uses configured assetsPath fallback without changing asset URL semantics', () => {
+    const harness = createIconRuntimeHarness();
+    const assetsPath = '/tmp/supercmd-extension-assets';
+    const iconPath = `${assetsPath}/nested/icon dark.png`;
+    const expectedUrl = harness.assets.toScAssetUrl(iconPath);
+    harness.addExistingPath(iconPath);
+    harness.config.configureIconRuntime({
+      getExtensionContext: () => ({ assetsPath }),
+    });
+
+    assert.equal(harness.assets.resolveIconSrc('nested/icon dark.png'), expectedUrl);
+    assert.equal(expectedUrl, 'sc-asset://ext-asset/tmp/supercmd-extension-assets/nested/icon%20dark.png');
+    assert.equal(harness.statCalls, 1);
+  });
+
+  await t.test('repeated positive measurement avoids repeated statSync calls', () => {
+    const harness = createIconRuntimeHarness();
+    const assetsPath = '/tmp/supercmd-assets';
+    const iconPath = `${assetsPath}/measured.png`;
+    const expectedUrl = harness.assets.toScAssetUrl(iconPath);
+    const iterations = 10_000;
+    harness.addExistingPath(iconPath);
+
+    const start = performance.now();
+    let result = '';
+    for (let i = 0; i < iterations; i += 1) {
+      result = harness.assets.resolveIconSrc('measured.png', assetsPath);
+    }
+    const elapsedMs = performance.now() - start;
+
+    assert.equal(result, expectedUrl);
+    assert.equal(harness.statCalls, 1);
+    console.log(`icon-asset-cache measurement: iterations=${iterations} statSync=${harness.statCalls} elapsedMs=${elapsedMs.toFixed(3)}`);
+  });
+});

--- a/src/renderer/src/raycast-api/icon-runtime-assets.tsx
+++ b/src/renderer/src/raycast-api/icon-runtime-assets.tsx
@@ -6,6 +6,9 @@
 import React from 'react';
 import { getIconRuntimeContext } from './icon-runtime-config';
 
+const LOCAL_PATH_EXISTS_CACHE_MAX = 4096;
+const positiveLocalPathExistsCache = new Set<string>();
+
 type RgbColor = {
   r: number;
   g: number;
@@ -41,9 +44,18 @@ export function toScAssetUrl(filePath: string): string {
 
 function localPathExists(filePath: string): boolean {
   if (!filePath) return false;
+  if (positiveLocalPathExistsCache.has(filePath)) return true;
+
   try {
     const stat = (window as any).electron?.statSync?.(filePath);
-    return Boolean(stat?.exists);
+    const exists = Boolean(stat?.exists);
+    if (exists) {
+      if (positiveLocalPathExistsCache.size >= LOCAL_PATH_EXISTS_CACHE_MAX) {
+        positiveLocalPathExistsCache.clear();
+      }
+      positiveLocalPathExistsCache.add(filePath);
+    }
+    return exists;
   } catch {
     return false;
   }


### PR DESCRIPTION
## What Changed

- Added a bounded positive cache for local icon/asset existence checks in `icon-runtime-assets.tsx`.
- Kept negative checks uncached so newly-created extension assets can resolve without waiting for invalidation.
- Added a focused Node test harness for `resolveIconSrc` that stubs `window.electron.statSync` and covers extension-relative assets, `sc-asset://` URLs, absolute paths, missing assets, configured `assetsPath`, and the repeated-resolution measurement.

## Why

`resolveIconSrc` was calling `window.electron.statSync` synchronously every time a local icon or asset source was normalized. List rows, grid cells, and action overlays can all hit this path repeatedly, so resolving the same known-good asset caused repeated sync renderer-to-main IPC/stat work.

## Compatibility Impact

- `sc-asset://ext-asset` URL formatting and local path resolution are unchanged.
- Missing files are intentionally not cached, preserving fallback behavior for assets that appear later.
- Positive results may stay warm until the 4096-entry cache clears. If an asset is deleted after a positive check, the renderer may still emit its `sc-asset://` URL until the cache is cleared; this matches the accepted positive-only caching tradeoff for stable extension asset paths.

## Metrics

Baseline before code changes, 10,000 resolves of the same stubbed local asset path:

| Case | statSync calls | elapsedMs |
| --- | ---: | ---: |
| relative-positive | 10,000 | 18.216 |
| sc-asset-positive | 10,000 | 31.312 |
| absolute-positive | 10,000 | 14.656 |
| relative-negative | 10,000 | 3.197 |

After change, same 10,000-resolve measurement with a fresh module per case:

| Case | statSync calls | elapsedMs |
| --- | ---: | ---: |
| relative-positive | 1 | 15.771 |
| sc-asset-positive | 1 | 33.430 |
| absolute-positive | 1 | 15.359 |
| relative-negative | 10,000 | 5.770 |

The checked-in focused test also reports: `iterations=10000 statSync=1 elapsedMs=14.997`.

## Checks

- `node --test scripts/test-icon-asset-cache.mjs`
- `pnpm test` — 30 passed, 1 skipped live Electron test
- `pnpm build:renderer`
- `pnpm check:i18n` — command exited 0; reported existing missing Italian keys `settings.ai.whisper.vocabulary` and `settings.extensions.appSearchScope`
- Codex LSP diagnostics on `src/renderer/src/raycast-api/icon-runtime-assets.tsx` — no errors

## Notes / Risks

- A broader LSP scan of `src/renderer/src/raycast-api` still reports unrelated pre-existing TypeScript diagnostics in `context-scope-runtime.ts` and `hooks/use-cached-promise.ts`.
- Full `pnpm build` was not run because this change is renderer-only and the full build compiles native Swift/addon artifacts; `pnpm build:renderer` was run for the touched surface.
