### PR TITLE
perf(extensions): cache bundle preparation

### DIFF
--- a/scripts/measure-extension-bundle-cache.mjs
+++ b/scripts/measure-extension-bundle-cache.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { build } from 'esbuild';
+import { performance } from 'node:perf_hooks';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const iterations = Number.parseInt(process.env.SUPERCMD_EXTENSION_BUNDLE_MEASURE_ITERATIONS || '20', 10);
+
+export function createFixture() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-extension-bundle-cache-'));
+  const userDataDir = path.join(tmpDir, 'userData');
+  const extensionsDir = path.join(userDataDir, 'extensions');
+  const extDir = path.join(extensionsDir, 'bundle-cache-fixture');
+  const buildDir = path.join(extDir, '.sc-build');
+
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(extDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'bundle-cache-fixture',
+        title: 'Bundle Cache Fixture',
+        description: 'Fixture for extension bundle cache measurement',
+        owner: 'codex',
+        commands: [
+          {
+            name: 'background',
+            title: 'Background',
+            description: 'No-view command',
+            mode: 'no-view',
+            preferences: [
+              {
+                name: 'freshCommandPref',
+                title: 'Fresh Command Pref',
+                type: 'textfield',
+                default: 'default-command',
+              },
+            ],
+          },
+          {
+            name: 'menu',
+            title: 'Menu',
+            description: 'Menu-bar command',
+            mode: 'menu-bar',
+          },
+        ],
+        preferences: [
+          {
+            name: 'freshExtensionPref',
+            title: 'Fresh Extension Pref',
+            type: 'textfield',
+            default: 'default-extension',
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+  fs.writeFileSync(path.join(buildDir, 'background.js'), 'module.exports = { name: "background" };\n');
+  fs.writeFileSync(path.join(buildDir, 'menu.js'), 'module.exports = { name: "menu" };\n');
+
+  return { tmpDir, userDataDir, extDir };
+}
+
+export async function bundleExtensionRunner(userDataDir) {
+  const outFile = path.join(
+    os.tmpdir(),
+    `sc-extension-runner-measure-${process.pid}-${Date.now()}.cjs`
+  );
+
+  const stubModule = (filter, source) => ({
+    name: `stub-${filter}`,
+    setup(pluginBuild) {
+      pluginBuild.onResolve({ filter }, () => ({
+        path: filter.source,
+        namespace: `stub-${filter.source}`,
+      }));
+      pluginBuild.onLoad({ filter: /.*/, namespace: `stub-${filter.source}` }, () => ({
+        contents: source,
+        loader: 'js',
+      }));
+    },
+  });
+
+  await build({
+    entryPoints: [path.join(root, 'src/main/extension-runner.ts')],
+    outfile: outFile,
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    target: 'node20',
+    logLevel: 'silent',
+    plugins: [
+      stubModule(
+        /^electron$/,
+        `
+          module.exports = {
+            app: {
+              getPath(name) {
+                if (name === 'userData') return ${JSON.stringify(userDataDir)};
+                return ${JSON.stringify(userDataDir)};
+              }
+            }
+          };
+        `
+      ),
+      stubModule(
+        /extension-preferences-store$/,
+        `
+          module.exports = {
+            getExtensionPreferences(extName, cmdName) {
+              const values = globalThis.__extensionPreferenceValues || {};
+              if (cmdName) return values[extName + '/' + cmdName] || {};
+              return values[extName] || {};
+            }
+          };
+        `
+      ),
+      stubModule(
+        /settings-store$/,
+        `
+          module.exports = {
+            loadSettings() {
+              return { customExtensionFolders: [] };
+            }
+          };
+        `
+      ),
+    ],
+  });
+
+  return outFile;
+}
+
+export function createCounters(extDir) {
+  const counters = {
+    readFileSync: 0,
+    packageJsonReads: 0,
+    bundleReads: 0,
+    jsonParseCalls: 0,
+    existsSync: 0,
+    statSync: 0,
+    readdirSync: 0,
+  };
+  const restore = [];
+  const packageJsonPath = path.join(extDir, 'package.json');
+  const buildDir = path.join(extDir, '.sc-build');
+
+  const patch = (target, key, wrapper) => {
+    const original = target[key];
+    target[key] = wrapper(original);
+    restore.push(() => {
+      target[key] = original;
+    });
+  };
+
+  patch(fs, 'readFileSync', (original) => function patchedReadFileSync(filePath, ...args) {
+    const normalizedPath = typeof filePath === 'string' ? filePath : String(filePath);
+    counters.readFileSync++;
+    if (path.resolve(normalizedPath) === packageJsonPath) counters.packageJsonReads++;
+    if (path.resolve(normalizedPath).startsWith(buildDir + path.sep)) counters.bundleReads++;
+    return original.call(this, filePath, ...args);
+  });
+  patch(fs, 'existsSync', (original) => function patchedExistsSync(filePath) {
+    counters.existsSync++;
+    return original.call(this, filePath);
+  });
+  patch(fs, 'statSync', (original) => function patchedStatSync(filePath, ...args) {
+    counters.statSync++;
+    return original.call(this, filePath, ...args);
+  });
+  patch(fs, 'readdirSync', (original) => function patchedReaddirSync(filePath, ...args) {
+    counters.readdirSync++;
+    return original.call(this, filePath, ...args);
+  });
+  patch(JSON, 'parse', (original) => function patchedJsonParse(source, ...args) {
+    counters.jsonParseCalls++;
+    return original.call(this, source, ...args);
+  });
+
+  return {
+    counters,
+    restore() {
+      while (restore.length > 0) restore.pop()();
+    },
+  };
+}
+
+export async function measure(label, extDir, fn) {
+  const { counters, restore } = createCounters(extDir);
+  const started = performance.now();
+  try {
+    await fn();
+  } finally {
+    counters.elapsedMs = Number((performance.now() - started).toFixed(3));
+    restore();
+  }
+  return { label, iterations, ...counters };
+}
+
+async function main() {
+  const fixture = createFixture();
+  let bundledRunner;
+  try {
+    bundledRunner = await bundleExtensionRunner(fixture.userDataDir);
+    const runner = require(bundledRunner);
+
+    globalThis.__extensionPreferenceValues = {
+      'bundle-cache-fixture': { freshExtensionPref: 'stored-extension-1' },
+      'bundle-cache-fixture/background': { freshCommandPref: 'stored-command-1' },
+    };
+
+    const noView = await measure('repeated-getExtensionBundle-no-view', fixture.extDir, async () => {
+      for (let i = 0; i < iterations; i++) {
+        const bundle = await runner.getExtensionBundle('bundle-cache-fixture', 'background');
+        assert.equal(bundle.mode, 'no-view');
+        assert.equal(bundle.preferences.freshExtensionPref, 'stored-extension-1');
+        assert.equal(bundle.preferences.freshCommandPref, 'stored-command-1');
+      }
+    });
+
+    const menuBar = await measure('repeated-menu-bar-background-prep', fixture.extDir, async () => {
+      for (let i = 0; i < iterations; i++) {
+        const commands = runner
+          .discoverInstalledExtensionCommands()
+          .filter((command) => command.mode === 'menu-bar');
+        assert.equal(commands.length, 1);
+        const bundle = await runner.getExtensionBundle(commands[0].extName, commands[0].cmdName);
+        assert.equal(bundle.mode, 'menu-bar');
+      }
+    });
+
+    console.log(JSON.stringify({ iterations, measurements: [noView, menuBar] }, null, 2));
+  } finally {
+    try {
+      if (bundledRunner) fs.unlinkSync(bundledRunner);
+    } catch {}
+    try {
+      fs.rmSync(fixture.tmpDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test-extension-bundle-cache.mjs
+++ b/scripts/test-extension-bundle-cache.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import {
+  bundleExtensionRunner,
+  createCounters,
+  createFixture,
+} from './measure-extension-bundle-cache.mjs';
+
+const require = createRequire(import.meta.url);
+
+function updatedFixtureManifest() {
+  return {
+    name: 'bundle-cache-fixture',
+    title: 'Bundle Cache Fixture',
+    description: 'Fixture for extension bundle cache measurement',
+    owner: 'codex',
+    commands: [
+      {
+        name: 'background',
+        title: 'Background Updated',
+        description: 'No-view command',
+        mode: 'no-view',
+        preferences: [
+          {
+            name: 'freshCommandPref',
+            title: 'Fresh Command Pref',
+            type: 'textfield',
+            default: 'default-command',
+          },
+        ],
+      },
+      {
+        name: 'menu',
+        title: 'Menu',
+        description: 'Menu-bar command',
+        mode: 'menu-bar',
+      },
+    ],
+    preferences: [
+      {
+        name: 'freshExtensionPref',
+        title: 'Fresh Extension Pref',
+        type: 'textfield',
+        default: 'default-extension',
+      },
+    ],
+  };
+}
+
+test('extension bundle cache hits and invalidates by file stats', async () => {
+  const fixture = createFixture();
+  const bundledRunner = await bundleExtensionRunner(fixture.userDataDir);
+  const runner = require(bundledRunner);
+  const { counters, restore } = createCounters(fixture.extDir);
+
+  try {
+    globalThis.__extensionPreferenceValues = {
+      'bundle-cache-fixture': { freshExtensionPref: 'stored-extension-1' },
+      'bundle-cache-fixture/background': { freshCommandPref: 'stored-command-1' },
+    };
+
+    const first = await runner.getExtensionBundle('bundle-cache-fixture', 'background');
+    assert.equal(first.title, 'Background');
+    assert.match(first.code, /background/);
+    assert.equal(first.preferences.freshExtensionPref, 'stored-extension-1');
+    assert.equal(first.preferences.freshCommandPref, 'stored-command-1');
+    assert.equal(counters.packageJsonReads, 1);
+    assert.equal(counters.bundleReads, 1);
+    assert.equal(counters.jsonParseCalls, 1);
+    assert.equal(counters.readdirSync, 1);
+
+    const afterFirst = { ...counters };
+    globalThis.__extensionPreferenceValues = {
+      'bundle-cache-fixture': { freshExtensionPref: 'stored-extension-2' },
+      'bundle-cache-fixture/background': { freshCommandPref: 'stored-command-2' },
+    };
+
+    const second = await runner.getExtensionBundle('bundle-cache-fixture', 'background');
+    assert.equal(second.preferences.freshExtensionPref, 'stored-extension-2');
+    assert.equal(second.preferences.freshCommandPref, 'stored-command-2');
+    assert.equal(counters.packageJsonReads, afterFirst.packageJsonReads);
+    assert.equal(counters.bundleReads, afterFirst.bundleReads);
+    assert.equal(counters.jsonParseCalls, afterFirst.jsonParseCalls);
+    assert.equal(counters.readdirSync, afterFirst.readdirSync);
+
+    const bundlePath = path.join(fixture.extDir, '.sc-build', 'background.js');
+    fs.writeFileSync(bundlePath, 'module.exports = { name: "background", version: 2 };\n');
+    const beforeBundleInvalidation = { ...counters };
+    const third = await runner.getExtensionBundle('bundle-cache-fixture', 'background');
+    assert.match(third.code, /version: 2/);
+    assert.equal(counters.bundleReads, beforeBundleInvalidation.bundleReads + 1);
+    assert.equal(counters.packageJsonReads, beforeBundleInvalidation.packageJsonReads);
+
+    const manifestPath = path.join(fixture.extDir, 'package.json');
+    fs.writeFileSync(manifestPath, JSON.stringify(updatedFixtureManifest(), null, 2));
+    const beforeManifestInvalidation = { ...counters };
+    const fourth = await runner.getExtensionBundle('bundle-cache-fixture', 'background');
+    assert.equal(fourth.title, 'Background Updated');
+    assert.equal(counters.packageJsonReads, beforeManifestInvalidation.packageJsonReads + 1);
+    assert.equal(counters.jsonParseCalls, beforeManifestInvalidation.jsonParseCalls + 1);
+    assert.equal(counters.bundleReads, beforeManifestInvalidation.bundleReads);
+  } finally {
+    restore();
+    try { fs.unlinkSync(bundledRunner); } catch {}
+    try { fs.rmSync(fixture.tmpDir, { recursive: true, force: true }); } catch {}
+  }
+});

--- a/src/main/extension-registry.ts
+++ b/src/main/extension-registry.ts
@@ -36,6 +36,13 @@ import { installDepsWithBun } from './bun-manager';
 
 const execAsync = promisify(exec);
 
+function invalidateExtensionRunnerCaches(): void {
+  try {
+    const runner = require('./extension-runner');
+    runner.invalidateExtensionRunnerCaches?.();
+  } catch {}
+}
+
 function shellQuoteSingle(value: string): string {
   return `'${String(value || '').replace(/'/g, `'\\''`)}'`;
 }
@@ -1137,6 +1144,7 @@ async function installExtensionFromBundle(
 
     // Copy to extensions directory
     fs.cpSync(srcDir, installPath, { recursive: true });
+    invalidateExtensionRunnerCaches();
 
     // Cleanup backup
     if (backupPath && fs.existsSync(backupPath)) {
@@ -1244,6 +1252,7 @@ async function installExtensionViaAPI(name: string): Promise<boolean> {
       const { buildAllCommands } = require('./extension-runner');
       const builtCount = await buildAllCommands(name);
       console.log(`  Build: ${Date.now() - t1}ms. Extension "${name}" installed (${builtCount} commands) in ${Date.now() - t0}ms total`);
+      invalidateExtensionRunnerCaches();
     }
 
     // Cleanup backup
@@ -1355,6 +1364,7 @@ async function installExtensionViaGit(name: string): Promise<boolean> {
     const { buildAllCommands } = require('./extension-runner');
     const builtCount = await buildAllCommands(name);
     console.log(`Extension "${name}" installed (${builtCount} commands) at ${installPath}`);
+    invalidateExtensionRunnerCaches();
     if (backupPath && fs.existsSync(backupPath)) {
       fs.rmSync(backupPath, { recursive: true, force: true });
     }
@@ -1535,6 +1545,7 @@ export async function uninstallExtension(name: string): Promise<boolean> {
 
   try {
     fs.rmSync(installPath, { recursive: true, force: true });
+    invalidateExtensionRunnerCaches();
     console.log(`Extension "${name}" uninstalled.`);
 
     // Report uninstall to backend (fire-and-forget)

--- a/src/main/extension-runner.ts
+++ b/src/main/extension-runner.ts
@@ -111,6 +111,43 @@ interface InstalledExtensionSource {
   sourceRoot: string;
 }
 
+interface FsPathSignature {
+  exists: boolean;
+  isFile: boolean;
+  isDirectory: boolean;
+  size: number;
+  mtimeMs: number;
+}
+
+interface InstalledExtensionSourceSignature {
+  extName: string;
+  extPath: string;
+  sourceRoot: string;
+  extPathSignature: FsPathSignature;
+  packageJsonSignature: FsPathSignature;
+}
+
+interface InstalledExtensionsSnapshot {
+  roots: string[];
+  rootSignatures: FsPathSignature[];
+  sources: InstalledExtensionSource[];
+  sourceSignatures: InstalledExtensionSourceSignature[];
+}
+
+interface CachedManifest {
+  signature: FsPathSignature;
+  value: any;
+}
+
+interface CachedTextFile {
+  signature: FsPathSignature;
+  value: string;
+}
+
+let _installedExtensionsSnapshot: InstalledExtensionsSnapshot | null = null;
+const _extensionManifestCache = new Map<string, CachedManifest>();
+const _extensionBundleCodeCache = new Map<string, CachedTextFile>();
+
 function getManagedExtensionsDir(): string {
   const dir = path.join(app.getPath('userData'), 'extensions');
   if (!fs.existsSync(dir)) {
@@ -144,6 +181,91 @@ function normalizeExtensionName(name: string): string {
   return raw.replace(/^@/, '').replace(/[\\/]/g, '-');
 }
 
+function getPathSignature(filePath: string): FsPathSignature {
+  try {
+    const stat = fs.statSync(filePath);
+    return {
+      exists: true,
+      isFile: stat.isFile(),
+      isDirectory: stat.isDirectory(),
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+    };
+  } catch {
+    return {
+      exists: false,
+      isFile: false,
+      isDirectory: false,
+      size: -1,
+      mtimeMs: -1,
+    };
+  }
+}
+
+function samePathSignature(a: FsPathSignature, b: FsPathSignature): boolean {
+  return (
+    a.exists === b.exists &&
+    a.isFile === b.isFile &&
+    a.isDirectory === b.isDirectory &&
+    a.size === b.size &&
+    a.mtimeMs === b.mtimeMs
+  );
+}
+
+function sameRootSnapshot(
+  roots: string[],
+  rootSignatures: FsPathSignature[],
+  snapshot: InstalledExtensionsSnapshot
+): boolean {
+  if (roots.length !== snapshot.roots.length) return false;
+  if (rootSignatures.length !== snapshot.rootSignatures.length) return false;
+  for (let i = 0; i < roots.length; i++) {
+    if (roots[i] !== snapshot.roots[i]) return false;
+    if (!samePathSignature(rootSignatures[i], snapshot.rootSignatures[i])) return false;
+  }
+  return true;
+}
+
+function getInstalledExtensionSourceSignature(source: InstalledExtensionSource): InstalledExtensionSourceSignature {
+  return {
+    extName: source.extName,
+    extPath: source.extPath,
+    sourceRoot: source.sourceRoot,
+    extPathSignature: getPathSignature(source.extPath),
+    packageJsonSignature: getPathSignature(path.join(source.extPath, 'package.json')),
+  };
+}
+
+function sameInstalledExtensionSourceSignature(
+  a: InstalledExtensionSourceSignature,
+  b: InstalledExtensionSourceSignature
+): boolean {
+  return (
+    a.extName === b.extName &&
+    a.extPath === b.extPath &&
+    a.sourceRoot === b.sourceRoot &&
+    samePathSignature(a.extPathSignature, b.extPathSignature) &&
+    samePathSignature(a.packageJsonSignature, b.packageJsonSignature)
+  );
+}
+
+function getInstalledExtensionSourceSignatures(
+  sources: InstalledExtensionSource[]
+): InstalledExtensionSourceSignature[] {
+  return sources.map((source) => getInstalledExtensionSourceSignature(source));
+}
+
+function sameInstalledExtensionSourceSignatures(
+  a: InstalledExtensionSourceSignature[],
+  b: InstalledExtensionSourceSignature[]
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (!sameInstalledExtensionSourceSignature(a[i], b[i])) return false;
+  }
+  return true;
+}
+
 function getConfiguredExtensionRoots(): string[] {
   const settingsPaths = Array.isArray(loadSettings().customExtensionFolders)
     ? loadSettings().customExtensionFolders
@@ -162,7 +284,7 @@ function getConfiguredExtensionRoots(): string[] {
   return [...unique];
 }
 
-function collectInstalledExtensions(): InstalledExtensionSource[] {
+function scanInstalledExtensions(roots: string[]): InstalledExtensionSource[] {
   const results: InstalledExtensionSource[] = [];
   const seen = new Set<string>();
 
@@ -183,7 +305,7 @@ function collectInstalledExtensions(): InstalledExtensionSource[] {
     results.push({ extName, extPath, sourceRoot });
   };
 
-  for (const sourceRoot of getConfiguredExtensionRoots()) {
+  for (const sourceRoot of roots) {
     if (!fs.existsSync(sourceRoot)) continue;
 
     const sourceRootPkg = path.join(sourceRoot, 'package.json');
@@ -206,6 +328,27 @@ function collectInstalledExtensions(): InstalledExtensionSource[] {
   return results;
 }
 
+function collectInstalledExtensions(): InstalledExtensionSource[] {
+  const roots = getConfiguredExtensionRoots();
+  const rootSignatures = roots.map((root) => getPathSignature(root));
+
+  if (_installedExtensionsSnapshot && sameRootSnapshot(roots, rootSignatures, _installedExtensionsSnapshot)) {
+    const currentSourceSignatures = getInstalledExtensionSourceSignatures(_installedExtensionsSnapshot.sources);
+    if (sameInstalledExtensionSourceSignatures(currentSourceSignatures, _installedExtensionsSnapshot.sourceSignatures)) {
+      return _installedExtensionsSnapshot.sources;
+    }
+  }
+
+  const sources = scanInstalledExtensions(roots);
+  _installedExtensionsSnapshot = {
+    roots,
+    rootSignatures,
+    sources,
+    sourceSignatures: getInstalledExtensionSourceSignatures(sources),
+  };
+  return sources;
+}
+
 function resolveInstalledExtensionPath(extName: string): string | null {
   const normalized = normalizeExtensionName(extName);
   if (!normalized) return null;
@@ -213,11 +356,60 @@ function resolveInstalledExtensionPath(extName: string): string | null {
   return match?.extPath || null;
 }
 
+function readExtensionManifest(extPath: string): any | null {
+  const pkgPath = path.join(extPath, 'package.json');
+  const signature = getPathSignature(pkgPath);
+  if (!signature.exists || !signature.isFile) return null;
+
+  const cached = _extensionManifestCache.get(pkgPath);
+  if (cached && samePathSignature(cached.signature, signature)) {
+    return cached.value;
+  }
+
+  const value = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+  _extensionManifestCache.set(pkgPath, { signature, value });
+  return value;
+}
+
+function readExtensionBundleCode(outFile: string): string {
+  const signature = getPathSignature(outFile);
+  if (!signature.exists || !signature.isFile) return '';
+
+  const cached = _extensionBundleCodeCache.get(outFile);
+  if (cached && samePathSignature(cached.signature, signature)) {
+    return cached.value;
+  }
+
+  const value = fs.readFileSync(outFile, 'utf-8');
+  _extensionBundleCodeCache.set(outFile, { signature, value });
+  return value;
+}
+
+function invalidateExtensionStaticCacheForPath(extPath: string): void {
+  const normalizedExtPath = path.resolve(extPath);
+  _installedExtensionsSnapshot = null;
+  _extensionManifestCache.delete(path.join(normalizedExtPath, 'package.json'));
+
+  const buildDir = path.join(normalizedExtPath, '.sc-build') + path.sep;
+  for (const bundlePath of _extensionBundleCodeCache.keys()) {
+    if (bundlePath.startsWith(buildDir)) {
+      _extensionBundleCodeCache.delete(bundlePath);
+    }
+  }
+}
+
+export function invalidateExtensionRunnerCaches(): void {
+  _installedExtensionsSnapshot = null;
+  _extensionManifestCache.clear();
+  _extensionBundleCodeCache.clear();
+  _extensionIconCache.clear();
+}
+
 // ─── Icon extraction ────────────────────────────────────────────────
 
 // Session-level cache: absolute icon path → stable data URL string.
 // Prevents re-reading and re-encoding the same icon file on every getCommands() call.
-const _extensionIconCache = new Map<string, string>();
+const _extensionIconCache = new Map<string, { signature: FsPathSignature; value: string }>();
 
 function resizeIconWithSips(inputPath: string): Buffer | null {
   const tmp = path.join(os.tmpdir(), `sc-icon-${Date.now()}-${Math.random().toString(36).slice(2)}.png`);
@@ -241,10 +433,13 @@ function getExtensionIconDataUrl(
   ];
 
   for (const p of candidates) {
-    if (!fs.existsSync(p)) continue;
+    const signature = getPathSignature(p);
+    if (!signature.exists || !signature.isFile) continue;
 
     const cached = _extensionIconCache.get(p);
-    if (cached !== undefined) return cached;
+    if (cached !== undefined && samePathSignature(cached.signature, signature)) {
+      return cached.value;
+    }
 
     try {
       const ext = path.extname(p).toLowerCase();
@@ -260,7 +455,7 @@ function getExtensionIconDataUrl(
         result = `data:image/png;base64,${finalData.toString('base64')}`;
       }
 
-      _extensionIconCache.set(p, result);
+      _extensionIconCache.set(p, { signature, value: result });
       return result;
     } catch {}
   }
@@ -310,11 +505,11 @@ export function discoverInstalledExtensionCommands(): ExtensionCommandInfo[] {
   const results: ExtensionCommandInfo[] = [];
   for (const source of collectInstalledExtensions()) {
     const extPath = source.extPath;
-    const pkgPath = path.join(extPath, 'package.json');
     const extName = source.extName;
 
     try {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+      const pkg = readExtensionManifest(extPath);
+      if (!pkg) continue;
       if (!isManifestPlatformCompatible(pkg)) continue;
       const iconDataUrl = getExtensionIconDataUrl(
         extPath,
@@ -375,11 +570,11 @@ export function getInstalledExtensionsSettingsSchema(): InstalledExtensionSettin
   const results: InstalledExtensionSettingsSchema[] = [];
   for (const source of collectInstalledExtensions()) {
     const extPath = source.extPath;
-    const pkgPath = path.join(extPath, 'package.json');
     const extName = source.extName;
 
     try {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+      const pkg = readExtensionManifest(extPath);
+      if (!pkg) continue;
       if (!isManifestPlatformCompatible(pkg)) continue;
       const iconDataUrl = getExtensionIconDataUrl(extPath, pkg.icon || 'icon.png');
       const ownerRaw = pkg.owner || pkg.author || '';
@@ -660,11 +855,14 @@ export async function buildAllCommands(extName: string, extPathOverride?: string
     return 0;
   }
 
+  invalidateExtensionStaticCacheForPath(extPath);
+
   let commands: any[];
   let requiresNodeModules = false;
   let manifestExternal: string[] = [];
   try {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    const pkg = readExtensionManifest(extPath);
+    if (!pkg) return 0;
     if (!isManifestPlatformCompatible(pkg)) {
       console.warn(`Skipping build for incompatible extension ${extName}`);
       return 0;
@@ -954,11 +1152,14 @@ export async function buildSingleCommand(extName: string, cmdName: string): Prom
     return false;
   }
 
+  invalidateExtensionStaticCacheForPath(extPath);
+
   let cmd: any;
   let requiresNodeModules = false;
   let manifestExternal: string[] = [];
   try {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    const pkg = readExtensionManifest(extPath);
+    if (!pkg) return false;
     if (!isManifestPlatformCompatible(pkg)) {
       console.error(`buildSingleCommand: platform not compatible for ${extName}`);
       return false;
@@ -1172,8 +1373,7 @@ export async function getExtensionBundle(
     if (!fs.existsSync(outFile)) {
       let entryMissing = false;
       try {
-        const pkgPath = path.join(extPath, 'package.json');
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+        const pkg = readExtensionManifest(extPath);
         const cmd = (Array.isArray(pkg?.commands) ? pkg.commands : []).find((c: any) => c?.name === cmdName);
         if (cmd && !resolveEntryFile(extPath, cmd)) entryMissing = true;
       } catch {}
@@ -1203,8 +1403,7 @@ export async function getExtensionBundle(
     if (!fs.existsSync(outFile)) {
       let diagnostic = '';
       try {
-        const pkgPath = path.join(extPath, 'package.json');
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+        const pkg = readExtensionManifest(extPath);
         const commands = Array.isArray(pkg?.commands) ? pkg.commands : [];
         const cmd = commands.find((c: any) => c?.name === cmdName);
         const nodeModulesExists = fs.existsSync(path.join(extPath, 'node_modules'));
@@ -1230,7 +1429,7 @@ export async function getExtensionBundle(
     }
   }
 
-  const code = fs.readFileSync(outFile, 'utf-8');
+  const code = readExtensionBundleCode(outFile);
   if (!code) {
     const msg = `Pre-built bundle is empty: ${outFile}`;
     console.error(msg);
@@ -1266,8 +1465,8 @@ export async function getExtensionBundle(
   }> = [];
 
   try {
-    const pkgPath = path.join(extPath, 'package.json');
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    const pkg = readExtensionManifest(extPath);
+    if (!pkg) return null;
     if (!isManifestPlatformCompatible(pkg)) {
       return null;
     }


### PR DESCRIPTION
## Summary
- Cache installed extension root snapshots, parsed package manifests, bundle JS text, and icon data behind `mtimeMs`/`size` file signatures.
- Keep preferences and support/assets path setup live on every `getExtensionBundle()` call.
- Clear runner caches when builds rewrite `.sc-build/` and when install/uninstall replaces extension files.
- Add a focused measurement harness plus regression coverage for cache hits, bundle invalidation, manifest invalidation, and fresh preference reads.

## Root Cause
Repeated no-view/background extension launches re-scanned extension roots, re-read built JS bundles, and re-parsed `package.json` even when the installed extension files were unchanged.

## Before / After Evidence
Measured with `node scripts/measure-extension-bundle-cache.mjs` using 20 repeated calls per phase.

| Phase | Metric | Before | After |
| --- | ---: | ---: | ---: |
| repeated `getExtensionBundle()` no-view | `packageJsonReads` | 20 | 1 |
| repeated `getExtensionBundle()` no-view | `bundleReads` | 20 | 1 |
| repeated `getExtensionBundle()` no-view | `jsonParseCalls` | 20 | 1 |
| repeated `getExtensionBundle()` no-view | `readdirSync` | 20 | 1 |
| repeated `getExtensionBundle()` no-view | `elapsedMs` | 9.989 | 3.871 |
| repeated menu-bar/background prep | `packageJsonReads` | 40 | 0 |
| repeated menu-bar/background prep | `bundleReads` | 20 | 1 |
| repeated menu-bar/background prep | `jsonParseCalls` | 40 | 0 |
| repeated menu-bar/background prep | `readdirSync` | 40 | 0 |
| repeated menu-bar/background prep | `elapsedMs` | 6.354 | 2.409 |

The menu-bar/background phase runs after no-view warmup in the same process, matching the shared main-process cache behavior.

## Validation
- `node --test scripts/test-extension-bundle-cache.mjs`
- `node scripts/measure-extension-bundle-cache.mjs`
- `pnpm test` (passes; live Electron crash-recovery test skipped because Electron is not launchable here)
- `pnpm run build:main`
- Codex LSP diagnostics: no errors in `src/main/extension-runner.ts` or `src/main/extension-registry.ts`

## Risks / Notes
- Runtime preference values are intentionally not cached; the regression test mutates preferences between cached bundle reads.
- Cache validation trades repeated reads/parses for lightweight `statSync` checks. External filesystem changes are invalidated by root/source/package/bundle signatures, and in-app install/update/uninstall paths explicitly clear the runner caches.
