### PR TITLE
ci: add project regression checks

### DIFF
--- a/.github/workflows/project-checks.yml
+++ b/.github/workflows/project-checks.yml
@@ -1,0 +1,56 @@
+name: Project Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: project-checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-i18n-build:
+    name: Tests, i18n, and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CI: true
+      ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+      SUPERCMD_SKIP_ELECTRON_TESTS: '1'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies without native postinstall scripts
+        # package.json pins darwin esbuild packages for release packaging; --force lets Ubuntu install the lockfile.
+        run: npm ci --ignore-scripts --force
+
+      - name: Run tests
+        run: npm test
+
+      - name: Check i18n
+        run: npm run check:i18n
+
+      - name: Build main process
+        run: npm run build:main
+
+      - name: Build renderer
+        run: npm run build:renderer


### PR DESCRIPTION
## What changed

Added a lightweight root `Project Checks` GitHub Actions workflow for pull requests, pushes to `main`, and manual runs.

The workflow runs on Node 22 with npm caching and covers:
- `npm test`
- `npm run check:i18n`
- `npm run build:main`
- `npm run build:renderer`

It installs dependencies with native postinstall scripts disabled and skips the live Electron harness on Ubuntu so the job stays focused on fast regression coverage rather than macOS packaging.

## Why

The current workflows cover Claude review/assistant flows and the canvas bundle, but do not run the normal root project test/i18n/build checks. That leaves performance cleanup PRs vulnerable to quiet regressions in ranking tests, i18n structure, main-process TypeScript compilation, or renderer bundling.

## Compatibility impact

CI-only change. No runtime code, packaged app behavior, or Raycast extension API surface changes.

## How tested

- `/opt/homebrew/Cellar/node@22/22.22.3/bin/npm ci --ignore-scripts --force`
- `SUPERCMD_SKIP_ELECTRON_TESTS=1 /opt/homebrew/Cellar/node@22/22.22.3/bin/npm test` - 25 tests reported, 24 pass, 1 Electron live test skipped
- `/opt/homebrew/Cellar/node@22/22.22.3/bin/npm run check:i18n` - exits 0; existing non-strict Italian gaps still warn
- `/opt/homebrew/Cellar/node@22/22.22.3/bin/npm run build:main`
- `/opt/homebrew/Cellar/node@22/22.22.3/bin/npm run build:renderer`
- YAML parse smoke test with `js-yaml`
- Codex LSP: TypeScript diagnostics on `vite.config.ts` reported no errors; YAML LSP could not run in this local environment because its installed `yaml-language-server` package is missing `vscode-languageserver-protocol`

## Risks

- `npm ci --force` is intentional because `package.json` pins darwin esbuild platform packages for release packaging; without it, npm rejects the lockfile on a single runner platform.
- `check:i18n` currently treats only configured strict locales as failures, so non-strict locale drift remains a warning unless that script policy changes later.
