### PR TITLE
perf(menubar): avoid storage self-remounts

### DIFF
--- a/scripts/test-menubar-storage-remounts.mjs
+++ b/scripts/test-menubar-storage-remounts.mjs
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function depsChanged(prevDeps, nextDeps) {
+  if (!prevDeps || !nextDeps || prevDeps.length !== nextDeps.length) return true;
+  return nextDeps.some((dep, index) => !Object.is(dep, prevDeps[index]));
+}
+
+function createReactHookHarness() {
+  const hooks = [];
+  const effects = [];
+  let hookIndex = 0;
+  let pendingEffects = [];
+
+  const react = {
+    useState(initialValue) {
+      const index = hookIndex++;
+      if (!hooks[index]) {
+        hooks[index] = {
+          value: typeof initialValue === 'function' ? initialValue() : initialValue,
+        };
+      }
+      const setState = (nextValue) => {
+        hooks[index].value =
+          typeof nextValue === 'function' ? nextValue(hooks[index].value) : nextValue;
+      };
+      return [hooks[index].value, setState];
+    },
+
+    useRef(initialValue) {
+      const index = hookIndex++;
+      if (!hooks[index]) hooks[index] = { current: initialValue };
+      return hooks[index];
+    },
+
+    useCallback(callback, deps) {
+      const index = hookIndex++;
+      const slot = hooks[index];
+      if (!slot || depsChanged(slot.deps, deps)) {
+        hooks[index] = { value: callback, deps };
+      }
+      return hooks[index].value;
+    },
+
+    useEffect(effect, deps) {
+      const index = hookIndex++;
+      const slot = effects[index];
+      if (!slot || depsChanged(slot.deps, deps)) {
+        pendingEffects.push({ index, effect, deps });
+      }
+    },
+  };
+
+  function flushEffects() {
+    const toRun = pendingEffects;
+    pendingEffects = [];
+    for (const next of toRun) {
+      const prev = effects[next.index];
+      if (typeof prev?.cleanup === 'function') prev.cleanup();
+      effects[next.index] = {
+        deps: next.deps,
+        cleanup: next.effect() || undefined,
+      };
+    }
+  }
+
+  return {
+    react,
+    render(callback) {
+      hookIndex = 0;
+      const result = callback();
+      flushEffects();
+      return result;
+    },
+    cleanup() {
+      for (const effect of effects) {
+        if (typeof effect?.cleanup === 'function') effect.cleanup();
+      }
+    },
+  };
+}
+
+function installWindowHarness() {
+  const listeners = new Map();
+  const removedMenuBars = [];
+
+  const win = {
+    electron: {
+      removeMenuBar(extId) {
+        removedMenuBars.push(extId);
+      },
+      onExtensionPreferencesUpdated() {
+        return () => {};
+      },
+    },
+    addEventListener(type, listener) {
+      const next = listeners.get(type) || new Set();
+      next.add(listener);
+      listeners.set(type, next);
+    },
+    removeEventListener(type, listener) {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatchEvent(event) {
+      for (const listener of listeners.get(event.type) || []) {
+        listener(event);
+      }
+      return true;
+    },
+  };
+
+  globalThis.window = win;
+  globalThis.CustomEvent = class TestCustomEvent {
+    constructor(type, init = {}) {
+      this.type = type;
+      this.detail = init.detail;
+    }
+  };
+
+  return {
+    removedMenuBars,
+    restore() {
+      delete globalThis.window;
+      delete globalThis.CustomEvent;
+    },
+  };
+}
+
+function loadTsModule(filePath, stubs = {}) {
+  const resolvedPath = path.resolve(root, filePath);
+  const source = fs.readFileSync(resolvedPath, 'utf8');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      jsx: ts.JsxEmit.ReactJSX,
+      esModuleInterop: true,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    },
+    fileName: resolvedPath,
+  });
+
+  const module = { exports: {} };
+  const localRequire = (request) => {
+    if (request in stubs) return stubs[request];
+    if (request.startsWith('.')) {
+      const candidate = path.resolve(path.dirname(resolvedPath), request);
+      for (const suffix of ['', '.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.tsx']) {
+        const nextPath = `${candidate}${suffix}`;
+        if (fs.existsSync(nextPath) && fs.statSync(nextPath).isFile()) {
+          return loadTsModule(path.relative(root, nextPath), stubs);
+        }
+      }
+    }
+    return require(request);
+  };
+
+  vm.runInNewContext(transpiled.outputText, {
+    module,
+    exports: module.exports,
+    require: localRequire,
+    console,
+    window: globalThis.window,
+    CustomEvent: globalThis.CustomEvent,
+    Date,
+    Math,
+  }, { filename: resolvedPath });
+
+  return module.exports;
+}
+
+function makeBundle(extName, cmdName) {
+  return {
+    code: 'module.exports = function Command() { return null; }',
+    title: cmdName,
+    extName,
+    cmdName,
+    extensionName: extName,
+    commandName: cmdName,
+  };
+}
+
+function findEntry(entries, extName, cmdName) {
+  return entries.find((entry) => {
+    const entryExt = entry.bundle.extName || entry.bundle.extensionName;
+    const entryCmd = entry.bundle.cmdName || entry.bundle.commandName;
+    return entryExt === extName && entryCmd === cmdName;
+  });
+}
+
+function createMenuBarSubject() {
+  const windowHarness = installWindowHarness();
+  const reactHarness = createReactHookHarness();
+  const { useMenuBarExtensions } = loadTsModule('src/renderer/src/hooks/useMenuBarExtensions.ts', {
+    react: reactHarness.react,
+  });
+
+  let current = reactHarness.render(() => useMenuBarExtensions());
+
+  return {
+    get current() {
+      return current;
+    },
+    rerender() {
+      current = reactHarness.render(() => useMenuBarExtensions());
+      return current;
+    },
+    cleanup() {
+      reactHarness.cleanup();
+      windowHarness.restore();
+    },
+  };
+}
+
+test('menu-bar storage refresh behavior', async (t) => {
+  await t.test('emitted storage events keep extensionName compatibility and include command origin', () => {
+    const windowHarness = installWindowHarness();
+    const events = [];
+    globalThis.window.addEventListener('sc-extension-storage-changed', (event) => {
+      events.push(event.detail);
+    });
+
+    const { configureStorageEvents, emitExtensionStorageChanged } = loadTsModule(
+      'src/renderer/src/raycast-api/storage-events.ts'
+    );
+
+    configureStorageEvents({
+      getExtensionContext: () => ({
+        extensionName: 'Demo',
+        commandName: 'Menu',
+        commandMode: 'menu-bar',
+      }),
+    });
+    emitExtensionStorageChanged();
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].extensionName, 'Demo');
+    assert.equal(events[0].commandName, 'Menu');
+    assert.equal(events[0].commandMode, 'menu-bar');
+    windowHarness.restore();
+  });
+
+  await t.test('self-originated menu-bar storage writes do not remount the writer', () => {
+    const subject = createMenuBarSubject();
+    try {
+      subject.current.upsertMenuBarExtension(makeBundle('Demo', 'Menu'));
+      subject.rerender();
+      const before = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
+      assert.ok(before, 'menu-bar command should be mounted');
+
+      globalThis.window.dispatchEvent(
+        new CustomEvent('sc-extension-storage-changed', {
+          detail: {
+            extensionName: 'Demo',
+            commandName: 'Menu',
+            commandMode: 'menu-bar',
+          },
+        })
+      );
+      subject.rerender();
+
+      const after = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
+      assert.equal(after, before, 'the writer keeps its ExtensionView key');
+    } finally {
+      subject.cleanup();
+    }
+  });
+
+  await t.test('sibling menu-bar commands still remount for same-extension writes', () => {
+    const subject = createMenuBarSubject();
+    try {
+      subject.current.upsertMenuBarExtension(makeBundle('Demo', 'Writer'));
+      subject.current.upsertMenuBarExtension(makeBundle('Demo', 'Reader'));
+      subject.rerender();
+      const writerBefore = findEntry(subject.current.menuBarExtensions, 'Demo', 'Writer')?.key;
+      const readerBefore = findEntry(subject.current.menuBarExtensions, 'Demo', 'Reader')?.key;
+
+      globalThis.window.dispatchEvent(
+        new CustomEvent('sc-extension-storage-changed', {
+          detail: {
+            extensionName: 'Demo',
+            commandName: 'Writer',
+            commandMode: 'menu-bar',
+          },
+        })
+      );
+      subject.rerender();
+
+      const writerAfter = findEntry(subject.current.menuBarExtensions, 'Demo', 'Writer')?.key;
+      const readerAfter = findEntry(subject.current.menuBarExtensions, 'Demo', 'Reader')?.key;
+      assert.equal(writerAfter, writerBefore, 'writer is not remounted');
+      assert.notEqual(readerAfter, readerBefore, 'sibling command is refreshed');
+    } finally {
+      subject.cleanup();
+    }
+  });
+
+  await t.test('external storage updates without origin metadata still remount every command', () => {
+    const subject = createMenuBarSubject();
+    try {
+      subject.current.upsertMenuBarExtension(makeBundle('Demo', 'Menu'));
+      subject.rerender();
+      const before = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
+
+      globalThis.window.dispatchEvent(
+        new CustomEvent('sc-extension-storage-changed', {
+          detail: { extensionName: 'Demo' },
+        })
+      );
+      subject.rerender();
+
+      const after = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
+      assert.notEqual(after, before, 'external update refreshes the mounted command');
+    } finally {
+      subject.cleanup();
+    }
+  });
+});

--- a/src/renderer/src/hooks/useMenuBarExtensions.ts
+++ b/src/renderer/src/hooks/useMenuBarExtensions.ts
@@ -19,6 +19,7 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react';
 import type { ExtensionBundle } from '../../types/electron';
+import type { ExtensionStorageChangedDetail } from '../raycast-api/storage-events';
 
 export interface MenuBarEntry {
   key: string;
@@ -46,7 +47,13 @@ export interface UseMenuBarExtensionsReturn {
   hideMenuBarExtension: (bundle: Partial<ExtensionBundle>) => void;
   hideMenuBarExtensionsForExtension: (extensionName: string) => void;
   upsertMenuBarExtension: (bundle: ExtensionBundle, options?: { remount?: boolean }) => void;
-  remountMenuBarExtensionsForExtension: (extensionName: string) => void;
+  remountMenuBarExtensionsForExtension: (
+    extensionName: string,
+    options?: {
+      sourceCommandName?: string;
+      sourceCommandMode?: string;
+    }
+  ) => void;
 }
 
 export function useMenuBarExtensions(): UseMenuBarExtensionsReturn {
@@ -133,25 +140,35 @@ export function useMenuBarExtensions(): UseMenuBarExtensionsReturn {
     });
   }, [getMenuBarIdentity]);
 
-  const remountMenuBarExtensionsForExtension = useCallback((extensionName: string) => {
+  const remountMenuBarExtensionsForExtension = useCallback((
+    extensionName: string,
+    options?: {
+      sourceCommandName?: string;
+      sourceCommandMode?: string;
+    }
+  ) => {
     const normalized = (extensionName || '').trim();
     if (!normalized) return;
     const now = Date.now();
     const lastTs = menuBarRemountTimestampsRef.current[normalized] || 0;
     if (now - lastTs < 200) return;
-    menuBarRemountTimestampsRef.current[normalized] = now;
+    const sourceCommandName = (options?.sourceCommandName || '').trim();
+    const sourceCommandMode = (options?.sourceCommandMode || '').trim();
+    const skipSourceCommand = sourceCommandMode === 'menu-bar' && Boolean(sourceCommandName);
     setMenuBarExtensions((prev) => {
       let changed = false;
       const next = prev.map((entry) => {
         const entryExt = (entry.bundle.extName || entry.bundle.extensionName || '').trim();
         if (!entryExt || entryExt !== normalized) return entry;
+        const cmdName = (entry.bundle.cmdName || entry.bundle.commandName || '').trim();
+        if (skipSourceCommand && cmdName === sourceCommandName) return entry;
         changed = true;
-        const cmdName = entry.bundle.cmdName || entry.bundle.commandName || '';
         return {
           key: `${normalized}:${cmdName}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
           bundle: entry.bundle,
         };
       });
+      if (changed) menuBarRemountTimestampsRef.current[normalized] = now;
       return changed ? next : prev;
     });
   }, []);
@@ -163,10 +180,13 @@ export function useMenuBarExtensions(): UseMenuBarExtensionsReturn {
   // This matches Raycast behavior where menu-bar commands observe state changes quickly.
   useEffect(() => {
     const onStorageChanged = (event: Event) => {
-      const custom = event as CustomEvent<{ extensionName?: string }>;
+      const custom = event as CustomEvent<Partial<ExtensionStorageChangedDetail>>;
       const extensionName = (custom.detail?.extensionName || '').trim();
       if (!extensionName) return;
-      remountMenuBarExtensionsForExtension(extensionName);
+      remountMenuBarExtensionsForExtension(extensionName, {
+        sourceCommandName: custom.detail?.commandName,
+        sourceCommandMode: custom.detail?.commandMode,
+      });
     };
     window.addEventListener('sc-extension-storage-changed', onStorageChanged as EventListener);
     return () => {

--- a/src/renderer/src/raycast-api/hooks/use-local-storage.ts
+++ b/src/renderer/src/raycast-api/hooks/use-local-storage.ts
@@ -5,6 +5,7 @@
 
 import { useCallback, useState } from 'react';
 import { emitExtensionStorageChanged } from '../storage-events';
+import { getCurrentScopedExtensionContext } from '../context-scope-runtime';
 import { getScopedLocalStorageKeys, readScopedJsonState } from './storage-scope';
 
 export function useLocalStorage<T>(
@@ -17,6 +18,10 @@ export function useLocalStorage<T>(
   isLoading: boolean;
 } {
   const { scopedKey, legacyKeys } = getScopedLocalStorageKeys(key);
+  const currentContext = getCurrentScopedExtensionContext();
+  const storageEventExtensionName = currentContext.extensionName;
+  const storageEventCommandName = currentContext.commandName;
+  const storageEventCommandMode = currentContext.commandMode;
   const [value, setValueState] = useState<T | undefined>(() => {
     return readScopedJsonState(scopedKey, legacyKeys, initialValue);
   });
@@ -29,8 +34,12 @@ export function useLocalStorage<T>(
     } catch {
       // best-effort
     }
-    emitExtensionStorageChanged();
-  }, [scopedKey]);
+    emitExtensionStorageChanged({
+      extensionName: storageEventExtensionName,
+      commandName: storageEventCommandName,
+      commandMode: storageEventCommandMode,
+    });
+  }, [scopedKey, storageEventCommandMode, storageEventCommandName, storageEventExtensionName]);
 
   const removeValue = useCallback(async () => {
     setValueState(undefined);
@@ -42,8 +51,12 @@ export function useLocalStorage<T>(
     } catch {
       // best-effort
     }
-    emitExtensionStorageChanged();
-  }, [legacyKeys, scopedKey]);
+    emitExtensionStorageChanged({
+      extensionName: storageEventExtensionName,
+      commandName: storageEventCommandName,
+      commandMode: storageEventCommandMode,
+    });
+  }, [legacyKeys, scopedKey, storageEventCommandMode, storageEventCommandName, storageEventExtensionName]);
 
   return { value, setValue, removeValue, isLoading };
 }

--- a/src/renderer/src/raycast-api/storage-events.ts
+++ b/src/renderer/src/raycast-api/storage-events.ts
@@ -3,7 +3,17 @@
  * Purpose: Shared extension storage change event bridge.
  */
 
-type ExtensionCtx = { extensionName?: string };
+export type ExtensionStorageChangedDetail = {
+  extensionName: string;
+  commandName?: string;
+  commandMode?: string;
+};
+
+type ExtensionCtx = {
+  extensionName?: string;
+  commandName?: string;
+  commandMode?: string;
+};
 
 let getExtensionContextRef: () => ExtensionCtx = () => ({ extensionName: '' });
 
@@ -11,14 +21,21 @@ export function configureStorageEvents(deps: { getExtensionContext: () => Extens
   getExtensionContextRef = deps.getExtensionContext;
 }
 
-export function emitExtensionStorageChanged(): void {
+export function emitExtensionStorageChanged(origin?: Partial<ExtensionStorageChangedDetail>): void {
   try {
-    const extensionName = (getExtensionContextRef().extensionName || '').trim();
+    const context = getExtensionContextRef();
+    const extensionName = (origin?.extensionName || context.extensionName || '').trim();
     if (!extensionName) return;
+
+    const commandName = (origin?.commandName || context.commandName || '').trim();
+    const commandMode = (origin?.commandMode || context.commandMode || '').trim();
+    const detail: ExtensionStorageChangedDetail = { extensionName };
+    if (commandName) detail.commandName = commandName;
+    if (commandMode) detail.commandMode = commandMode;
 
     window.dispatchEvent(
       new CustomEvent('sc-extension-storage-changed', {
-        detail: { extensionName },
+        detail,
       })
     );
   } catch {


### PR DESCRIPTION
## Summary
- Add optional command-origin metadata to extension storage change events while preserving the existing `extensionName` detail for compatibility.
- Emit scoped command metadata from `useLocalStorage` so menu-bar storage writes can identify their originating command.
- Keep same-extension sibling/external refresh behavior, but skip the matching menu-bar writer so its hidden `ExtensionView` key does not churn on its own write.
- Add a focused hook-level regression harness for self-write, sibling-write, and external-update remount behavior.

## Metrics
Baseline before production edit:
- Command: `node scripts/test-menubar-storage-remounts.mjs`
- Result: failed 3 of 4 behavior subtests.
- Event detail: `extensionName` was present, `commandName`/`commandMode` were missing.
- Self-write: mounted writer key changed from `Demo:Menu:<ts>` to `Demo:Menu:<ts>:<random>`, proving a full remount.
- Sibling-write: writer key also changed, so the origin command remounted along with siblings.
- External update: full remount behavior already worked.

After this change:
- Command: `node scripts/test-menubar-storage-remounts.mjs`
- Result: 5 tests pass.
- Self-write: writer key changes avoided: 0.
- Sibling-write: writer key preserved, sibling key refreshed.
- External update without origin metadata: mounted command key refreshed as before.

## Validation
- `node scripts/test-menubar-storage-remounts.mjs`
- `pnpm test` (29 pass, 1 skipped live Electron test)
- `node scripts/check-i18n.mjs` (completed; existing Italian locale warnings remain: `settings.ai.whisper.vocabulary`, `settings.extensions.appSearchScope`)
- `pnpm exec tsc -p tsconfig.main.json`
- `pnpm exec vite build`
- Codex LSP diagnostics for touched files: no errors
- `pnpm exec tsc -p tsconfig.renderer.json --pretty false` still fails on existing repo-wide renderer errors outside this change, including `App.tsx`, `CameraExtension.tsx`, `LiquidGlassSurface.tsx`, launcher browser profile typing, i18n runtime circular type, and quicklink icon typing.

## Risk
Menu-bar commands that intentionally relied on a full self-remount after writing storage will now keep their current hidden runner mounted. Sibling commands and legacy/external events without command metadata still refresh with the previous full-remount behavior.