### PR TITLE
perf(menubar): cache visible payload hashes

### DIFF
--- a/scripts/test-menubar-payload-cache.mjs
+++ b/scripts/test-menubar-payload-cache.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importTs } from './lib/ts-import.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  createMenuBarVisiblePayloadHashCache,
+  shouldSendMenuBarVisiblePayload,
+} = await importTs(path.join(root, 'src/renderer/src/raycast-api/menubar-runtime-payload-cache.ts'));
+
+function makePayload(overrides = {}) {
+  return {
+    extId: 'demo/timer',
+    iconPath: undefined,
+    iconDataUrl: undefined,
+    iconEmoji: '*',
+    iconTemplate: undefined,
+    iconBitmapScale: undefined,
+    fallbackIconDataUrl: '',
+    title: 'Timer',
+    tooltip: 'Timer status',
+    items: [
+      {
+        type: 'item',
+        id: '__mbi_1',
+        title: 'Start',
+        subtitle: 'Ready',
+        tooltip: 'Start timer',
+        disabled: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+test('MenuBarExtra visible payload cache', async (t) => {
+  await t.test('skips equivalent renderer sends while action maps stay current', () => {
+    const cache = createMenuBarVisiblePayloadHashCache();
+    let updateSends = 0;
+    let actionMapUpdates = 0;
+
+    for (let i = 0; i < 3; i += 1) {
+      const actions = new Map([['__mbi_1', () => i]]);
+      actionMapUpdates += actions.size;
+      if (shouldSendMenuBarVisiblePayload(cache, makePayload())) {
+        updateSends += 1;
+      }
+    }
+
+    t.diagnostic(`equivalent registrations: before=3 sends, after=${updateSends} send`);
+    assert.equal(updateSends, 1, 'only the first equivalent visible payload crosses IPC');
+    assert.equal(actionMapUpdates, 3, 'action maps still refresh for every registration pass');
+  });
+
+  await t.test('sends again when visible tray or menu fields change', () => {
+    const cache = createMenuBarVisiblePayloadHashCache();
+    assert.equal(shouldSendMenuBarVisiblePayload(cache, makePayload()), true, 'initial payload sends');
+    assert.equal(shouldSendMenuBarVisiblePayload(cache, makePayload()), false, 'equivalent payload is skipped');
+    assert.equal(shouldSendMenuBarVisiblePayload(cache, makePayload({ title: 'Timer Running' })), true, 'title change sends');
+    assert.equal(shouldSendMenuBarVisiblePayload(cache, makePayload({ iconEmoji: '>' })), true, 'icon change sends');
+    assert.equal(shouldSendMenuBarVisiblePayload(cache, makePayload({
+      items: [{ type: 'item', id: '__mbi_1', title: 'Pause', disabled: false }],
+    })), true, 'menu item change sends');
+  });
+
+  await t.test('parent refreshes actions before skipping unchanged visible payloads', () => {
+    const parentSource = fs.readFileSync(
+      path.join(root, 'src/renderer/src/raycast-api/menubar-runtime-parent.tsx'),
+      'utf8',
+    );
+    const actionIndex = parentSource.indexOf('setMenuBarActions(extId');
+    const cacheIndex = parentSource.indexOf('shouldSendMenuBarVisiblePayload(');
+    const updateIndex = parentSource.indexOf('updateMenuBar?.(payload)');
+
+    assert.ok(actionIndex >= 0, 'parent updates the action map');
+    assert.ok(cacheIndex >= 0, 'parent checks the visible payload cache');
+    assert.ok(updateIndex >= 0, 'parent sends the cached payload object');
+    assert.ok(actionIndex < cacheIndex, 'actions update before unchanged payloads are skipped');
+    assert.ok(cacheIndex < updateIndex, 'IPC send happens only after the cache check');
+  });
+});

--- a/src/renderer/src/raycast-api/menubar-runtime-parent.tsx
+++ b/src/renderer/src/raycast-api/menubar-runtime-parent.tsx
@@ -6,6 +6,11 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { getMenuBarRuntimeDeps } from './menubar-runtime-config';
 import {
+  createMenuBarVisiblePayloadHashCache,
+  shouldSendMenuBarVisiblePayload,
+  type SerializedMenuBarVisiblePayload,
+} from './menubar-runtime-payload-cache';
+import {
   type MBItemRegistration,
   type MBRegistryAPI,
   MBRegistryContext,
@@ -31,6 +36,7 @@ export function MenuBarExtraComponent({ children, icon, title, tooltip, isLoadin
   const registryRef = useRef(new Map<string, MBItemRegistration>());
   const [registryVersion, setRegistryVersion] = useState(0);
   const pendingRef = useRef(false);
+  const visiblePayloadHashCacheRef = useRef(createMenuBarVisiblePayloadHashCache());
 
   resetMenuBarOrderCounters();
 
@@ -160,7 +166,7 @@ export function MenuBarExtraComponent({ children, icon, title, tooltip, isLoadin
 
       if (cancelled) return;
       setMenuBarActions(extId, actions as unknown as Map<string, () => void>);
-      (window as any).electron?.updateMenuBar?.({
+      const payload: SerializedMenuBarVisiblePayload = {
         extId,
         iconPath: trayIconPayload.iconPath,
         iconDataUrl: trayIconPayload.iconDataUrl,
@@ -171,7 +177,13 @@ export function MenuBarExtraComponent({ children, icon, title, tooltip, isLoadin
         title: title || '',
         tooltip: tooltip || '',
         items: dividedSerialized,
-      });
+      };
+
+      if (!shouldSendMenuBarVisiblePayload(visiblePayloadHashCacheRef.current, payload)) {
+        return;
+      }
+
+      (window as any).electron?.updateMenuBar?.(payload);
     };
 
     syncMenuBar().catch((error) => {

--- a/src/renderer/src/raycast-api/menubar-runtime-payload-cache.ts
+++ b/src/renderer/src/raycast-api/menubar-runtime-payload-cache.ts
@@ -1,0 +1,39 @@
+/**
+ * raycast-api/menubar-runtime-payload-cache.ts
+ * Purpose: Detect unchanged MenuBarExtra payloads before crossing IPC.
+ */
+
+export type SerializedMenuBarVisiblePayload = {
+  extId: string;
+  iconPath?: string;
+  iconDataUrl?: string;
+  iconEmoji?: string;
+  iconTemplate?: boolean;
+  iconBitmapScale?: number;
+  fallbackIconDataUrl: string;
+  title: string;
+  tooltip: string;
+  items: any[];
+};
+
+export type MenuBarVisiblePayloadHashCache = {
+  current: string | null;
+};
+
+export function createMenuBarVisiblePayloadHashCache(): MenuBarVisiblePayloadHashCache {
+  return { current: null };
+}
+
+export function hashMenuBarVisiblePayload(payload: SerializedMenuBarVisiblePayload): string {
+  return JSON.stringify(payload);
+}
+
+export function shouldSendMenuBarVisiblePayload(
+  cache: MenuBarVisiblePayloadHashCache,
+  payload: SerializedMenuBarVisiblePayload,
+): boolean {
+  const nextHash = hashMenuBarVisiblePayload(payload);
+  if (cache.current === nextHash) return false;
+  cache.current = nextHash;
+  return true;
+}


### PR DESCRIPTION
## What changed

- Added a small renderer-side MenuBarExtra visible-payload hash cache.
- MenuBarExtra now refreshes the current action map on every sync, then skips `updateMenuBar` when the serialized visible payload is unchanged.
- Added focused regression coverage for repeated equivalent registrations, visible title/icon/menu changes, and action-map-before-cache ordering.

## Why

Equivalent menu-bar registrations could repeatedly send the same visible payload to the main process. Each IPC update made main rebuild the tray icon/menu even when the native result would be identical.

## Compatibility impact

No extension API or visible UI behavior changes are intended. Changed title, icon, tooltip, menu items, disabled state, and action presence still send a fresh payload. Callback-only action changes keep working because the renderer action map is updated before the unchanged payload is skipped.

## How tested

- Baseline pre-change instrumentation: 3 equivalent visible menu-bar registrations produced 3 renderer `updateMenuBar` sends and 3 action-map updates.
- After regression test: 3 equivalent registrations produce 1 renderer send and still perform 3 action-map updates.
- `node --test scripts/test-menubar-payload-cache.mjs` passes.
- `pnpm run test` passes: 28 passed, 1 skipped.
- Codex LSP diagnostics: no errors in touched TypeScript files.
- `pnpm run build:renderer` passes.
- `pnpm run build:main` passes.
- `node scripts/check-i18n.mjs` completed; it reports pre-existing Italian missing keys unrelated to this no-string change.
- `pnpm exec tsc -p tsconfig.renderer.json --noEmit` still fails on existing unrelated project-wide renderer type errors outside this change.
