### PR TITLE
perf(extension): reduce sync IPC in extension facades

### DIFF
--- a/scripts/test-extension-sync-facade.mjs
+++ b/scripts/test-extension-sync-facade.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+
+import assert from 'assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createRequire } from 'module';
+import { performance } from 'perf_hooks';
+import vm from 'vm';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+const ROOT = process.cwd();
+const EXTENSION_VIEW_PATH = path.join(ROOT, 'src/renderer/src/ExtensionView.tsx');
+const SYNC_METHODS = ['execCommandSync', 'fileExistsSync', 'readFileSync', 'statSync'];
+
+function parseArgs() {
+  const args = new Set(process.argv.slice(2));
+  const modeArg = process.argv.find((arg) => arg.startsWith('--mode=')) || '--mode=both';
+  const mode = modeArg.slice('--mode='.length);
+  if (!['fallback', 'node', 'both'].includes(mode)) {
+    throw new Error(`Unsupported --mode value: ${mode}`);
+  }
+  return {
+    mode,
+    assertNodeDirect: !args.has('--report-only') || args.has('--assert-node-direct'),
+  };
+}
+
+function createLocalStorage() {
+  const store = new Map();
+  return {
+    get length() {
+      return store.size;
+    },
+    key(index) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    getItem(key) {
+      return store.has(String(key)) ? store.get(String(key)) : null;
+    },
+    setItem(key, value) {
+      store.set(String(key), String(value));
+    },
+    removeItem(key) {
+      store.delete(String(key));
+    },
+    clear() {
+      store.clear();
+    },
+  };
+}
+
+function createSyncIpcProbe() {
+  const entries = [];
+  const counts = Object.fromEntries(SYNC_METHODS.map((name) => [name, 0]));
+  const timeMs = Object.fromEntries(SYNC_METHODS.map((name) => [name, 0]));
+
+  function record(name, fn) {
+    const started = performance.now();
+    try {
+      return fn();
+    } finally {
+      const elapsed = performance.now() - started;
+      counts[name] += 1;
+      timeMs[name] += elapsed;
+      entries.push({ name, elapsedMs: elapsed });
+    }
+  }
+
+  function snapshot() {
+    return {
+      counts: { ...counts },
+      timeMs: { ...timeMs },
+      totalCount: Object.values(counts).reduce((sum, value) => sum + value, 0),
+      totalTimeMs: Object.values(timeMs).reduce((sum, value) => sum + value, 0),
+    };
+  }
+
+  function delta(before) {
+    const after = snapshot();
+    const deltaCounts = {};
+    const deltaTimeMs = {};
+    for (const name of SYNC_METHODS) {
+      deltaCounts[name] = after.counts[name] - before.counts[name];
+      deltaTimeMs[name] = after.timeMs[name] - before.timeMs[name];
+    }
+    return {
+      counts: deltaCounts,
+      timeMs: deltaTimeMs,
+      totalCount: Object.values(deltaCounts).reduce((sum, value) => sum + value, 0),
+      totalTimeMs: Object.values(deltaTimeMs).reduce((sum, value) => sum + value, 0),
+    };
+  }
+
+  return { entries, record, snapshot, delta };
+}
+
+function statPayload(filePath) {
+  const stat = fs.statSync(filePath);
+  return {
+    exists: true,
+    isDirectory: stat.isDirectory(),
+    isFile: stat.isFile(),
+    size: stat.size,
+    mode: stat.mode,
+    uid: stat.uid,
+    gid: stat.gid,
+    dev: stat.dev,
+    ino: stat.ino,
+    nlink: stat.nlink,
+    atimeMs: stat.atimeMs,
+    mtimeMs: stat.mtimeMs,
+    ctimeMs: stat.ctimeMs,
+    birthtimeMs: stat.birthtimeMs,
+  };
+}
+
+function createElectronFacade(probe) {
+  return {
+    execCommandSync(command, args = [], options = {}) {
+      return probe.record('execCommandSync', () => {
+        if (command === '/bin/ls' && args[0] === '-A1') {
+          return {
+            stdout: fs.readdirSync(args[1]).join('\n'),
+            stderr: '',
+            exitCode: 0,
+          };
+        }
+        const childProcess = require('child_process');
+        const result = childProcess.spawnSync(command, args, {
+          shell: options.shell ?? false,
+          env: { ...process.env, ...options.env },
+          cwd: options.cwd || process.cwd(),
+          input: options.input,
+          encoding: 'utf8',
+        });
+        return {
+          stdout: result.stdout || '',
+          stderr: result.stderr || '',
+          exitCode: typeof result.status === 'number' ? result.status : result.error ? 1 : 0,
+        };
+      });
+    },
+    fileExistsSync(filePath) {
+      return probe.record('fileExistsSync', () => fs.existsSync(filePath));
+    },
+    readFileSync(filePath) {
+      return probe.record('readFileSync', () => {
+        try {
+          return { data: fs.readFileSync(filePath, 'utf8'), error: null };
+        } catch (error) {
+          return { data: null, error: error instanceof Error ? error.message : String(error) };
+        }
+      });
+    },
+    statSync(filePath) {
+      return probe.record('statSync', () => {
+        try {
+          return statPayload(filePath);
+        } catch {
+          return { exists: false, isDirectory: false, isFile: false, size: 0 };
+        }
+      });
+    },
+  };
+}
+
+function extractFsFacadeSource() {
+  const source = fs.readFileSync(EXTENSION_VIEW_PATH, 'utf8');
+  const start = source.indexOf('const _bufferMarker');
+  const end = source.indexOf('// ── path stub', start);
+  assert.notEqual(start, -1, 'Could not locate Buffer/fs facade start marker');
+  assert.notEqual(end, -1, 'Could not locate fs facade end marker');
+  return source.slice(start, end);
+}
+
+function loadFsFacade({ nodeAvailable, electron, localStorage }) {
+  const source = `
+    const USE_REAL_NODE_BUILTINS = ${nodeAvailable ? 'true' : 'false'};
+    const _realNodeRequire = ${nodeAvailable ? '__REAL_NODE_REQUIRE' : 'undefined'};
+    const _realNodeProcess = ${nodeAvailable ? '__REAL_NODE_PROCESS' : 'undefined'};
+    const noop = () => {};
+    const noopAsync = (..._args) => Promise.resolve();
+    const noopCb = (...args) => {
+      const cb = args[args.length - 1];
+      if (typeof cb === 'function') cb(null);
+    };
+    ${extractFsFacadeSource()}
+    globalThis.__extensionSyncFacadeHarness = { fsStub, commandPathCache };
+  `;
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: EXTENSION_VIEW_PATH,
+  });
+  const sandbox = {
+    __REAL_NODE_REQUIRE: nodeAvailable ? require : undefined,
+    __REAL_NODE_PROCESS: nodeAvailable ? process : undefined,
+    console,
+    localStorage,
+    window: {
+      electron,
+      __scNodeRequire: nodeAvailable ? require : undefined,
+    },
+    performance,
+    TextEncoder,
+    TextDecoder,
+    URL,
+    Uint8Array,
+    ArrayBuffer,
+    DataView,
+    Blob: globalThis.Blob,
+    File: globalThis.File,
+    ReadableStream: globalThis.ReadableStream,
+    WritableStream: globalThis.WritableStream,
+    TransformStream: globalThis.TransformStream,
+    atob: (value) => Buffer.from(value, 'base64').toString('binary'),
+    btoa: (value) => Buffer.from(value, 'binary').toString('base64'),
+    setTimeout,
+    clearTimeout,
+    queueMicrotask,
+    Promise,
+    Date,
+    Error,
+    Map,
+    Set,
+    Symbol,
+    Object,
+    Array,
+    String,
+    Number,
+    Boolean,
+    RegExp,
+    Math,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(transpiled.outputText, sandbox, { filename: EXTENSION_VIEW_PATH });
+  return sandbox.__extensionSyncFacadeHarness.fsStub;
+}
+
+function writeFixtureTree() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'supercmd-extension-sync-facade-'));
+  const nestedDir = path.join(dir, 'nested');
+  fs.mkdirSync(nestedDir);
+  fs.writeFileSync(path.join(dir, 'real.txt'), 'real text', 'utf8');
+  fs.writeFileSync(path.join(dir, 'shadow.txt'), 'real shadow', 'utf8');
+  fs.writeFileSync(path.join(nestedDir, 'child.txt'), 'child text', 'utf8');
+  return dir;
+}
+
+function runScenario(mode) {
+  const probe = createSyncIpcProbe();
+  const localStorage = createLocalStorage();
+  const electron = createElectronFacade(probe);
+  const tmpDir = writeFixtureTree();
+  const fsStub = loadFsFacade({
+    nodeAvailable: mode === 'node',
+    electron,
+    localStorage,
+  });
+
+  try {
+    const realFile = path.join(tmpDir, 'real.txt');
+    const shadowFile = path.join(tmpDir, 'shadow.txt');
+    const virtualFile = path.join(tmpDir, 'virtual.txt');
+
+    fsStub.writeFileSync(shadowFile, 'virtual shadow');
+    fsStub.writeFileSync(virtualFile, 'virtual only');
+
+    const beforeVirtual = probe.snapshot();
+    assert.equal(fsStub.readFileSync(shadowFile, 'utf8'), 'virtual shadow');
+    assert.equal(fsStub.existsSync(shadowFile), true);
+    assert.equal(fsStub.statSync(shadowFile).size, 'virtual shadow'.length);
+    const virtualDelta = probe.delta(beforeVirtual);
+    assert.equal(virtualDelta.totalCount, 0, 'virtual/localStorage operations must not hit sync IPC');
+
+    const beforeReal = probe.snapshot();
+    assert.equal(fsStub.existsSync(realFile), true);
+    assert.equal(fsStub.statSync(realFile).isFile(), true);
+    assert.equal(fsStub.readFileSync(realFile, 'utf8'), 'real text');
+    assert.doesNotThrow(() => fsStub.accessSync(realFile));
+    const entries = fsStub.readdirSync(tmpDir, { withFileTypes: true });
+    assert.ok(entries.some((entry) => String(entry.name) === 'real.txt' && entry.isFile()));
+    assert.ok(entries.some((entry) => String(entry.name) === 'nested' && entry.isDirectory()));
+    assert.ok(entries.some((entry) => String(entry.name) === 'virtual.txt' && entry.isFile()));
+    const realDelta = probe.delta(beforeReal);
+
+    return {
+      mode,
+      realPathOps: realDelta,
+      virtualPathOps: virtualDelta,
+      total: probe.snapshot(),
+    };
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function formatCounts(result) {
+  return SYNC_METHODS
+    .map((name) => `${name}=${result.realPathOps.counts[name]}`)
+    .join(', ');
+}
+
+const { mode, assertNodeDirect } = parseArgs();
+const modes = mode === 'both' ? ['fallback', 'node'] : [mode];
+const results = modes.map((entry) => runScenario(entry));
+
+for (const result of results) {
+  const elapsed = result.realPathOps.totalTimeMs.toFixed(3);
+  console.log(
+    `[extension-sync-facade:${result.mode}] real path ops sync IPC calls: ${result.realPathOps.totalCount} (${formatCounts(result)}), sync IPC time: ${elapsed}ms`
+  );
+  console.log(
+    `[extension-sync-facade:${result.mode}] virtual precedence sync IPC calls: ${result.virtualPathOps.totalCount}`
+  );
+}
+
+const fallbackResult = results.find((result) => result.mode === 'fallback');
+if (fallbackResult) {
+  assert.ok(
+    fallbackResult.realPathOps.totalCount > 0,
+    'fallback mode should exercise the sync IPC path for real filesystem operations'
+  );
+}
+
+const nodeResult = results.find((result) => result.mode === 'node');
+if (assertNodeDirect && nodeResult) {
+  assert.equal(
+    nodeResult.realPathOps.totalCount,
+    0,
+    'node mode should avoid sync IPC for representative real filesystem operations'
+  );
+}

--- a/src/renderer/src/ExtensionView.tsx
+++ b/src/renderer/src/ExtensionView.tsx
@@ -529,6 +529,203 @@ function fsStatResult(
 
 const commandPathCache = new Map<string, string | null>();
 
+type SyncCommandResult = { stdout: string; stderr: string; exitCode: number };
+type RealFsStatPayload = {
+  exists: boolean;
+  isDirectory: boolean;
+  isFile: boolean;
+  size: number;
+  mode?: number;
+  uid?: number;
+  gid?: number;
+  dev?: number;
+  ino?: number;
+  nlink?: number;
+  atimeMs?: number;
+  mtimeMs?: number;
+  ctimeMs?: number;
+  birthtimeMs?: number;
+};
+
+let realNodeFsModule: any | undefined;
+let realNodeChildProcessModule: any | undefined;
+
+function getRealNodeRequire(): ((id: string) => any) | null {
+  if (!USE_REAL_NODE_BUILTINS) return null;
+  if (typeof _realNodeRequire === 'function') return _realNodeRequire;
+  if (typeof window !== 'undefined' && typeof (window as any).__scNodeRequire === 'function') {
+    return (window as any).__scNodeRequire;
+  }
+  return null;
+}
+
+function getRealNodeBuiltin(name: string): any | null {
+  const realRequire = getRealNodeRequire();
+  if (!realRequire) return null;
+  try {
+    return realRequire(name);
+  } catch {
+    return null;
+  }
+}
+
+function getRealNodeFsModule(): any | null {
+  if (realNodeFsModule !== undefined) return realNodeFsModule;
+  const mod = getRealNodeBuiltin('fs');
+  if (mod) realNodeFsModule = mod;
+  return mod || null;
+}
+
+function getRealNodeChildProcessModule(): any | null {
+  if (realNodeChildProcessModule !== undefined) return realNodeChildProcessModule;
+  const mod = getRealNodeBuiltin('child_process');
+  if (mod) realNodeChildProcessModule = mod;
+  return mod || null;
+}
+
+function formatSyncOutput(value: any): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return BufferPolyfill.from(toUint8Array(value)).toString();
+  } catch {
+    return String(value ?? '');
+  }
+}
+
+function buildSyncCommandEnv(options?: { env?: Record<string, string> }): Record<string, string> {
+  const baseEnv = { ...((_realNodeProcess?.env || {}) as Record<string, string>) };
+  const extraPaths = [
+    '/opt/homebrew/bin', '/opt/homebrew/sbin',
+    '/usr/local/bin', '/usr/local/sbin',
+    '/usr/bin', '/usr/sbin', '/bin', '/sbin',
+  ];
+  const currentPath = (options?.env?.PATH ?? baseEnv.PATH ?? '');
+  const augmentedPath = [
+    ...extraPaths,
+    ...String(currentPath).split(':').filter(Boolean),
+  ].filter((value, index, all) => all.indexOf(value) === index).join(':');
+  return {
+    ...baseEnv,
+    ...(options?.env || {}),
+    PATH: augmentedPath,
+  };
+}
+
+function runNodeCommandSync(
+  command: string,
+  args: string[],
+  options?: { shell?: boolean | string; input?: string; env?: Record<string, string>; cwd?: string }
+): SyncCommandResult | null {
+  const childProcess = getRealNodeChildProcessModule();
+  if (!childProcess || typeof childProcess.spawnSync !== 'function') return null;
+  try {
+    const spawnOptions: any = {
+      shell: options?.shell ?? false,
+      env: buildSyncCommandEnv(options),
+      cwd: options?.cwd || _realNodeProcess?.cwd?.() || undefined,
+      input: options?.input,
+      encoding: 'utf-8',
+      timeout: 60_000,
+    };
+    const result = options?.shell
+      ? childProcess.spawnSync([command, ...(args || [])].join(' '), [], { ...spawnOptions, shell: true })
+      : childProcess.spawnSync(command, args || [], spawnOptions);
+    return {
+      stdout: formatSyncOutput(result?.stdout),
+      stderr: formatSyncOutput(result?.stderr || result?.error?.message),
+      exitCode: typeof result?.status === 'number' ? result.status : result?.error ? 1 : 0,
+    };
+  } catch (error: any) {
+    return {
+      stdout: '',
+      stderr: error?.message || 'Failed to execute command',
+      exitCode: 1,
+    };
+  }
+}
+
+function runExtensionCommandSync(
+  command: string,
+  args: string[],
+  options?: { shell?: boolean | string; input?: string; env?: Record<string, string>; cwd?: string }
+): SyncCommandResult {
+  const nodeResult = runNodeCommandSync(command, args, options);
+  if (nodeResult) return nodeResult;
+  try {
+    return (window as any).electron?.execCommandSync?.(command, args, options) || { stdout: '', stderr: '', exitCode: 0 };
+  } catch (error: any) {
+    return { stdout: '', stderr: error?.message || 'Failed to execute command', exitCode: 1 };
+  }
+}
+
+function realFileExistsSync(path: string): boolean {
+  const fs = getRealNodeFsModule();
+  if (fs && typeof fs.existsSync === 'function') {
+    try {
+      return Boolean(fs.existsSync(path));
+    } catch {
+      return false;
+    }
+  }
+  try {
+    return (window as any).electron?.fileExistsSync?.(path) ?? false;
+  } catch {
+    return false;
+  }
+}
+
+function readRealFileSyncText(path: string): { data: string | null; error: string | null } {
+  const fs = getRealNodeFsModule();
+  if (fs && typeof fs.readFileSync === 'function') {
+    try {
+      return { data: String(fs.readFileSync(path, 'utf-8')), error: null };
+    } catch (error: any) {
+      return { data: null, error: error?.message || String(error) };
+    }
+  }
+  try {
+    return (window as any).electron?.readFileSync?.(path) || { data: null, error: 'readFileSync unavailable' };
+  } catch (error: any) {
+    return { data: null, error: error?.message || String(error) };
+  }
+}
+
+function toRealFsStatPayload(stat: any): RealFsStatPayload {
+  return {
+    exists: true,
+    isDirectory: typeof stat?.isDirectory === 'function' ? stat.isDirectory() : Boolean(stat?.isDirectory),
+    isFile: typeof stat?.isFile === 'function' ? stat.isFile() : Boolean(stat?.isFile),
+    size: Number(stat?.size) || 0,
+    mode: Number(stat?.mode) || undefined,
+    uid: Number(stat?.uid) || undefined,
+    gid: Number(stat?.gid) || undefined,
+    dev: Number(stat?.dev) || undefined,
+    ino: Number(stat?.ino) || undefined,
+    nlink: Number(stat?.nlink) || undefined,
+    atimeMs: Number(stat?.atimeMs) || undefined,
+    mtimeMs: Number(stat?.mtimeMs) || undefined,
+    ctimeMs: Number(stat?.ctimeMs) || undefined,
+    birthtimeMs: Number(stat?.birthtimeMs) || undefined,
+  };
+}
+
+function realStatSync(path: string): RealFsStatPayload {
+  const fs = getRealNodeFsModule();
+  if (fs && typeof fs.statSync === 'function') {
+    try {
+      return toRealFsStatPayload(fs.statSync(path));
+    } catch {
+      return { exists: false, isDirectory: false, isFile: false, size: 0 };
+    }
+  }
+  try {
+    return (window as any).electron?.statSync?.(path) || { exists: false, isDirectory: false, isFile: false, size: 0 };
+  } catch {
+    return { exists: false, isDirectory: false, isFile: false, size: 0 };
+  }
+}
+
 function isBareCommandPath(p: string): boolean {
   if (!p) return false;
   if (p.includes('/') || p.includes('\\')) return false;
@@ -540,7 +737,7 @@ function resolveCommandOnPath(command: string): string | null {
   if (!isBareCommandPath(command)) return null;
   if (commandPathCache.has(command)) return commandPathCache.get(command) || null;
   try {
-    const result = (window as any).electron?.execCommandSync?.(
+    const result = runExtensionCommandSync(
       '/bin/zsh',
       ['-lc', `command -v -- ${JSON.stringify(command)} 2>/dev/null || true`],
       {}
@@ -553,7 +750,7 @@ function resolveCommandOnPath(command: string): string | null {
     const commonDirs = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin'];
     for (const dir of commonDirs) {
       const candidate = `${dir}/${command}`;
-      if ((window as any).electron?.fileExistsSync?.(candidate)) {
+      if (realFileExistsSync(candidate)) {
         commandPathCache.set(command, candidate);
         return candidate;
       }
@@ -572,7 +769,7 @@ function resolveExecutablePath(input: any): string {
 
   if (raw.startsWith('/')) {
     try {
-      const exists = (window as any).electron?.fileExistsSync?.(raw);
+      const exists = realFileExistsSync(raw);
       if (exists) return raw;
       const base = raw.split('/').filter(Boolean).pop() || '';
       if (base) {
@@ -705,8 +902,16 @@ function collectVirtualDirectoryEntries(dirPath: string): Map<string, FsEntryKin
 }
 
 function getRealDirectoryEntriesSync(dirPath: string): string[] {
+  const fs = getRealNodeFsModule();
+  if (fs && typeof fs.readdirSync === 'function') {
+    try {
+      return fs.readdirSync(dirPath).map((entry: any) => String(entry || '')).filter((entry: string) => entry.length > 0);
+    } catch {
+      return [];
+    }
+  }
   try {
-    const result = (window as any).electron?.execCommandSync?.('/bin/ls', ['-A1', dirPath], {});
+    const result = runExtensionCommandSync('/bin/ls', ['-A1', dirPath], {});
     if (!result || result.exitCode !== 0) return [];
     return String(result.stdout || '')
       .split(/\r?\n/)
@@ -729,7 +934,7 @@ async function getRealDirectoryEntriesAsync(dirPath: string): Promise<string[]> 
 
 function getEntryKindFromRealStat(path: string): FsEntryKind {
   try {
-    const stat = (window as any).electron?.statSync?.(path);
+    const stat = realStatSync(path);
     if (!stat?.exists) return 'unknown';
     if (stat.isDirectory) return 'directory';
     if (stat.isFile) return 'file';
@@ -773,7 +978,7 @@ function combineDirectoryEntries(
 }
 
 function assertReadableDirectory(path: string, hasEntries: boolean): void {
-  const stat = (window as any).electron?.statSync?.(path);
+  const stat = realStatSync(path);
   if (stat?.exists && !stat.isDirectory) {
     throw createFsError('ENOTDIR', 'scandir', path);
   }
@@ -819,7 +1024,7 @@ const fsStub: Record<string, any> = {
     if (getStoredText(path) !== null) return true;
     // Fall back to real file system via sync IPC
     try {
-      return (window as any).electron?.fileExistsSync?.(path) ?? false;
+      return realFileExistsSync(path);
     } catch {
       return false;
     }
@@ -834,7 +1039,7 @@ const fsStub: Record<string, any> = {
     }
     // Fall back to real file system via sync IPC (for reading extension assets etc.)
     try {
-      const result = (window as any).electron?.readFileSync?.(path);
+      const result = readRealFileSyncText(path);
       if (result && result.data !== null) {
         if (opts?.encoding || typeof opts === 'string') return result.data;
         return BufferPolyfill.from(result.data);
@@ -876,7 +1081,7 @@ const fsStub: Record<string, any> = {
     const content = getStoredText(path);
     if (content !== null) return fsStatResult(true, false, content.length);
     try {
-      const result = (window as any).electron?.statSync?.(path);
+      const result = realStatSync(path);
       if (result?.exists) return fsStatResult(true, result.isDirectory, Number(result.size) || 0, result);
     } catch {}
     return fsStatResult(false);
@@ -886,7 +1091,7 @@ const fsStub: Record<string, any> = {
     const content = getStoredText(path);
     if (content !== null) return fsStatResult(true, false, content.length);
     try {
-      const result = (window as any).electron?.statSync?.(path);
+      const result = realStatSync(path);
       if (result?.exists) return fsStatResult(true, result.isDirectory, Number(result.size) || 0, result);
     } catch {}
     return fsStatResult(false);
@@ -915,7 +1120,7 @@ const fsStub: Record<string, any> = {
     const path = resolveFsLookupPath(p);
     if (getStoredText(path) !== null) return;
     try {
-      if ((window as any).electron?.fileExistsSync?.(path)) return;
+      if (realFileExistsSync(path)) return;
     } catch {}
     const err: any = new Error(`ENOENT: no such file or directory, access '${path}'`);
     err.code = 'ENOENT';
@@ -1007,7 +1212,7 @@ const fsStub: Record<string, any> = {
         cb(null, content);
       } else {
         // Fall back to real file system
-        const exists = Boolean((window as any).electron?.fileExistsSync?.(path));
+        const exists = realFileExistsSync(path);
         ((window as any).electron?.readFile?.(path) as Promise<string>)
           ?.then((data: string) => {
             if (exists) {
@@ -1049,7 +1254,7 @@ const fsStub: Record<string, any> = {
       if (getStoredText(path) !== null) cb(null);
       else {
         try {
-          if ((window as any).electron?.fileExistsSync?.(path)) { cb(null); return; }
+          if (realFileExistsSync(path)) { cb(null); return; }
         } catch {}
         const err: any = new Error(`ENOENT: no such file or directory, access '${path}'`);
         err.code = 'ENOENT';
@@ -1067,7 +1272,7 @@ const fsStub: Record<string, any> = {
       return;
     }
     try {
-      const result = (window as any).electron?.statSync?.(path);
+      const result = realStatSync(path);
       if (result?.exists) {
         cb(null, fsStatResult(true, result.isDirectory, Number(result.size) || 0, result));
         return;
@@ -1085,7 +1290,7 @@ const fsStub: Record<string, any> = {
       return;
     }
     try {
-      const result = (window as any).electron?.statSync?.(path);
+      const result = realStatSync(path);
       if (result?.exists) {
         cb(null, fsStatResult(true, result.isDirectory, Number(result.size) || 0, result));
         return;
@@ -1131,7 +1336,7 @@ const fsStub: Record<string, any> = {
       }
       // Fall back to real file system
       try {
-        const exists = Boolean((window as any).electron?.fileExistsSync?.(path));
+        const exists = realFileExistsSync(path);
         const data = await (window as any).electron?.readFile?.(path);
         if (exists) {
           if (opts?.encoding || typeof opts === 'string') return data;
@@ -1167,7 +1372,7 @@ const fsStub: Record<string, any> = {
       const content = getStoredText(path);
       if (content !== null) return fsStatResult(true, false, content.length);
       try {
-        const result = (window as any).electron?.statSync?.(path);
+        const result = realStatSync(path);
         if (result?.exists) return fsStatResult(true, result.isDirectory, Number(result.size) || 0, result);
       } catch {}
       throw createFsError('ENOENT', 'stat', path);
@@ -1177,7 +1382,7 @@ const fsStub: Record<string, any> = {
       const content = getStoredText(path);
       if (content !== null) return fsStatResult(true, false, content.length);
       try {
-        const result = (window as any).electron?.statSync?.(path);
+        const result = realStatSync(path);
         if (result?.exists) return fsStatResult(true, result.isDirectory, Number(result.size) || 0, result);
       } catch {}
       throw createFsError('ENOENT', 'lstat', path);
@@ -1187,7 +1392,7 @@ const fsStub: Record<string, any> = {
       const path = resolveFsLookupPath(p);
       if (getStoredText(path) !== null) return;
       try {
-        if ((window as any).electron?.fileExistsSync?.(path)) return;
+        if (realFileExistsSync(path)) return;
       } catch {}
       const err: any = new Error(`ENOENT: no such file or directory, access '${path}'`);
       err.code = 'ENOENT';
@@ -1874,7 +2079,7 @@ const childProcessStub = {
   },
   execSync: (command: string) => {
     const normalizedCommand = rewriteShellCommandForMissingBinary(command);
-    const result = (window as any).electron?.execCommandSync?.(
+    const result = runExtensionCommandSync(
       '/bin/zsh',
       ['-lc', normalizedCommand],
       { shell: false }
@@ -1982,11 +2187,11 @@ const childProcessStub = {
       options = args[1];
     }
 
-    const result = (window as any).electron?.execCommandSync?.(
+    const result = runExtensionCommandSync(
       file,
       execArgs,
       { shell: false, env: options?.env, cwd: options?.cwd, input: options?.input }
-    ) || { stdout: '', stderr: '', exitCode: 0 };
+    );
 
     if (result.exitCode !== 0) {
       const stderrOrMsg = String(result?.stderr || '');
@@ -2203,11 +2408,11 @@ const childProcessStub = {
   },
   spawnSync: (command: string, spawnArgs?: string[], options?: any) => {
     const resolvedCommand = resolveExecutablePath(command);
-    const result = (window as any).electron?.execCommandSync?.(
+    const result = runExtensionCommandSync(
       resolvedCommand,
       Array.isArray(spawnArgs) ? spawnArgs : [],
       { shell: options?.shell ?? false, env: options?.env, cwd: options?.cwd, input: options?.input }
-    ) || { stdout: '', stderr: '', exitCode: 0 };
+    );
 
     const stdoutBuf = BufferPolyfill.from(result.stdout || '');
     const stderrBuf = BufferPolyfill.from(result.stderr || '');
@@ -3037,6 +3242,11 @@ function isNodeBuiltinRequest(name: string): boolean {
   return false;
 }
 
+function shouldUseSuperCmdBuiltinFacade(name: string): boolean {
+  const normalized = name.startsWith('node:') ? name.slice(5) : name;
+  return normalized === 'fs' || normalized === 'fs/promises' || normalized === 'child_process';
+}
+
 // Capture real Node globals once, then remove them from globalThis so
 // extensions can't reach around fakeRequire. Runs at module load, before
 // any extension code executes.
@@ -3747,6 +3957,10 @@ function loadExtensionExport(
       // Prefer real Node (via the preload bridge) when the hosting window
       // has Node enabled. Falls back to the stub if the module isn't a
       // recognised built-in, or if real require throws.
+      if (shouldUseSuperCmdBuiltinFacade(name)) {
+        const facade = nodeBuiltinStubs[name] || nodeBuiltinStubs[`node:${name}`];
+        if (facade) return facade;
+      }
       const realModule = tryRealNodeRequire(name);
       if (realModule !== undefined) {
         return realModule;


### PR DESCRIPTION
## What changed
- Added a focused extension sync-facade measurement/regression script for representative real and virtual filesystem path operations.
- Added a lazy Node-backed sync adapter in `ExtensionView.tsx` for real filesystem and child_process sync fallbacks when Node require is available.
- Kept virtual/localStorage filesystem reads ahead of real filesystem access and preserved the existing `window.electron` sync IPC fallback for non-Node contexts.
- Routed `fs`, `fs/promises`, and `child_process` module resolution through SuperCmd facades so extensions keep the compatibility layer instead of raw Node bypassing it.

## Why
Extension filesystem and shell-like facades were using preload `sendSync` calls for real path lookups and sync child process calls. Those calls block the renderer and main process even though the launcher renderer already has Node APIs available.

## Metrics
Focused harness: `node scripts/test-extension-sync-facade.mjs`.

| Scenario | Real path sync IPC calls | Breakdown | Sync IPC time |
| --- | ---: | --- | ---: |
| Before production edit, fallback path | 9 | execCommandSync=1, fileExistsSync=2, readFileSync=1, statSync=5 | 0.318ms |
| After, fallback path still available | 9 | execCommandSync=1, fileExistsSync=2, readFileSync=1, statSync=5 | 0.374ms |
| After, Node-backed path | 0 | execCommandSync=0, fileExistsSync=0, readFileSync=0, statSync=0 | 0.000ms |

Virtual/localStorage precedence stayed at 0 sync IPC calls before and after.

## Validation
- Baseline before implementation: `node scripts/test-extension-sync-facade.mjs --mode=fallback`
- `node scripts/test-extension-sync-facade.mjs`
- `node --test scripts/test-*.mjs` (passes; live Electron crash-recovery test skipped here)
- `node scripts/check-i18n.mjs` (exits 0; existing Italian missing-key warnings remain for `settings.ai.whisper.vocabulary` and `settings.extensions.appSearchScope`)
- Codex LSP diagnostics on `src/renderer/src/ExtensionView.tsx`: no errors
- `node_modules/.bin/tsc -p tsconfig.main.json`
- `node_modules/.bin/vite build`
- `git diff --check`

## Notes and risks
- `node_modules/.bin/tsc -p tsconfig.renderer.json` still fails on existing unrelated renderer type errors outside this change, including `App.tsx`, `CameraExtension.tsx`, `LiquidGlassSurface.tsx`, browser profile typing in `useLauncherCommandModel.ts`, Raycast runtime types, and quicklink icon typing.
- This machine redirects `npm` to pnpm; `pnpm run test` / `pnpm run check:i18n` attempted a pre-run install and hit pnpm build-approval policy, so validation used the underlying Node scripts and local binaries directly.
- The Node-backed path intentionally mirrors the existing text-based file reads and result shaping rather than exposing raw Node `fs` behavior to extensions.