### PR TITLE
perf(audio): avoid idle buffer conversion

### DIFF
--- a/src/native/audio-capturer.swift
+++ b/src/native/audio-capturer.swift
@@ -279,6 +279,16 @@ class AudioCapturer {
   // MARK: Buffer processing
 
   private func processBuffer(_ buffer: AVAudioPCMBuffer) {
+    let now = Date()
+    let shouldUpdateMeter = now.timeIntervalSince(lastMeterAt) >= meterInterval
+
+    guard isRecording || shouldUpdateMeter else { return }
+
+    if !isRecording {
+      updateMeter(fromInputBuffer: buffer, now: now)
+      return
+    }
+
     guard let converted = convertBuffer(buffer),
           converted.frameLength > 0,
           let samples = converted.floatChannelData?[0]
@@ -290,25 +300,100 @@ class AudioCapturer {
       ringBuffer.append(UnsafeBufferPointer(start: samples, count: sampleCount))
     }
 
-    // Compute meter
-    let now = Date()
-    if now.timeIntervalSince(lastMeterAt) >= meterInterval {
-      var sumSquares: Float = 0
-      var peak: Float = 0
-      for i in 0..<sampleCount {
-        let s = samples[i]
-        sumSquares += s * s
-        peak = max(peak, abs(s))
-      }
-      let rms = sqrt(sumSquares / Float(max(1, sampleCount)))
-      meterAverage = Double(min(1, rms * 5))
-      meterPeak = Double(min(1, peak * 5))
-      lastMeterAt = now
+    if shouldUpdateMeter {
+      updateMeter(samples: samples, sampleCount: sampleCount, stride: 1, now: now)
     }
   }
 
   func getMeter() -> [String: Double] {
     return ["average": meterAverage, "peak": meterPeak]
+  }
+
+  private func updateMeter(fromInputBuffer buffer: AVAudioPCMBuffer, now: Date) {
+    let sampleCount = Int(buffer.frameLength)
+    guard sampleCount > 0 else { return }
+
+    let channelStride = buffer.format.isInterleaved ? Int(max(1, buffer.format.channelCount)) : 1
+
+    switch buffer.format.commonFormat {
+    case .pcmFormatFloat32:
+      guard let samples = buffer.floatChannelData?[0] else { return }
+      updateMeter(samples: samples, sampleCount: sampleCount, stride: channelStride, now: now)
+    case .pcmFormatFloat64:
+      guard let rawSamples = buffer.audioBufferList.pointee.mBuffers.mData else { return }
+      updateMeter(
+        samples: rawSamples.assumingMemoryBound(to: Double.self),
+        sampleCount: sampleCount,
+        stride: channelStride,
+        now: now
+      )
+    case .pcmFormatInt16:
+      guard let samples = buffer.int16ChannelData?[0] else { return }
+      updateMeter(samples: samples, sampleCount: sampleCount, stride: channelStride, divisor: Float(Int16.max), now: now)
+    case .pcmFormatInt32:
+      guard let samples = buffer.int32ChannelData?[0] else { return }
+      updateMeter(samples: samples, sampleCount: sampleCount, stride: channelStride, divisor: Float(Int32.max), now: now)
+    case .otherFormat:
+      return
+    @unknown default:
+      return
+    }
+  }
+
+  private func updateMeter(
+    samples: UnsafePointer<Float>,
+    sampleCount: Int,
+    stride: Int,
+    now: Date
+  ) {
+    var sumSquares: Float = 0
+    var peak: Float = 0
+    for i in 0..<sampleCount {
+      let s = samples[i * stride]
+      sumSquares += s * s
+      peak = max(peak, abs(s))
+    }
+    updateMeter(sumSquares: sumSquares, peak: peak, sampleCount: sampleCount, now: now)
+  }
+
+  private func updateMeter(
+    samples: UnsafePointer<Double>,
+    sampleCount: Int,
+    stride: Int,
+    now: Date
+  ) {
+    var sumSquares: Float = 0
+    var peak: Float = 0
+    for i in 0..<sampleCount {
+      let s = Float(samples[i * stride])
+      sumSquares += s * s
+      peak = max(peak, abs(s))
+    }
+    updateMeter(sumSquares: sumSquares, peak: peak, sampleCount: sampleCount, now: now)
+  }
+
+  private func updateMeter<T: BinaryInteger>(
+    samples: UnsafePointer<T>,
+    sampleCount: Int,
+    stride: Int,
+    divisor: Float,
+    now: Date
+  ) {
+    var sumSquares: Float = 0
+    var peak: Float = 0
+    for i in 0..<sampleCount {
+      let s = max(-1, min(1, Float(Int64(samples[i * stride])) / divisor))
+      sumSquares += s * s
+      peak = max(peak, abs(s))
+    }
+    updateMeter(sumSquares: sumSquares, peak: peak, sampleCount: sampleCount, now: now)
+  }
+
+  private func updateMeter(sumSquares: Float, peak: Float, sampleCount: Int, now: Date) {
+    let rms = sqrt(sumSquares / Float(max(1, sampleCount)))
+    meterAverage = Double(min(1, rms * 5))
+    meterPeak = Double(min(1, peak * 5))
+    lastMeterAt = now
   }
 
   // MARK: Audio conversion


### PR DESCRIPTION
## Summary
- skip `AVAudioConverter` work on warm idle audio taps unless a meter update is due
- compute idle meter levels directly from the input buffer, while keeping recording conversion/output unchanged
- keep warmup and command behavior unchanged; conversion still happens for recording buffers and recording meters

## Evidence
Focused temporary instrumentation around `processBuffer` counted converted, recorded, and metered buffers over matching 1.2s windows:

| Scenario | Before | After |
| --- | ---: | ---: |
| Warm idle conversions | 12 | 0 |
| Warm idle recorded buffers | 0 | 0 |
| Warm idle meter updates | 7 | 7 |
| Recording conversion delta | 12 | 12 |
| Recording append delta | 12 | 12 |
| Recording meter delta | 8 | 8 |

This removes idle converter work while preserving recording conversion and meter cadence in the measured run.

## Checks
- `mcp__lsp.diagnostics` on `src/native/audio-capturer.swift`: no errors
- `swiftc -O -o /tmp/supercmd-audio-capturer-final src/native/audio-capturer.swift -framework AVFoundation -framework Foundation`: passed
- `git diff --check`: passed
- `node scripts/check-i18n.mjs`: completed; existing `it` locale missing keys were reported and are unrelated to this native-only change
- `npm run build:native`: blocked by local policy; npm is disabled on this Mac, pnpm attempted install, then failed with `ERR_PNPM_IGNORED_BUILDS`

## Risks
- Idle meter levels are now calculated from the input buffer instead of the converted 16 kHz mono buffer. The code reads channel 0 with the same RMS/peak scaling, matching the converter's channel map for typical mic formats.
