### PR TITLE
perf(raycast): improve abortable promise hook lifecycle

### DIFF
--- a/scripts/test-abortable-promise-hooks.mjs
+++ b/scripts/test-abortable-promise-hooks.mjs
@@ -1,0 +1,378 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+let activeHost = null;
+
+const fakeReact = {
+  useCallback: (...args) => activeHost.useCallback(...args),
+  useEffect: (...args) => activeHost.useEffect(...args),
+  useMemo: (...args) => activeHost.useMemo(...args),
+  useRef: (...args) => activeHost.useRef(...args),
+  useState: (...args) => activeHost.useState(...args),
+};
+
+const moduleCache = new Map();
+
+function loadTsModule(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  if (moduleCache.has(resolvedPath)) return moduleCache.get(resolvedPath).exports;
+
+  const source = fs.readFileSync(resolvedPath, 'utf8');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    },
+    fileName: resolvedPath,
+  });
+
+  const module = { exports: {} };
+  moduleCache.set(resolvedPath, module);
+  const localRequire = (request) => {
+    if (request === 'react') return fakeReact;
+    if (request.startsWith('.')) {
+      const candidate = path.resolve(path.dirname(resolvedPath), request);
+      for (const suffix of ['', '.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.tsx']) {
+        const nextPath = `${candidate}${suffix}`;
+        if (fs.existsSync(nextPath) && fs.statSync(nextPath).isFile()) {
+          if (nextPath.endsWith('.ts') || nextPath.endsWith('.tsx')) return loadTsModule(nextPath);
+          return require(nextPath);
+        }
+      }
+    }
+    return require(request);
+  };
+
+  const sandbox = {
+    AbortController,
+    Array,
+    console,
+    Date,
+    Error,
+    JSON,
+    Map,
+    Math,
+    module,
+    Object,
+    Promise,
+    queueMicrotask,
+    RegExp,
+    require: localRequire,
+    setTimeout,
+    clearTimeout,
+    String,
+    Symbol,
+    URL,
+    exports: module.exports,
+  };
+  vm.runInNewContext(transpiled.outputText, sandbox, { filename: resolvedPath });
+  return module.exports;
+}
+
+class HookHost {
+  constructor(renderHook) {
+    this.renderHook = renderHook;
+    this.hookIndex = 0;
+    this.hooks = [];
+    this.pendingEffects = [];
+    this.output = undefined;
+    this.isRendering = false;
+    this.isFlushingEffects = false;
+    this.needsRender = false;
+    this.unmounted = false;
+  }
+
+  render() {
+    if (this.unmounted) return this.output;
+    this.hookIndex = 0;
+    this.pendingEffects = [];
+    this.isRendering = true;
+    const previousHost = activeHost;
+    activeHost = this;
+    try {
+      this.output = this.renderHook();
+    } finally {
+      activeHost = previousHost;
+      this.isRendering = false;
+    }
+    this.flushEffects();
+    return this.output;
+  }
+
+  flushEffects() {
+    this.isFlushingEffects = true;
+    try {
+      for (const { index, effect } of this.pendingEffects) {
+        const record = this.hooks[index];
+        if (record.cleanup) record.cleanup();
+        const cleanup = effect();
+        record.cleanup = typeof cleanup === 'function' ? cleanup : undefined;
+      }
+    } finally {
+      this.isFlushingEffects = false;
+    }
+
+    if (this.needsRender && !this.unmounted) {
+      this.needsRender = false;
+      this.render();
+    }
+  }
+
+  scheduleRender() {
+    if (this.unmounted) return;
+    if (this.isRendering || this.isFlushingEffects) {
+      this.needsRender = true;
+      return;
+    }
+    this.render();
+  }
+
+  useState(initialValue) {
+    const index = this.hookIndex++;
+    if (!this.hooks[index]) {
+      this.hooks[index] = {
+        state: typeof initialValue === 'function' ? initialValue() : initialValue,
+      };
+    }
+    const setState = (nextValue) => {
+      const record = this.hooks[index];
+      const next = typeof nextValue === 'function' ? nextValue(record.state) : nextValue;
+      if (Object.is(record.state, next)) return;
+      record.state = next;
+      this.scheduleRender();
+    };
+    return [this.hooks[index].state, setState];
+  }
+
+  useRef(initialValue) {
+    const index = this.hookIndex++;
+    if (!this.hooks[index]) {
+      this.hooks[index] = { current: initialValue };
+    }
+    return this.hooks[index];
+  }
+
+  useEffect(effect, deps) {
+    const index = this.hookIndex++;
+    const record = this.hooks[index] || {};
+    const changed = !record.deps || !depsEqual(record.deps, deps);
+    this.hooks[index] = { ...record, deps };
+    if (changed) {
+      this.pendingEffects.push({ index, effect });
+    }
+  }
+
+  useCallback(callback, deps) {
+    return this.useMemo(() => callback, deps);
+  }
+
+  useMemo(factory, deps) {
+    const index = this.hookIndex++;
+    const record = this.hooks[index];
+    if (record && depsEqual(record.deps, deps)) return record.value;
+    const value = factory();
+    this.hooks[index] = { value, deps };
+    return value;
+  }
+
+  unmount() {
+    this.unmounted = true;
+    for (const record of this.hooks) {
+      if (record?.cleanup) {
+        record.cleanup();
+        record.cleanup = undefined;
+      }
+    }
+  }
+}
+
+function depsEqual(previousDeps, nextDeps) {
+  if (!previousDeps || !nextDeps || previousDeps.length !== nextDeps.length) return false;
+  return previousDeps.every((value, index) => Object.is(value, nextDeps[index]));
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function currentController(abortable) {
+  const controller = abortable.current;
+  assert.ok(controller instanceof AbortController, 'abortable.current should be an AbortController for each run');
+  return controller;
+}
+
+const { usePromise } = loadTsModule('src/renderer/src/raycast-api/hooks/use-promise.ts');
+const { useCachedPromise } = loadTsModule('src/renderer/src/raycast-api/hooks/use-cached-promise.ts');
+
+test('usePromise aborts the previous abortable run before revalidate starts another run', async () => {
+  const abortable = { current: null };
+  const controllers = [];
+  const pending = [];
+  const fn = () => {
+    controllers.push(currentController(abortable));
+    const run = deferred();
+    pending.push(run);
+    return run.promise;
+  };
+  const host = new HookHost(() => usePromise(fn, [], { abortable }));
+
+  host.render();
+  await flushAsync();
+  assert.equal(controllers.length, 1);
+
+  host.output.revalidate();
+  await flushAsync();
+
+  assert.equal(controllers.length, 2);
+  assert.equal(controllers[0].signal.aborted, true);
+  assert.notEqual(controllers[1], controllers[0]);
+  assert.equal(controllers[1].signal.aborted, false);
+
+  host.unmount();
+});
+
+test('useCachedPromise aborts the previous abortable run before revalidate starts another run', async () => {
+  const abortable = { current: null };
+  const controllers = [];
+  const pending = [];
+  const fn = () => {
+    controllers.push(currentController(abortable));
+    const run = deferred();
+    pending.push(run);
+    return run.promise;
+  };
+  const host = new HookHost(() => useCachedPromise(fn, [], { abortable }));
+
+  host.render();
+  await flushAsync();
+  assert.equal(controllers.length, 1);
+
+  host.output.revalidate();
+  await flushAsync();
+
+  assert.equal(controllers.length, 2);
+  assert.equal(controllers[0].signal.aborted, true);
+  assert.notEqual(controllers[1], controllers[0]);
+  assert.equal(controllers[1].signal.aborted, false);
+
+  host.unmount();
+});
+
+test('usePromise aborts active abortable work on unmount and clears the abortable ref', async () => {
+  const abortable = { current: null };
+  const controllers = [];
+  const fn = () => {
+    controllers.push(currentController(abortable));
+    return deferred().promise;
+  };
+  const host = new HookHost(() => usePromise(fn, [], { abortable }));
+
+  host.render();
+  await flushAsync();
+  host.unmount();
+
+  assert.equal(controllers.length, 1);
+  assert.equal(controllers[0].signal.aborted, true);
+  assert.equal(abortable.current, null);
+});
+
+test('useCachedPromise aborts active abortable work on unmount and clears the abortable ref', async () => {
+  const abortable = { current: null };
+  const controllers = [];
+  const fn = () => {
+    controllers.push(currentController(abortable));
+    return deferred().promise;
+  };
+  const host = new HookHost(() => useCachedPromise(fn, [], { abortable }));
+
+  host.render();
+  await flushAsync();
+  host.unmount();
+
+  assert.equal(controllers.length, 1);
+  assert.equal(controllers[0].signal.aborted, true);
+  assert.equal(abortable.current, null);
+});
+
+test('usePromise keeps the latest abortable result when an older aborted run resolves later', async () => {
+  const abortable = { current: null };
+  const pending = [];
+  const onDataCalls = [];
+  const fn = () => {
+    currentController(abortable);
+    const run = deferred();
+    pending.push(run);
+    return run.promise;
+  };
+  const host = new HookHost(() => usePromise(fn, [], { abortable, onData: (data) => onDataCalls.push(data) }));
+
+  host.render();
+  await flushAsync();
+  host.output.revalidate();
+  await flushAsync();
+
+  pending[1].resolve('latest');
+  await flushAsync();
+  assert.equal(host.output.data, 'latest');
+  assert.deepEqual(onDataCalls, ['latest']);
+
+  pending[0].resolve('stale');
+  await flushAsync();
+  assert.equal(host.output.data, 'latest');
+  assert.deepEqual(onDataCalls, ['latest']);
+
+  host.unmount();
+});
+
+test('useCachedPromise keeps the latest abortable result when an older aborted run resolves later', async () => {
+  const abortable = { current: null };
+  const pending = [];
+  const onDataCalls = [];
+  const fn = () => {
+    currentController(abortable);
+    const run = deferred();
+    pending.push(run);
+    return run.promise;
+  };
+  const host = new HookHost(() => useCachedPromise(fn, [], { abortable, onData: (data) => onDataCalls.push(data) }));
+
+  host.render();
+  await flushAsync();
+  host.output.revalidate();
+  await flushAsync();
+
+  pending[1].resolve('latest');
+  await flushAsync();
+  assert.equal(host.output.data, 'latest');
+  assert.deepEqual(onDataCalls, ['latest']);
+
+  pending[0].resolve('stale');
+  await flushAsync();
+  assert.equal(host.output.data, 'latest');
+  assert.deepEqual(onDataCalls, ['latest']);
+
+  host.unmount();
+});

--- a/src/renderer/src/raycast-api/hooks/use-cached-promise.ts
+++ b/src/renderer/src/raycast-api/hooks/use-cached-promise.ts
@@ -47,13 +47,8 @@ export function useCachedPromise<T>(
   const [isPaginated, setIsPaginated] = useState(false);
 
   const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const abortableRefRef = useRef<React.MutableRefObject<AbortController | null | undefined> | undefined>(undefined);
   const fnRef = useRef(fn);
   const argsRef = useRef(args || []);
   const optionsRef = useRef(options);
@@ -63,30 +58,68 @@ export function useCachedPromise<T>(
   optionsRef.current = options;
   runtimeCtxRef.current = snapshotExtensionContext();
 
+  const clearAbortController = useCallback((controller: AbortController) => {
+    const abortableRef = abortableRefRef.current;
+    if (abortableRef?.current === controller) {
+      abortableRef.current = null;
+    }
+    if (abortControllerRef.current === controller) {
+      abortControllerRef.current = null;
+      if (abortableRefRef.current === abortableRef) {
+        abortableRefRef.current = undefined;
+      }
+    }
+  }, []);
+
+  const abortCurrentRun = useCallback(() => {
+    const controller = abortControllerRef.current;
+    if (!controller) return;
+    controller.abort();
+    clearAbortController(controller);
+  }, [clearAbortController]);
+
+  const prepareAbortController = useCallback((abortable?: React.MutableRefObject<AbortController | null | undefined>) => {
+    abortCurrentRun();
+    if (!abortable) return null;
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    abortableRefRef.current = abortable;
+    abortable.current = controller;
+    return controller;
+  }, [abortCurrentRun]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      abortCurrentRun();
+    };
+  }, [abortCurrentRun]);
+
   const fetchPage = useCallback(async (pageNum: number, currentCursor?: string) => {
     const opts = optionsRef.current;
     if (opts?.execute === false || !mountedRef.current) return;
 
+    const runController = prepareAbortController(opts?.abortable);
+    const runCtx = runtimeCtxRef.current;
+    const isCurrentRun = () => !runController || abortControllerRef.current === runController;
+
     setIsLoading(true);
     setError(undefined);
 
-    if (opts?.abortable) {
-      const controller = new AbortController();
-      opts.abortable.current = controller;
-    }
-
-    withExtensionContext(runtimeCtxRef.current, () => {
+    withExtensionContext(runCtx, () => {
       opts?.onWillExecute?.(argsRef.current);
     });
 
     try {
-      const outerResult = withExtensionContext(runtimeCtxRef.current, () => fnRef.current(...argsRef.current));
+      const outerResult = withExtensionContext(runCtx, () => fnRef.current(...argsRef.current));
 
       if (typeof outerResult === 'function') {
         setIsPaginated(true);
         const paginationOptions = { page: pageNum, cursor: currentCursor, lastItem: undefined };
-        const innerResult = await withExtensionContext(runtimeCtxRef.current, () => outerResult(paginationOptions));
-        if (!mountedRef.current) return;
+        const innerResult = await withExtensionContext(runCtx, () => outerResult(paginationOptions));
+        if (!mountedRef.current || !isCurrentRun()) return;
 
         if (innerResult && typeof innerResult === 'object' && 'data' in innerResult) {
           const { data: pageData, hasMore: more, cursor: nextCursor } = innerResult;
@@ -96,14 +129,14 @@ export function useCachedPromise<T>(
           if (pageNum === 0) {
             setAccumulatedData(Array.isArray(pageData) ? pageData : []);
           } else {
-            setAccumulatedData((prev) => {
+            setAccumulatedData((prev: any) => {
               const prevArr = Array.isArray(prev) ? prev : [];
               const newArr = Array.isArray(pageData) ? pageData : [];
               return [...prevArr, ...newArr];
             });
           }
 
-          withExtensionContext(runtimeCtxRef.current, () => {
+          withExtensionContext(runCtx, () => {
             opts?.onData?.((innerResult as any).data);
           });
         } else {
@@ -112,7 +145,7 @@ export function useCachedPromise<T>(
         }
       } else {
         const result = await outerResult;
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || !isCurrentRun()) return;
 
         if (result && typeof result === 'object' && 'data' in result && 'hasMore' in result) {
           setIsPaginated(true);
@@ -123,35 +156,40 @@ export function useCachedPromise<T>(
           if (pageNum === 0) {
             setAccumulatedData(Array.isArray(pageData) ? pageData : []);
           } else {
-            setAccumulatedData((prev) => {
+            setAccumulatedData((prev: any) => {
               const prevArr = Array.isArray(prev) ? prev : [];
               const newArr = Array.isArray(pageData) ? pageData : [];
               return [...prevArr, ...newArr];
             });
           }
 
-          withExtensionContext(runtimeCtxRef.current, () => {
+          withExtensionContext(runCtx, () => {
             opts?.onData?.(pageData as T);
           });
         } else {
           setAccumulatedData(result as any);
           setHasMore(false);
-          withExtensionContext(runtimeCtxRef.current, () => {
+          withExtensionContext(runCtx, () => {
             opts?.onData?.(result as T);
           });
         }
       }
     } catch (err) {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || !isCurrentRun()) return;
       const e = err instanceof Error ? err : new Error(String(err));
       setError(e);
-      withExtensionContext(runtimeCtxRef.current, () => {
+      withExtensionContext(runCtx, () => {
         opts?.onError?.(e);
       });
     } finally {
-      if (mountedRef.current) setIsLoading(false);
+      if (mountedRef.current && isCurrentRun()) {
+        setIsLoading(false);
+      }
+      if (runController) {
+        clearAbortController(runController);
+      }
     }
-  }, []);
+  }, [prepareAbortController, clearAbortController]);
 
   const argsKey = JSON.stringify(args || []);
   useEffect(() => {

--- a/src/renderer/src/raycast-api/hooks/use-promise.ts
+++ b/src/renderer/src/raycast-api/hooks/use-promise.ts
@@ -49,51 +49,98 @@ export function usePromise<T>(
   const [error, setError] = useState<Error | undefined>(undefined);
 
   const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const abortableRefRef = useRef<React.MutableRefObject<AbortController | null | undefined> | undefined>(undefined);
 
   const stableArgs = useStableArgs(args || []);
 
   const fnRef = useRef(fn);
   const argsRef = useRef(stableArgs);
+  const optionsRef = useRef(options);
   const runtimeCtxRef = useRef<ExtensionContextSnapshot>(snapshotExtensionContext());
   fnRef.current = fn;
   argsRef.current = stableArgs;
+  optionsRef.current = options;
   runtimeCtxRef.current = snapshotExtensionContext();
 
+  const clearAbortController = useCallback((controller: AbortController) => {
+    const abortableRef = abortableRefRef.current;
+    if (abortableRef?.current === controller) {
+      abortableRef.current = null;
+    }
+    if (abortControllerRef.current === controller) {
+      abortControllerRef.current = null;
+      if (abortableRefRef.current === abortableRef) {
+        abortableRefRef.current = undefined;
+      }
+    }
+  }, []);
+
+  const abortCurrentRun = useCallback(() => {
+    const controller = abortControllerRef.current;
+    if (!controller) return;
+    controller.abort();
+    clearAbortController(controller);
+  }, [clearAbortController]);
+
+  const prepareAbortController = useCallback((abortable?: React.MutableRefObject<AbortController | null | undefined>) => {
+    abortCurrentRun();
+    if (!abortable) return null;
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    abortableRefRef.current = abortable;
+    abortable.current = controller;
+    return controller;
+  }, [abortCurrentRun]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      abortCurrentRun();
+    };
+  }, [abortCurrentRun]);
+
   const execute = useCallback(() => {
-    if (options?.execute === false || !mountedRef.current) return;
+    const opts = optionsRef.current;
+    if (opts?.execute === false || !mountedRef.current) return;
+
+    const runController = prepareAbortController(opts?.abortable);
+    const runCtx = runtimeCtxRef.current;
+    const isCurrentRun = () => !runController || abortControllerRef.current === runController;
 
     setIsLoading(true);
     setError(undefined);
-    withExtensionContext(runtimeCtxRef.current, () => {
-      options?.onWillExecute?.(argsRef.current);
+    withExtensionContext(runCtx, () => {
+      opts?.onWillExecute?.(argsRef.current);
     });
 
     Promise.resolve()
-      .then(() => withExtensionContext(runtimeCtxRef.current, () => fnRef.current(...argsRef.current)))
+      .then(() => withExtensionContext(runCtx, () => fnRef.current(...argsRef.current)))
       .then((result) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || !isCurrentRun()) return;
         setData(result);
         setIsLoading(false);
-        withExtensionContext(runtimeCtxRef.current, () => {
-          options?.onData?.(result);
+        withExtensionContext(runCtx, () => {
+          opts?.onData?.(result);
         });
       })
       .catch((err) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || !isCurrentRun()) return;
         const e = err instanceof Error ? err : new Error(String(err));
         setError(e);
         setIsLoading(false);
-        withExtensionContext(runtimeCtxRef.current, () => {
-          options?.onError?.(e);
+        withExtensionContext(runCtx, () => {
+          opts?.onError?.(e);
         });
+      })
+      .finally(() => {
+        if (runController) {
+          clearAbortController(runController);
+        }
       });
-  }, [options?.execute]);
+  }, [options?.execute, prepareAbortController, clearAbortController]);
 
   useEffect(() => {
     execute();


### PR DESCRIPTION
## Summary
- Add real AbortController lifecycle handling to usePromise and useCachedPromise when callers pass options.abortable.
- Abort the current controller before starting a new run, abort active work on unmount, and clear abortable refs only when they still point at the matching run.
- Ignore late results/errors from older abortable runs so an aborted stale promise cannot overwrite the latest successful result.
- Add focused regression coverage for abort-on-revalidate, abort-on-unmount, and latest-result behavior across both hooks.

## Root Cause
`usePromise` accepted `abortable` but never created or published an `AbortController`. `useCachedPromise` created a controller for each run, but did not abort the previous controller, abort on unmount, clear refs, or guard against stale completions after a newer run started.

## Before / After Evidence
- Before: `node --test scripts/test-abortable-promise-hooks.mjs` failed 6/6 against the unmodified hooks. `usePromise` never exposed a controller; `useCachedPromise` left previous/unmounted controllers un-aborted and allowed stale data to overwrite latest data.
- After: `node --test scripts/test-abortable-promise-hooks.mjs` passes 6/6.

## Checks
- `node --test scripts/test-abortable-promise-hooks.mjs`
- `pnpm test`
- `pnpm run check:i18n` (exits 0; reports pre-existing Italian locale gaps for `settings.ai.whisper.vocabulary` and `settings.extensions.appSearchScope`)
- `pnpm run build:main`
- `pnpm run build:renderer`
- Codex LSP diagnostics on both changed hook files: no errors
- `git diff --check`

## Risks
- Abortable hook callers may observe `abortable.current` returning to `null` after the active run settles or unmounts; this matches the controller ownership lifecycle and avoids retaining stale controllers.
- Non-abortable calls intentionally keep existing behavior, including legacy race semantics.
