### PR TITLE
perf(extensions): cache extension wrapper compilation

### DIFF
--- a/scripts/measure-extension-wrapper-cache.mjs
+++ b/scripts/measure-extension-wrapper-cache.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import { performance } from 'node:perf_hooks';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importTs } from './lib/ts-import.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  clearCompiledExtensionWrapperCache,
+  EXTENSION_WRAPPER_ARGUMENTS,
+  getCompiledExtensionWrapper,
+  getCompiledExtensionWrapperCacheStats,
+} = await importTs(path.join(root, 'src/renderer/src/utils/extension-wrapper-cache.ts'));
+
+const ITERATIONS = Number.parseInt(process.env.SUPERCMD_WRAPPER_MEASURE_ITERATIONS || '1000', 10);
+
+function patchSchemeDynamicImports(sourceCode) {
+  return String(sourceCode || '').replace(
+    /\bimport\(\s*(["'])(swift:[^"']+|rust:[^"']+)\1\s*\)/g,
+    (_match, quote, specifier) => `__scDynamicImport(${quote}${specifier}${quote})`
+  );
+}
+
+function createFixtureExtensionCode() {
+  const body = `
+Object.defineProperty(exports, "__esModule", { value: true });
+const React = require("react");
+let moduleScopedCounter = 0;
+moduleScopedCounter += 1;
+const pendingTimer = setTimeout(() => {}, 60000);
+exports.default = function FixtureCommand() {
+  return {
+    reactVersion: React.version,
+    moduleScopedCounter,
+    pendingTimerType: typeof pendingTimer
+  };
+};
+`;
+  return body + '\n'.repeat(20) + '// filler '.repeat(250);
+}
+
+function createRunEnv() {
+  const moduleExports = {};
+  const fakeModule = { exports: moduleExports };
+  const timers = new Set();
+  const trackTimeout = (cb, ms, ...rest) => {
+    const id = setTimeout(cb, ms, ...rest);
+    timers.add(id);
+    return id;
+  };
+  const trackClearTimeout = (id) => {
+    timers.delete(id);
+    clearTimeout(id);
+  };
+  const fakeRequire = (name) => {
+    if (name === 'react') return { version: '18.2.0' };
+    return {};
+  };
+
+  return {
+    args: [
+      moduleExports,
+      fakeRequire,
+      fakeModule,
+      '/extension/index.js',
+      '/extension',
+      { env: {} },
+      Buffer,
+      globalThis,
+      globalThis,
+      (fn, ...args) => trackTimeout(() => fn(...args), 0),
+      trackClearTimeout,
+      () => 0,
+      () => {},
+      trackTimeout,
+      trackClearTimeout,
+      () => 0,
+      () => {},
+      undefined,
+      async () => ({}),
+    ],
+    fakeModule,
+    cleanup: () => {
+      timers.forEach((id) => clearTimeout(id));
+      timers.clear();
+    },
+    getTimerCount: () => timers.size,
+  };
+}
+
+function measureUncachedLoads(code, iterations) {
+  let wrapperCreationCount = 0;
+  let wrapperCreationMs = 0;
+  let executionMs = 0;
+  let leakedTimerPeak = 0;
+
+  for (let i = 0; i < iterations; i++) {
+    const executableCode = patchSchemeDynamicImports(code);
+
+    const compileStart = performance.now();
+    const wrapper = new Function(...EXTENSION_WRAPPER_ARGUMENTS, executableCode);
+    wrapperCreationMs += performance.now() - compileStart;
+    wrapperCreationCount++;
+
+    const env = createRunEnv();
+    const executionStart = performance.now();
+    wrapper(...env.args);
+    executionMs += performance.now() - executionStart;
+    leakedTimerPeak = Math.max(leakedTimerPeak, env.getTimerCount());
+    env.cleanup();
+
+    if (typeof env.fakeModule.exports.default !== 'function') {
+      throw new Error('Fixture did not export a function');
+    }
+  }
+
+  return {
+    iterations,
+    wrapperCreationCount,
+    wrapperCreationMs,
+    executionMs,
+    totalLoadMs: wrapperCreationMs + executionMs,
+    leakedTimerPeak,
+  };
+}
+
+function measureCachedLoads(code, iterations) {
+  clearCompiledExtensionWrapperCache();
+
+  let cacheLookupMs = 0;
+  let executionMs = 0;
+  let leakedTimerPeak = 0;
+
+  for (let i = 0; i < iterations; i++) {
+    const executableCode = patchSchemeDynamicImports(code);
+
+    const cacheStart = performance.now();
+    const { wrapper } = getCompiledExtensionWrapper({
+      extensionIdentity: 'fixture-owner/fixture-extension/fixture-command',
+      code,
+      executableCode,
+    });
+    cacheLookupMs += performance.now() - cacheStart;
+
+    const env = createRunEnv();
+    const executionStart = performance.now();
+    wrapper(...env.args);
+    executionMs += performance.now() - executionStart;
+    leakedTimerPeak = Math.max(leakedTimerPeak, env.getTimerCount());
+    env.cleanup();
+
+    if (typeof env.fakeModule.exports.default !== 'function') {
+      throw new Error('Fixture did not export a function');
+    }
+  }
+
+  const stats = getCompiledExtensionWrapperCacheStats();
+  return {
+    iterations,
+    wrapperCreationCount: stats.wrapperCreationCount,
+    wrapperCreationMs: stats.wrapperCreationMs,
+    cacheHits: stats.hits,
+    cacheMisses: stats.misses,
+    cacheLookupMs,
+    executionMs,
+    totalLoadMs: cacheLookupMs + executionMs,
+    leakedTimerPeak,
+  };
+}
+
+const fixtureCode = createFixtureExtensionCode();
+
+console.log(JSON.stringify({
+  scenario: 'extension-wrapper-cache',
+  codeLength: fixtureCode.length,
+  uncached: measureUncachedLoads(fixtureCode, ITERATIONS),
+  cached: measureCachedLoads(fixtureCode, ITERATIONS),
+}, null, 2));

--- a/scripts/test-extension-wrapper-cache.mjs
+++ b/scripts/test-extension-wrapper-cache.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importTs } from './lib/ts-import.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  clearCompiledExtensionWrapperCache,
+  getCompiledExtensionWrapper,
+  getCompiledExtensionWrapperCacheStats,
+} = await importTs(path.join(root, 'src/renderer/src/utils/extension-wrapper-cache.ts'));
+
+function createRunEnv() {
+  const moduleExports = {};
+  const fakeModule = { exports: moduleExports };
+  const timers = new Set();
+  const trackTimeout = (cb, ms, ...rest) => {
+    const id = setTimeout(cb, ms, ...rest);
+    timers.add(id);
+    return id;
+  };
+  const trackClearTimeout = (id) => {
+    timers.delete(id);
+    clearTimeout(id);
+  };
+
+  return {
+    fakeModule,
+    timers,
+    args: [
+      moduleExports,
+      () => ({}),
+      fakeModule,
+      '/extension/index.js',
+      '/extension',
+      { env: {} },
+      Buffer,
+      globalThis,
+      globalThis,
+      (fn, ...args) => trackTimeout(() => fn(...args), 0),
+      trackClearTimeout,
+      () => 0,
+      () => {},
+      trackTimeout,
+      trackClearTimeout,
+      () => 0,
+      () => {},
+      undefined,
+      async () => ({}),
+    ],
+    cleanup: () => {
+      timers.forEach((id) => clearTimeout(id));
+      timers.clear();
+    },
+  };
+}
+
+function runWrapper(wrapper) {
+  const env = createRunEnv();
+  wrapper(...env.args);
+  return env;
+}
+
+test('Extension wrapper cache', async (t) => {
+  await t.test('reuses the compiled wrapper for the same extension code', () => {
+    clearCompiledExtensionWrapperCache();
+    const code = 'exports.default = function Command() { return "ok"; };';
+
+    const first = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code,
+    });
+    const second = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code,
+    });
+
+    assert.equal(first.cacheHit, false);
+    assert.equal(second.cacheHit, true);
+    assert.strictEqual(second.wrapper, first.wrapper);
+    assert.equal(getCompiledExtensionWrapperCacheStats().wrapperCreationCount, 1);
+  });
+
+  await t.test('invalidates when code changes even if the length is unchanged', () => {
+    clearCompiledExtensionWrapperCache();
+    const codeA = 'exports.default = function Command() { return "a"; };';
+    const codeB = 'exports.default = function Command() { return "b"; };';
+    assert.equal(codeA.length, codeB.length, 'fixture code must keep equal length');
+
+    const first = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code: codeA,
+    });
+    const changed = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code: codeB,
+    });
+
+    assert.equal(first.cacheHit, false);
+    assert.equal(changed.cacheHit, false);
+    assert.notEqual(changed.cacheKey, first.cacheKey);
+    assert.notStrictEqual(changed.wrapper, first.wrapper);
+
+    const envA = runWrapper(first.wrapper);
+    const envB = runWrapper(changed.wrapper);
+    try {
+      assert.equal(envA.fakeModule.exports.default(), 'a');
+      assert.equal(envB.fakeModule.exports.default(), 'b');
+    } finally {
+      envA.cleanup();
+      envB.cleanup();
+    }
+  });
+
+  await t.test('keeps module exports and timer handles fresh across cached runs', () => {
+    clearCompiledExtensionWrapperCache();
+    const code = `
+let moduleScopedCounter = 0;
+moduleScopedCounter += 1;
+const timerId = setTimeout(() => {}, 60000);
+exports.default = {
+  moduleScopedCounter,
+  timerId,
+  previousTouchedValue: exports.touched
+};
+exports.touched = "mutated";
+`;
+
+    const first = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code,
+    });
+    const second = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code,
+    });
+    assert.equal(second.cacheHit, true);
+    assert.strictEqual(second.wrapper, first.wrapper);
+
+    const envA = runWrapper(second.wrapper);
+    const envB = runWrapper(second.wrapper);
+    try {
+      assert.notStrictEqual(envA.fakeModule.exports, envB.fakeModule.exports);
+      assert.equal(envA.fakeModule.exports.default.moduleScopedCounter, 1);
+      assert.equal(envB.fakeModule.exports.default.moduleScopedCounter, 1);
+      assert.equal(envA.fakeModule.exports.default.previousTouchedValue, undefined);
+      assert.equal(envB.fakeModule.exports.default.previousTouchedValue, undefined);
+      assert.equal(envA.timers.size, 1);
+      assert.equal(envB.timers.size, 1);
+      assert.notStrictEqual(
+        envA.fakeModule.exports.default.timerId,
+        envB.fakeModule.exports.default.timerId
+      );
+    } finally {
+      envA.cleanup();
+      envB.cleanup();
+    }
+
+    assert.equal(envA.timers.size, 0);
+    assert.equal(envB.timers.size, 0);
+  });
+});

--- a/src/renderer/src/ExtensionView.tsx
+++ b/src/renderer/src/ExtensionView.tsx
@@ -16,6 +16,7 @@ import { ArrowLeft, AlertTriangle } from 'lucide-react';
 import * as RaycastAPI from './raycast-api';
 import { NavigationContext, setExtensionContext, setGlobalNavigation, ExtensionContextType, ExtensionInfoReactContext } from './raycast-api';
 import { withExtensionContext } from './raycast-api/context-scope-runtime';
+import { getCompiledExtensionWrapper } from './utils/extension-wrapper-cache';
 
 // Also import @raycast/utils stubs from our shim
 import * as RaycastUtils from './raycast-api';
@@ -3571,7 +3572,8 @@ end tell`.trim();
 function loadExtensionExport(
   code: string,
   extensionPath?: string,
-  timerRegistry?: TimerRegistry
+  timerRegistry?: TimerRegistry,
+  extensionIdentity = extensionPath || 'unknown-extension'
 ): Function | null {
   const patchSchemeDynamicImports = (sourceCode: string): string => {
     // Extension bundles may emit dynamic imports for native Raycast bridges
@@ -3962,28 +3964,12 @@ function loadExtensionExport(
     // anyway because requests are routed through the main process). Code
     // that genuinely needs navigator can still reach it via
     // `globalThis.navigator` or `window.navigator`.
-    const fn = new Function(
-      'exports',
-      'require',
-      'module',
-      '__filename',
-      '__dirname',
-      'process',
-      'Buffer',
-      'global',
-      'globalThis',
-      'setImmediate',
-      'clearImmediate',
-      'setInterval',
-      'clearInterval',
-      'setTimeout',
-      'clearTimeout',
-      'requestAnimationFrame',
-      'cancelAnimationFrame',
-      'navigator',
-      '__scDynamicImport',
-      executableCode
-    );
+    const { wrapper: fn, cacheHit } = getCompiledExtensionWrapper({
+      extensionIdentity,
+      code,
+      executableCode,
+    });
+    console.debug(`[loadExtensionExport] Wrapper cache ${cacheHit ? 'hit' : 'miss'} for ${extensionIdentity}`);
 
     fn(
       moduleExports,
@@ -4239,6 +4225,11 @@ const ExtensionView: React.FC<ExtensionViewProps> = ({
     mode,
   ]);
 
+  const extensionWrapperIdentity = useMemo(
+    () => [owner, extensionName, commandName, extensionPath].map((part) => String(part || '')).join('\0'),
+    [owner, extensionName, commandName, extensionPath]
+  );
+
   // Set extension context before loading (so getPreferenceValues etc. work)
   useEffect(() => {
     setExtensionContext(extensionCtx);
@@ -4266,9 +4257,9 @@ const ExtensionView: React.FC<ExtensionViewProps> = ({
     // Load under the extension's scoped context so other async extension work
     // cannot leak a different context into this bundle.
     return withExtensionContext(extensionCtx, () =>
-      loadExtensionExport(code, extensionPath, timerRegistryRef.current)
+      loadExtensionExport(code, extensionPath, timerRegistryRef.current, extensionWrapperIdentity)
     );
-  }, [code, buildError, extensionCtx, extensionPath]);
+  }, [code, buildError, extensionCtx, extensionPath, extensionWrapperIdentity]);
 
   // Is this a no-view command? Trust the mode from package.json.
   // NOTE: 'menu-bar' commands ARE React components (they use hooks),

--- a/src/renderer/src/utils/extension-wrapper-cache.ts
+++ b/src/renderer/src/utils/extension-wrapper-cache.ts
@@ -1,0 +1,193 @@
+export type ExtensionWrapperFunction = (...args: any[]) => any;
+
+export const EXTENSION_WRAPPER_ARGUMENTS = [
+  'exports',
+  'require',
+  'module',
+  '__filename',
+  '__dirname',
+  'process',
+  'Buffer',
+  'global',
+  'globalThis',
+  'setImmediate',
+  'clearImmediate',
+  'setInterval',
+  'clearInterval',
+  'setTimeout',
+  'clearTimeout',
+  'requestAnimationFrame',
+  'cancelAnimationFrame',
+  'navigator',
+  '__scDynamicImport',
+] as const;
+
+const MAX_COMPILED_EXTENSION_WRAPPERS = 32;
+
+interface CacheEntry {
+  wrapper: ExtensionWrapperFunction;
+  codeLength: number;
+  codeHash: string;
+}
+
+interface CodeFingerprint {
+  code: string;
+  codeLength: number;
+  codeHash: string;
+}
+
+interface CacheStats {
+  entries: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+  wrapperCreationCount: number;
+  wrapperCreationMs: number;
+}
+
+const compiledWrapperCache = new Map<string, CacheEntry>();
+const codeFingerprintCache = new Map<string, CodeFingerprint>();
+const cacheStats: CacheStats = {
+  entries: 0,
+  hits: 0,
+  misses: 0,
+  evictions: 0,
+  wrapperCreationCount: 0,
+  wrapperCreationMs: 0,
+};
+
+function nowMs(): number {
+  return globalThis.performance?.now?.() ?? Date.now();
+}
+
+export function hashExtensionCodeForCache(code: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < code.length; i++) {
+    hash ^= code.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function createExtensionWrapperCacheKey(extensionIdentity: string, code: string): string {
+  const identity = extensionIdentity || 'unknown-extension';
+  return `${identity}\0${code.length}\0${hashExtensionCodeForCache(code)}`;
+}
+
+function createExtensionWrapperCacheKeyFromFingerprint(
+  extensionIdentity: string,
+  fingerprint: CodeFingerprint
+): string {
+  return `${extensionIdentity}\0${fingerprint.codeLength}\0${fingerprint.codeHash}`;
+}
+
+function getCodeFingerprint(extensionIdentity: string, code: string): CodeFingerprint {
+  const cached = codeFingerprintCache.get(extensionIdentity);
+  if (cached?.code === code) {
+    codeFingerprintCache.delete(extensionIdentity);
+    codeFingerprintCache.set(extensionIdentity, cached);
+    return cached;
+  }
+
+  const fingerprint = {
+    code,
+    codeLength: code.length,
+    codeHash: hashExtensionCodeForCache(code),
+  };
+  codeFingerprintCache.set(extensionIdentity, fingerprint);
+
+  if (codeFingerprintCache.size > MAX_COMPILED_EXTENSION_WRAPPERS) {
+    const oldestKey = codeFingerprintCache.keys().next().value;
+    if (oldestKey) codeFingerprintCache.delete(oldestKey);
+  }
+
+  return fingerprint;
+}
+
+export function getCompiledExtensionWrapper(options: {
+  extensionIdentity: string;
+  code: string;
+  executableCode?: string;
+}): {
+  wrapper: ExtensionWrapperFunction;
+  cacheHit: boolean;
+  cacheKey: string;
+  codeLength: number;
+  codeHash: string;
+  wrapperCreationMs: number;
+} {
+  const extensionIdentity = options.extensionIdentity || 'unknown-extension';
+  const executableCode = String(options.executableCode ?? options.code ?? '');
+  const sourceCode = executableCode;
+  const fingerprint = getCodeFingerprint(extensionIdentity, sourceCode);
+  const cacheKey = createExtensionWrapperCacheKeyFromFingerprint(extensionIdentity, fingerprint);
+  const cached = compiledWrapperCache.get(cacheKey);
+
+  if (cached) {
+    cacheStats.hits++;
+    compiledWrapperCache.delete(cacheKey);
+    compiledWrapperCache.set(cacheKey, cached);
+    return {
+      wrapper: cached.wrapper,
+      cacheHit: true,
+      cacheKey,
+      codeLength: cached.codeLength,
+      codeHash: cached.codeHash,
+      wrapperCreationMs: 0,
+    };
+  }
+
+  cacheStats.misses++;
+  const start = nowMs();
+  const wrapper = new Function(
+    ...EXTENSION_WRAPPER_ARGUMENTS,
+    executableCode
+  ) as ExtensionWrapperFunction;
+  const wrapperCreationMs = nowMs() - start;
+
+  cacheStats.wrapperCreationCount++;
+  cacheStats.wrapperCreationMs += wrapperCreationMs;
+
+  compiledWrapperCache.set(cacheKey, {
+    wrapper,
+    codeLength: fingerprint.codeLength,
+    codeHash: fingerprint.codeHash,
+  });
+
+  if (compiledWrapperCache.size > MAX_COMPILED_EXTENSION_WRAPPERS) {
+    const oldestKey = compiledWrapperCache.keys().next().value;
+    if (oldestKey) {
+      compiledWrapperCache.delete(oldestKey);
+      cacheStats.evictions++;
+    }
+  }
+
+  cacheStats.entries = compiledWrapperCache.size;
+
+  return {
+    wrapper,
+    cacheHit: false,
+    cacheKey,
+    codeLength: fingerprint.codeLength,
+    codeHash: fingerprint.codeHash,
+    wrapperCreationMs,
+  };
+}
+
+export function getCompiledExtensionWrapperCacheStats(): CacheStats {
+  return {
+    ...cacheStats,
+    entries: compiledWrapperCache.size,
+  };
+}
+
+export function clearCompiledExtensionWrapperCache(): void {
+  compiledWrapperCache.clear();
+  codeFingerprintCache.clear();
+  cacheStats.entries = 0;
+  cacheStats.hits = 0;
+  cacheStats.misses = 0;
+  cacheStats.evictions = 0;
+  cacheStats.wrapperCreationCount = 0;
+  cacheStats.wrapperCreationMs = 0;
+}


### PR DESCRIPTION
## Summary
- Add a bounded renderer cache for compiled extension wrapper functions, keyed by extension identity plus compiled code length/hash.
- Keep extension launches isolated by still creating fresh `module`, `exports`, `fakeRequire`, process, dynamic import hook, and tracked timer APIs for every run.
- Add focused measurement and regression coverage for cache hits, same-length code invalidation, and fresh module exports/timers across cached executions.

## Root Cause
`ExtensionView` rebuilt the CommonJS wrapper with `new Function(...)` every time the same extension bundle was loaded. In long sessions with repeated no-view/background/menu/view launches, that repeatedly paid parsing/compile cost even when the extension code was unchanged.

## Metrics
Baseline captured before changing the runtime path:
- `node scripts/measure-extension-wrapper-cache.mjs` pre-cache, 1000 iterations, codeLength 2886
- wrapperCreationCount: 1000
- wrapperCreationMs: 6.365626
- totalLoadMs: 8.101469

Post-change focused measurement:
- `node scripts/measure-extension-wrapper-cache.mjs`, 1000 iterations, codeLength 2886
- uncached wrapperCreationCount: 1000, wrapperCreationMs: 5.326457, totalLoadMs: 7.204954
- cached wrapperCreationCount: 1, cacheHits: 999, cacheMisses: 1, wrapperCreationMs: 0.006375, totalLoadMs: 1.713175

## Compatibility Impact
The wrapper signature and execution environment are unchanged. The cache stores only the compiled wrapper function; extension runtime state remains per-launch and is covered by the new regression test.

## Validation
- PASS: `node --test scripts/test-extension-wrapper-cache.mjs`
- PASS: `node --test scripts/test-*.mjs` (28 passing, 1 skipped live Electron test)
- PASS: `./node_modules/.bin/vite build`
- PASS: Codex LSP diagnostics for `src/renderer/src/ExtensionView.tsx` and `src/renderer/src/utils/extension-wrapper-cache.ts`
- PASS with existing report: `node scripts/check-i18n.mjs` exits 0; still reports pre-existing missing Italian keys `settings.ai.whisper.vocabulary` and `settings.extensions.appSearchScope`
- FAIL existing project-wide issues: `./node_modules/.bin/tsc -p tsconfig.renderer.json --noEmit` fails in unrelated files such as `App.tsx`, `CameraExtension.tsx`, `LiquidGlassSurface.tsx`, `useLauncherCommandModel.ts`, and existing Raycast API/settings utility types

## Risks
- The cache is intentionally small (32 entries) and may evict wrappers during very broad extension churn.
- Invalidating by compiled body length/hash protects changed code; the helper also memoizes the last fingerprint per identity to avoid rescanning identical code on hot paths.