### PR TITLE
perf(inline-args): coalesce settings writes

### DIFF
--- a/scripts/test-inline-args-write-coalesce.mjs
+++ b/scripts/test-inline-args-write-coalesce.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+
+const bundledPreferences = await build({
+  entryPoints: ['src/renderer/src/utils/extension-preferences.ts'],
+  bundle: true,
+  write: false,
+  format: 'esm',
+  platform: 'browser',
+  logLevel: 'silent',
+});
+
+const bundledPreferencesUrl =
+  'data:text/javascript;base64,' + Buffer.from(bundledPreferences.outputFiles[0].text).toString('base64');
+
+let moduleCounter = 0;
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function copyPayload(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function loadPreferencesWithMocks() {
+  const storage = new Map();
+  const commandArgumentWrites = [];
+
+  globalThis.localStorage = {
+    getItem: (key) => (storage.has(key) ? storage.get(key) : null),
+    setItem: (key, value) => {
+      storage.set(key, String(value));
+    },
+    removeItem: (key) => {
+      storage.delete(key);
+    },
+    key: (index) => Array.from(storage.keys())[index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  };
+  globalThis.window = {
+    electron: {
+      saveExtensionCommandArguments: async (args) => {
+        commandArgumentWrites.push(copyPayload(args));
+        return {};
+      },
+      saveExtensionPreferences: async (args) => {
+        return {};
+      },
+    },
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    dispatchEvent: () => true,
+  };
+  globalThis.CustomEvent = class CustomEvent {
+    constructor(type, init) {
+      this.type = type;
+      this.detail = init?.detail;
+    }
+  };
+
+  moduleCounter += 1;
+  const preferences = await import(`${bundledPreferencesUrl}#test-${moduleCounter}`);
+  return { preferences, storage, commandArgumentWrites };
+}
+
+test('inline command argument settings mirror coalesces rapid writes', async () => {
+  const { preferences, storage, commandArgumentWrites } = await loadPreferencesWithMocks();
+  const key = preferences.getCmdArgsKey('coalesce-extension', 'no-view-command');
+  const values = ['s', 'se', 'sea', 'sear', 'searc', 'search', 'search ', 'search t', 'search te', 'search tex', 'search text'];
+
+  for (const value of values) {
+    preferences.writeJsonObject(
+      key,
+      { query: value },
+      { commandArgumentSettingsSync: 'debounced' }
+    );
+  }
+
+  assert.equal(JSON.parse(storage.get(key)).query, 'search text');
+  assert.equal(commandArgumentWrites.length, 0);
+
+  await wait(preferences.COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS + 50);
+
+  assert.equal(commandArgumentWrites.length, 1);
+  assert.deepEqual(commandArgumentWrites[0], {
+    extName: 'coalesce-extension',
+    cmdName: 'no-view-command',
+    values: { query: 'search text' },
+  });
+});
+
+test('launch flush writes pending inline command arguments immediately once', async () => {
+  const { preferences, commandArgumentWrites } = await loadPreferencesWithMocks();
+  const key = preferences.getCmdArgsKey('flush-extension', 'no-view-command');
+
+  preferences.writeJsonObject(
+    key,
+    { query: 'stale' },
+    { commandArgumentSettingsSync: 'debounced' }
+  );
+  preferences.writeJsonObject(
+    key,
+    { query: 'fresh at launch' },
+    { commandArgumentSettingsSync: 'debounced' }
+  );
+
+  await preferences.flushCommandArgumentSettingsSync(key);
+
+  assert.equal(commandArgumentWrites.length, 1);
+  assert.deepEqual(commandArgumentWrites[0], {
+    extName: 'flush-extension',
+    cmdName: 'no-view-command',
+    values: { query: 'fresh at launch' },
+  });
+
+  await wait(preferences.COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS + 50);
+  assert.equal(commandArgumentWrites.length, 1);
+});
+
+test('immediate command argument writes cancel pending debounced settings sync', async () => {
+  const { preferences, commandArgumentWrites } = await loadPreferencesWithMocks();
+  const key = preferences.getCmdArgsKey('submit-extension', 'no-view-command');
+
+  preferences.writeJsonObject(
+    key,
+    { query: 'pending inline value' },
+    { commandArgumentSettingsSync: 'debounced' }
+  );
+  preferences.writeJsonObject(key, { query: 'submitted value' });
+
+  assert.equal(commandArgumentWrites.length, 1);
+  assert.deepEqual(commandArgumentWrites[0], {
+    extName: 'submit-extension',
+    cmdName: 'no-view-command',
+    values: { query: 'submitted value' },
+  });
+
+  await wait(preferences.COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS + 50);
+  assert.equal(commandArgumentWrites.length, 1);
+});

--- a/src/renderer/src/hooks/useLauncherCommandExecution.ts
+++ b/src/renderer/src/hooks/useLauncherCommandExecution.ts
@@ -3,6 +3,7 @@ import type React from 'react';
 import type { CommandInfo, ExtensionBundle, QuickLinkDynamicField } from '../../types/electron';
 import { LAST_EXT_KEY } from '../utils/constants';
 import {
+  flushCommandArgumentSettingsSync,
   getCmdArgsKey,
   getScriptCmdArgsKey,
   hydrateExtensionBundlePreferences,
@@ -266,10 +267,13 @@ export function useLauncherCommandExecution(
         };
 
         if (Object.keys(inlineArguments).length > 0 && command.mode === 'no-view') {
+          const commandArgsKey = getCmdArgsKey(extName, cmdName);
           writeJsonObject(
-            getCmdArgsKey(extName, cmdName),
-            { ...((hydratedWithInlineArguments as any).launchArguments || {}) }
+            commandArgsKey,
+            { ...((hydratedWithInlineArguments as any).launchArguments || {}) },
+            { commandArgumentSettingsSync: 'debounced' }
           );
+          await flushCommandArgumentSettingsSync(commandArgsKey);
         }
 
         if (shouldOpenCommandSetup(hydratedWithInlineArguments)) {

--- a/src/renderer/src/hooks/useLauncherInlineArguments.ts
+++ b/src/renderer/src/hooks/useLauncherInlineArguments.ts
@@ -272,7 +272,11 @@ export function useLauncherInlineArguments({
           [argumentName]: value,
         };
         if (extensionIdentity && command.mode === 'no-view') {
-          writeJsonObject(getCmdArgsKey(extensionIdentity.extName, extensionIdentity.cmdName), nextCommandValues);
+          writeJsonObject(
+            getCmdArgsKey(extensionIdentity.extName, extensionIdentity.cmdName),
+            nextCommandValues,
+            { commandArgumentSettingsSync: 'debounced' }
+          );
         }
         return {
           ...prev,

--- a/src/renderer/src/utils/extension-preferences.ts
+++ b/src/renderer/src/utils/extension-preferences.ts
@@ -41,17 +41,120 @@ function writeLocalJsonObject(key: string, value: Record<string, any>) {
   localStorage.setItem(key, JSON.stringify(value));
 }
 
-export function writeJsonObject(key: string, value: Record<string, any>) {
+export const COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS = 250;
+
+type CommandArgumentSettingsSyncMode = 'immediate' | 'debounced';
+
+type WriteJsonObjectOptions = {
+  commandArgumentSettingsSync?: CommandArgumentSettingsSyncMode;
+};
+
+type TimerHandle = number | ReturnType<typeof setTimeout>;
+
+type PendingCommandArgumentSettingsSync = {
+  extName: string;
+  cmdName: string;
+  values: Record<string, any>;
+  timer: TimerHandle | null;
+};
+
+const pendingCommandArgumentSettingsSyncs = new Map<string, PendingCommandArgumentSettingsSync>();
+
+function parseCommandArgumentsStorageKey(key: string): { extName: string; cmdName: string } | null {
+  if (!key.startsWith(CMD_ARGS_KEY_PREFIX)) return null;
+  const slug = key.slice(CMD_ARGS_KEY_PREFIX.length);
+  const slash = slug.indexOf('/');
+  if (slash <= 0) return null;
+  const extName = slug.slice(0, slash);
+  const cmdName = slug.slice(slash + 1);
+  if (!extName || !cmdName) return null;
+  return { extName, cmdName };
+}
+
+function cloneStoragePayload(value: Record<string, any>): Record<string, any> {
+  return { ...value };
+}
+
+function setCommandArgumentSettingsSyncTimer(callback: () => void): TimerHandle {
+  if (typeof window !== 'undefined' && typeof window.setTimeout === 'function') {
+    return window.setTimeout(callback, COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS);
+  }
+  return setTimeout(callback, COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS);
+}
+
+function clearCommandArgumentSettingsSyncTimer(timer: TimerHandle): void {
+  if (typeof window !== 'undefined' && typeof window.clearTimeout === 'function') {
+    window.clearTimeout(timer as number);
+    return;
+  }
+  clearTimeout(timer as ReturnType<typeof setTimeout>);
+}
+
+async function saveCommandArgumentsToSettings(
+  extName: string,
+  cmdName: string,
+  values: Record<string, any>
+): Promise<void> {
+  try {
+    const electron = typeof window !== 'undefined' ? window.electron : undefined;
+    await electron?.saveExtensionCommandArguments?.({ extName, cmdName, values });
+  } catch {
+    // best-effort — sync failure must not break local persistence
+  }
+}
+
+function cancelPendingCommandArgumentSettingsSync(key: string): void {
+  const pending = pendingCommandArgumentSettingsSyncs.get(key);
+  if (!pending) return;
+  if (pending.timer !== null) {
+    clearCommandArgumentSettingsSyncTimer(pending.timer);
+  }
+  pendingCommandArgumentSettingsSyncs.delete(key);
+}
+
+function queueCommandArgumentSettingsSync(key: string, value: Record<string, any>): void {
+  const parsed = parseCommandArgumentsStorageKey(key);
+  if (!parsed) return;
+  cancelPendingCommandArgumentSettingsSync(key);
+  const pending: PendingCommandArgumentSettingsSync = {
+    ...parsed,
+    values: cloneStoragePayload(value),
+    timer: null,
+  };
+  pending.timer = setCommandArgumentSettingsSyncTimer(() => {
+    void flushCommandArgumentSettingsSync(key);
+  });
+  pendingCommandArgumentSettingsSyncs.set(key, pending);
+}
+
+export async function flushCommandArgumentSettingsSync(key?: string): Promise<void> {
+  const keys = key ? [key] : Array.from(pendingCommandArgumentSettingsSyncs.keys());
+  await Promise.all(keys.map(async (pendingKey) => {
+    const pending = pendingCommandArgumentSettingsSyncs.get(pendingKey);
+    if (!pending) return;
+    if (pending.timer !== null) {
+      clearCommandArgumentSettingsSyncTimer(pending.timer);
+    }
+    pendingCommandArgumentSettingsSyncs.delete(pendingKey);
+    await saveCommandArgumentsToSettings(pending.extName, pending.cmdName, pending.values);
+  }));
+}
+
+export function writeJsonObject(key: string, value: Record<string, any>, options?: WriteJsonObjectOptions) {
   writeLocalJsonObject(key, value);
   // Mirror extension preferences and command arguments into the synced
   // settings.json so they propagate to other Macs. localStorage stays
   // the synchronous read cache; this is best-effort fire-and-forget.
   // Script-command args (sc-script-cmd-args:) and the hidden-menubar key
   // are intentionally not synced.
-  syncExtensionStorageKeyToSettings(key, value);
+  syncExtensionStorageKeyToSettings(key, value, options);
 }
 
-function syncExtensionStorageKeyToSettings(key: string, value: Record<string, any>): void {
+function syncExtensionStorageKeyToSettings(
+  key: string,
+  value: Record<string, any>,
+  options?: WriteJsonObjectOptions
+): void {
   try {
     if (key.startsWith(EXT_PREFS_KEY_PREFIX)) {
       const extName = key.slice(EXT_PREFS_KEY_PREFIX.length);
@@ -69,12 +172,14 @@ function syncExtensionStorageKeyToSettings(key: string, value: Record<string, an
       return;
     }
     if (key.startsWith(CMD_ARGS_KEY_PREFIX)) {
-      const slug = key.slice(CMD_ARGS_KEY_PREFIX.length);
-      const slash = slug.indexOf('/');
-      if (slash <= 0) return;
-      const extName = slug.slice(0, slash);
-      const cmdName = slug.slice(slash + 1);
-      void window.electron?.saveExtensionCommandArguments?.({ extName, cmdName, values: value });
+      const parsed = parseCommandArgumentsStorageKey(key);
+      if (!parsed) return;
+      if (options?.commandArgumentSettingsSync === 'debounced') {
+        queueCommandArgumentSettingsSync(key, value);
+        return;
+      }
+      cancelPendingCommandArgumentSettingsSync(key);
+      void saveCommandArgumentsToSettings(parsed.extName, parsed.cmdName, value);
       return;
     }
   } catch {


### PR DESCRIPTION
## Summary
- Add an opt-in debounced settings mirror for `sc-cmd-args:` writes while keeping `localStorage` updates synchronous.
- Route no-view inline argument typing through the debounced path so rapid keystrokes coalesce before IPC/settings persistence.
- Flush the pending command-argument mirror before no-view launch so the final argument payload is persisted before the command is queued.
- Add focused regression coverage for coalescing, launch flush, and immediate submit-style writes canceling pending debounced sync.

## Root Cause
`useLauncherInlineArguments` called `writeJsonObject(getCmdArgsKey(...), values)` on every no-view inline argument change. `writeJsonObject` immediately mirrored `sc-cmd-args:` keys through `saveExtensionCommandArguments`, so every keystroke could trigger a settings-store save and broadcast.

## Before / After Evidence
Baseline before production edit, using a Node/esbuild probe against the real bundled `extension-preferences.ts` with 11 rapid `sc-cmd-args:` updates:
- Before: 11 keystrokes produced 11 settings-mirror writes in 1.7 ms; `localStorage` immediately held `search text`.
- After: 11 keystrokes produced 0 immediate settings writes and 1 coalesced settings write after the 250 ms debounce window, measured at 301.8 ms total; `localStorage` still immediately held `search text`.

Focused regression coverage:
- Rapid inline-style writes coalesce to one `saveExtensionCommandArguments` call with the final value.
- `flushCommandArgumentSettingsSync(key)` writes the latest pending value immediately and avoids a later duplicate timer write.
- An immediate command-argument write cancels any pending debounced write for that key.

## Validation
- `node --test scripts/test-inline-args-write-coalesce.mjs`
- `node --test 'scripts/test-*.mjs'` (27 pass, 1 skipped live Electron test)
- `pnpm run build:renderer`
- `node scripts/check-i18n.mjs` (completed; existing Italian locale gaps remain: `settings.ai.whisper.vocabulary`, `settings.extensions.appSearchScope`)
- Codex LSP diagnostics for touched TypeScript files: no errors
- `git diff --cached --check`
- `pnpm exec tsc -p tsconfig.renderer.json --noEmit` still fails on existing repo-wide renderer errors outside this change, including `App.tsx`, `CameraExtension.tsx`, `LiquidGlassSurface.tsx`, launcher browser profile typing, i18n runtime circular type, Raycast API typing, and quicklink icon typing.

## Risks
- The settings mirror for no-view inline argument typing is now delayed by up to 250 ms unless launch/submit flushes it first; `localStorage` and UI state remain immediate.
- The debounce is scoped to callers that opt in for command-argument keys. Existing preference writes, script argument writes, and normal command argument submit writes remain immediate by default.
