### PR TITLE
perf(native): use index queues for AX BFS

### DIFF
--- a/scripts/bench-ax-bfs-queue.swift
+++ b/scripts/bench-ax-bfs-queue.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+private struct Node {
+  let firstChild: Int
+  let childCount: Int
+}
+
+private let depthLimit = 8
+private let branching = 3
+private var nodes: [Node] = []
+private var frontier: [(index: Int, depth: Int)] = [(0, 0)]
+
+nodes.reserveCapacity(9_841)
+nodes.append(Node(firstChild: -1, childCount: 0))
+
+var frontierIndex = 0
+while frontierIndex < frontier.count {
+  let (nodeIndex, depth) = frontier[frontierIndex]
+  frontierIndex += 1
+  guard depth < depthLimit else { continue }
+
+  let firstChild = nodes.count
+  for _ in 0..<branching {
+    nodes.append(Node(firstChild: -1, childCount: 0))
+    frontier.append((nodes.count - 1, depth + 1))
+  }
+  nodes[nodeIndex] = Node(firstChild: firstChild, childCount: branching)
+}
+
+private let roots = [0, 1, 2].filter { $0 < nodes.count }
+private let maxDepth = 8
+private let maxElements = 240
+private let iterations = 20_000
+
+@inline(never)
+private func removeFirstTraversal() -> Int {
+  var queue = roots.map { ($0, 0) }
+  var inspected = 0
+  var checksum = 0
+
+  while let (nodeIndex, depth) = queue.first {
+    queue.removeFirst()
+    inspected += 1
+    if inspected > maxElements { break }
+
+    checksum &+= nodeIndex &+ depth
+    if depth >= maxDepth { continue }
+
+    let node = nodes[nodeIndex]
+    if node.childCount > 0 {
+      for offset in 0..<node.childCount {
+        queue.append((node.firstChild + offset, depth + 1))
+      }
+    }
+  }
+  return checksum
+}
+
+@inline(never)
+private func cursorTraversal() -> Int {
+  var queue = roots.map { ($0, 0) }
+  var queueIndex = 0
+  var inspected = 0
+  var checksum = 0
+
+  while queueIndex < queue.count {
+    let (nodeIndex, depth) = queue[queueIndex]
+    queueIndex += 1
+    inspected += 1
+    if inspected > maxElements { break }
+
+    checksum &+= nodeIndex &+ depth
+    if depth >= maxDepth { continue }
+
+    let node = nodes[nodeIndex]
+    if node.childCount > 0 {
+      for offset in 0..<node.childCount {
+        queue.append((node.firstChild + offset, depth + 1))
+      }
+    }
+  }
+  return checksum
+}
+
+@inline(never)
+private func measure(_ label: String, _ block: () -> Int) -> (label: String, ms: Double, checksum: Int) {
+  var checksum = 0
+  let start = DispatchTime.now().uptimeNanoseconds
+  for _ in 0..<iterations {
+    checksum &+= block()
+  }
+  let elapsed = DispatchTime.now().uptimeNanoseconds - start
+  return (label, Double(elapsed) / 1_000_000.0, checksum)
+}
+
+let removeFirstWarmup = removeFirstTraversal()
+let cursorWarmup = cursorTraversal()
+precondition(removeFirstWarmup == cursorWarmup)
+
+let removeFirst = measure("removeFirst", removeFirstTraversal)
+let cursor = measure("cursor", cursorTraversal)
+
+print("nodes=\(nodes.count) roots=\(roots.count) maxDepth=\(maxDepth) maxElements=\(maxElements) iterations=\(iterations)")
+print("\(removeFirst.label): \(String(format: "%.2f", removeFirst.ms)) ms checksum=\(removeFirst.checksum)")
+print("\(cursor.label): \(String(format: "%.2f", cursor.ms)) ms checksum=\(cursor.checksum)")
+print("speedup: \(String(format: "%.2fx", removeFirst.ms / cursor.ms))")

--- a/src/native/ax-caret-query.swift
+++ b/src/native/ax-caret-query.swift
@@ -161,9 +161,11 @@ public enum AXCaretQuery {
     }
     // BFS up to a small depth to avoid walking huge trees.
     var queue: [(el: AXUIElement, depth: Int)] = [(root, 0)]
+    var queueIndex = 0
     let maxDepth = 6
-    while let (el, depth) = queue.first {
-      queue.removeFirst()
+    while queueIndex < queue.count {
+      let (el, depth) = queue[queueIndex]
+      queueIndex += 1
       if depth > 0 {
         let role = copyString(el, kAXRoleAttribute as CFString) ?? ""
         if TEXT_LEAF_ROLES.contains(role) && hasSelectedTextRange(el) {

--- a/src/native/get-selected-text.swift
+++ b/src/native/get-selected-text.swift
@@ -163,12 +163,14 @@ private func enqueueChildren(of element: AXUIElement, depth: Int, into queue: in
 
 private func findSelectedText(from roots: [AXUIElement]) -> String? {
   var queue = roots.map { ($0, 0) }
+  var queueIndex = 0
   var inspected = 0
   let maxDepth = 8
   let maxElements = 240
 
-  while let (element, depth) = queue.first {
-    queue.removeFirst()
+  while queueIndex < queue.count {
+    let (element, depth) = queue[queueIndex]
+    queueIndex += 1
     inspected += 1
     if inspected > maxElements { break }
 


### PR DESCRIPTION
## What changed

- Replaced `Array.removeFirst()` queue consumption in the native Accessibility BFS loops with monotonic index cursors.
- Added `scripts/bench-ax-bfs-queue.swift` so the queue behavior benchmark is repeatable.

## Why

Accessibility selected-text and caret lookup run on hot paths. `Array.removeFirst()` shifts/copies the remaining queue on every pop, even though these traversals only need FIFO order and already cap depth/element counts.

## Behavior and compatibility

- Preserves BFS search order, focused-child preference, depth limits, and selected/caret lookup fallback order.
- No user-facing strings changed.

## Evidence

- Baseline before editing, synthetic Swift BFS queue benchmark: `removeFirst: 235.47 ms`, `cursor: 37.95 ms`, equal checksum, `6.20x` speedup.
- Repeatable benchmark after change: `swift -O scripts/bench-ax-bfs-queue.swift` -> `removeFirst: 211.29 ms`, `cursor: 36.80 ms`, equal checksum, `5.74x` speedup.
- LSP diagnostics: no errors for `src/native/ax-caret-query.swift`, `src/native/get-selected-text.swift`, and `scripts/bench-ax-bfs-queue.swift`.
- `swiftc -O -o /tmp/supercmd-get-selected-text-check src/native/get-selected-text.swift -framework Foundation -framework ApplicationServices -framework AppKit`.
- `swiftc -O -o /tmp/supercmd-emoji-trigger-monitor-check src/native/emoji-trigger-monitor.swift src/native/ax-caret-query.swift -framework AppKit -framework ApplicationServices`.
- `node --test 'scripts/test-*.mjs'` passed: 24 passed, 1 skipped.
- `node scripts/check-i18n.mjs` exited 0; it reports pre-existing Italian locale gaps unrelated to this native-only change.

## Risk

Low. The traversal queue still appends in the same order and stops at the same caps; the only intentional change is avoiding per-pop array shifting.
