### PR TITLE
perf(cache): maintain Raycast cache sizes incrementally

### DIFF
--- a/scripts/test-raycast-cache-size-index.mjs
+++ b/scripts/test-raycast-cache-size-index.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+import { performance } from 'node:perf_hooks';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+const CACHE_SOURCE_FILE = 'src/renderer/src/raycast-api/index.tsx';
+const ENTRY_COUNT = 120;
+const ENTRY_SIZE = 1024;
+
+function extractCacheSource() {
+  const source = fs.readFileSync(CACHE_SOURCE_FILE, 'utf8');
+  const start = source.indexOf('export namespace Cache');
+  const end = source.indexOf('// =====================================================================\n// \u2500\u2500\u2500 AI', start);
+  assert.notEqual(start, -1, 'Cache namespace marker should exist');
+  assert.notEqual(end, -1, 'AI section marker should exist after Cache');
+  return source.slice(start, end);
+}
+
+const transpiledCache = ts.transpileModule(extractCacheSource(), {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+  },
+  fileName: CACHE_SOURCE_FILE,
+});
+
+function createInstrumentedLocalStorage() {
+  const data = new Map();
+  const stats = {
+    getItem: 0,
+    setItem: 0,
+    removeItem: 0,
+    key: 0,
+    length: 0,
+  };
+
+  return {
+    getItem(key) {
+      stats.getItem += 1;
+      const normalizedKey = String(key);
+      return data.has(normalizedKey) ? data.get(normalizedKey) : null;
+    },
+    setItem(key, value) {
+      stats.setItem += 1;
+      data.set(String(key), String(value));
+    },
+    removeItem(key) {
+      stats.removeItem += 1;
+      data.delete(String(key));
+    },
+    key(index) {
+      stats.key += 1;
+      return Array.from(data.keys())[index] ?? null;
+    },
+    get length() {
+      stats.length += 1;
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    resetStats() {
+      stats.getItem = 0;
+      stats.setItem = 0;
+      stats.removeItem = 0;
+      stats.key = 0;
+      stats.length = 0;
+    },
+    snapshotStats() {
+      return { ...stats };
+    },
+    rawValue(key) {
+      return data.get(String(key));
+    },
+  };
+}
+
+function loadCache(storage, sandboxConsole = console) {
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    console: sandboxConsole,
+    localStorage: storage,
+    JSON,
+    Map,
+    Set,
+  };
+
+  vm.runInNewContext(transpiledCache.outputText, sandbox, { filename: CACHE_SOURCE_FILE });
+  return module.exports.Cache;
+}
+
+function measure(storage, name, fn) {
+  storage.resetStats();
+  const startedAt = performance.now();
+  const result = fn();
+  const durationMs = performance.now() - startedAt;
+  return {
+    name,
+    durationMs: Number(durationMs.toFixed(3)),
+    ...storage.snapshotStats(),
+    ...result,
+  };
+}
+
+function payload(size = ENTRY_SIZE, char = 'x') {
+  return char.repeat(size);
+}
+
+function cacheStorageKey(namespace) {
+  return `sc-cache-${namespace}`;
+}
+
+function cacheItemStorageKey(namespace, key) {
+  return `${cacheStorageKey(namespace)}-item-${key}`;
+}
+
+function readMetadata(storage, namespace) {
+  return JSON.parse(storage.rawValue(cacheStorageKey(namespace)));
+}
+
+function runBenchmark() {
+  const setStorage = createInstrumentedLocalStorage();
+  const SetCache = loadCache(setStorage);
+  const setCache = new SetCache({ namespace: 'bench-set', capacity: ENTRY_COUNT * ENTRY_SIZE * 10 });
+  const setReport = measure(setStorage, 'set-fill', () => {
+    for (let index = 0; index < ENTRY_COUNT; index += 1) {
+      setCache.set(`key-${index}`, payload());
+    }
+    return { entries: ENTRY_COUNT };
+  });
+
+  const getReport = measure(setStorage, 'get-existing', () => {
+    for (let index = 0; index < ENTRY_COUNT; index += 1) {
+      assert.equal(setCache.get(`key-${index}`), payload());
+    }
+    return { entries: ENTRY_COUNT };
+  });
+
+  const evictionStorage = createInstrumentedLocalStorage();
+  const EvictionCache = loadCache(evictionStorage);
+  const seedCache = new EvictionCache({
+    namespace: 'bench-eviction',
+    capacity: ENTRY_COUNT * ENTRY_SIZE * 10,
+  });
+  for (let index = 0; index < ENTRY_COUNT; index += 1) {
+    seedCache.set(`key-${index}`, payload());
+  }
+
+  const evictingCache = new EvictionCache({
+    namespace: 'bench-eviction',
+    capacity: Math.floor(ENTRY_COUNT / 2) * ENTRY_SIZE,
+  });
+  const evictionReport = measure(evictionStorage, 'set-with-eviction', () => {
+    evictingCache.set('new-key', payload());
+    return { entries: ENTRY_COUNT, targetCapacityEntries: Math.floor(ENTRY_COUNT / 2) };
+  });
+
+  return [setReport, getReport, evictionReport];
+}
+
+function printBenchmarkReport(reports) {
+  console.log('Raycast Cache localStorage benchmark');
+  for (const report of reports) {
+    console.log(
+      [
+        `  ${report.name}`,
+        `entries=${report.entries}`,
+        `durationMs=${report.durationMs}`,
+        `getItem=${report.getItem}`,
+        `setItem=${report.setItem}`,
+        `removeItem=${report.removeItem}`,
+        `key=${report.key}`,
+        `length=${report.length}`,
+      ].join(' ')
+    );
+  }
+}
+
+test('Cache stores, removes, clears, and notifies subscribers', () => {
+  const storage = createInstrumentedLocalStorage();
+  const Cache = loadCache(storage);
+  const cache = new Cache({ namespace: 'behavior', capacity: 4096 });
+  const notifications = [];
+  cache.subscribe((key, data) => notifications.push([key, data]));
+
+  cache.set('alpha', 'one');
+  assert.equal(cache.get('alpha'), 'one');
+  assert.equal(cache.has('alpha'), true);
+  assert.equal(cache.remove('alpha'), true);
+  assert.equal(cache.remove('alpha'), false);
+  assert.equal(cache.has('alpha'), false);
+
+  cache.set('beta', 'two');
+  cache.set('gamma', 'three');
+  assert.equal(cache.isEmpty, false);
+  cache.clear();
+  assert.equal(cache.isEmpty, true);
+  assert.equal(cache.has('beta'), false);
+  assert.equal(cache.has('gamma'), false);
+  assert.deepEqual(notifications, [
+    ['alpha', 'one'],
+    ['alpha', undefined],
+    ['beta', 'two'],
+    ['gamma', 'three'],
+    [undefined, undefined],
+  ]);
+});
+
+test('Cache eviction honors least-recently-used ordering', () => {
+  const storage = createInstrumentedLocalStorage();
+  const Cache = loadCache(storage);
+  const cache = new Cache({ namespace: 'lru', capacity: 9 });
+
+  cache.set('a', '111');
+  cache.set('b', '222');
+  cache.set('c', '333');
+  assert.equal(cache.get('a'), '111');
+  cache.set('d', '444');
+
+  assert.equal(cache.has('a'), true);
+  assert.equal(cache.has('b'), false);
+  assert.equal(cache.has('c'), true);
+  assert.equal(cache.has('d'), true);
+});
+
+test('Cache migrates legacy LRU metadata into size metadata', () => {
+  const storage = createInstrumentedLocalStorage();
+  storage.setItem(cacheStorageKey('legacy'), JSON.stringify({ lruOrder: ['alpha', 'beta'] }));
+  storage.setItem(cacheItemStorageKey('legacy', 'alpha'), '111');
+  storage.setItem(cacheItemStorageKey('legacy', 'beta'), '2222');
+  storage.resetStats();
+
+  const Cache = loadCache(storage);
+  const cache = new Cache({ namespace: 'legacy', capacity: 4096 });
+  const metadata = readMetadata(storage, 'legacy');
+
+  assert.deepEqual(metadata.lruOrder, ['alpha', 'beta']);
+  assert.deepEqual(metadata.sizeByKey, { alpha: 3, beta: 4 });
+  assert.equal(metadata.totalSize, 7);
+  assert.equal(cache.get('alpha'), '111');
+  assert.equal(cache.get('beta'), '2222');
+});
+
+test('Cache recovers corrupt metadata by scanning cache item keys', () => {
+  const storage = createInstrumentedLocalStorage();
+  storage.setItem(cacheStorageKey('corrupt'), '{not valid json');
+  storage.setItem(cacheItemStorageKey('corrupt', 'alpha'), 'aaa');
+  storage.setItem(cacheItemStorageKey('corrupt', 'beta'), 'bbbb');
+  storage.resetStats();
+
+  const errors = [];
+  const Cache = loadCache(storage, {
+    ...console,
+    error: (...args) => errors.push(args),
+  });
+  const cache = new Cache({ namespace: 'corrupt', capacity: 4096 });
+  const metadata = readMetadata(storage, 'corrupt');
+
+  assert.equal(errors.length, 1);
+  assert.deepEqual(metadata.lruOrder, ['alpha', 'beta']);
+  assert.deepEqual(metadata.sizeByKey, { alpha: 3, beta: 4 });
+  assert.equal(metadata.totalSize, 7);
+  assert.equal(cache.get('alpha'), 'aaa');
+  assert.equal(cache.get('beta'), 'bbbb');
+});
+
+test('Cache recovers malformed LRU metadata by scanning cache item keys', () => {
+  const storage = createInstrumentedLocalStorage();
+  storage.setItem(cacheStorageKey('malformed'), JSON.stringify({ lruOrder: [42], sizeByKey: {} }));
+  storage.setItem(cacheItemStorageKey('malformed', 'alpha'), 'aaa');
+  storage.resetStats();
+
+  const Cache = loadCache(storage);
+  const cache = new Cache({ namespace: 'malformed', capacity: 4096 });
+  const metadata = readMetadata(storage, 'malformed');
+
+  assert.deepEqual(metadata.lruOrder, ['alpha']);
+  assert.deepEqual(metadata.sizeByKey, { alpha: 3 });
+  assert.equal(metadata.totalSize, 3);
+  assert.equal(cache.get('alpha'), 'aaa');
+});
+
+test('Cache benchmark reports localStorage reads for set, get, and eviction', () => {
+  const reports = runBenchmark();
+  printBenchmarkReport(reports);
+
+  const byName = Object.fromEntries(reports.map((report) => [report.name, report]));
+  assert.equal(byName['set-fill'].getItem, 0);
+  assert.equal(byName['get-existing'].getItem, ENTRY_COUNT);
+  assert.equal(byName['set-with-eviction'].getItem, 0);
+  assert.ok(byName['set-with-eviction'].removeItem > 0, 'eviction scenario should remove LRU entries');
+});

--- a/src/renderer/src/raycast-api/index.tsx
+++ b/src/renderer/src/raycast-api/index.tsx
@@ -1387,11 +1387,22 @@ export namespace Cache {
   export type Subscription = () => void;
 }
 
+const CACHE_METADATA_VERSION = 2;
+
+interface CacheStorageMetadata {
+  version?: number;
+  lruOrder?: unknown;
+  sizeByKey?: unknown;
+  totalSize?: unknown;
+}
+
 export class Cache {
   private storageKey: string;
   private capacity: number;
   private subscribers: Set<Cache.Subscriber> = new Set();
   private lruOrder: string[] = []; // Track access order for LRU
+  private sizeByKey: Map<string, number> = new Map();
+  private totalSize = 0;
 
   constructor(options: Cache.Options = {}) {
     this.capacity = options.capacity ?? 10 * 1024 * 1024; // 10MB default
@@ -1403,21 +1414,146 @@ export class Cache {
   }
 
   private loadFromStorage(): void {
+    let metadata: CacheStorageMetadata | null = null;
+    let hadStoredMetadata = false;
+
     try {
       const stored = localStorage.getItem(this.storageKey);
+      hadStoredMetadata = stored !== null;
       if (stored) {
-        const parsed = JSON.parse(stored);
-        this.lruOrder = parsed.lruOrder || [];
+        metadata = JSON.parse(stored);
       }
     } catch (e) {
       console.error('Failed to load cache from storage:', e);
+      this.recoverFromStorage(undefined, true);
+      return;
+    }
+
+    if (!metadata || typeof metadata !== 'object') {
+      this.recoverFromStorage(undefined, hadStoredMetadata);
+      return;
+    }
+
+    const lruOrder = this.parseLruOrder(metadata.lruOrder);
+    if (!lruOrder) {
+      this.recoverFromStorage(undefined, true);
+      return;
+    }
+
+    const storedSizes = this.parseStoredSizes(metadata.sizeByKey);
+    if (!storedSizes) {
+      this.recoverFromStorage(lruOrder, true);
+      return;
+    }
+
+    let totalSize = 0;
+    const nextSizes = new Map<string, number>();
+    let hasAllSizes = true;
+
+    for (const key of lruOrder) {
+      const size = storedSizes.get(key);
+      if (size === undefined) {
+        hasAllSizes = false;
+        break;
+      }
+      nextSizes.set(key, size);
+      totalSize += size;
+    }
+
+    if (!hasAllSizes) {
+      this.recoverFromStorage(lruOrder, true);
+      return;
+    }
+
+    this.lruOrder = lruOrder;
+    this.sizeByKey = nextSizes;
+    this.totalSize = totalSize;
+
+    if (
+      metadata.version !== CACHE_METADATA_VERSION ||
+      metadata.totalSize !== totalSize ||
+      storedSizes.size !== lruOrder.length
+    ) {
+      this.saveToStorage();
+    }
+  }
+
+  private parseLruOrder(value: unknown): string[] | null {
+    if (!Array.isArray(value)) return null;
+
+    const seen = new Set<string>();
+    const order: string[] = [];
+    for (const key of value) {
+      if (typeof key !== 'string') return null;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      order.push(key);
+    }
+    return order;
+  }
+
+  private parseStoredSizes(value: unknown): Map<string, number> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+
+    const sizes = new Map<string, number>();
+    for (const [key, size] of Object.entries(value as Record<string, unknown>)) {
+      if (typeof size !== 'number' || !Number.isFinite(size) || size < 0) return null;
+      sizes.set(key, size);
+    }
+    return sizes;
+  }
+
+  private recoverFromStorage(preferredOrder?: string[], shouldSave = false): void {
+    this.lruOrder = [];
+    this.sizeByKey.clear();
+    this.totalSize = 0;
+
+    const recovered = new Set<string>();
+    const recoverKey = (key: string): void => {
+      if (recovered.has(key)) return;
+      recovered.add(key);
+
+      const value = localStorage.getItem(this.getItemKey(key));
+      if (value === null) return;
+
+      this.lruOrder.push(key);
+      this.sizeByKey.set(key, value.length);
+      this.totalSize += value.length;
+    };
+
+    if (preferredOrder) {
+      for (const key of preferredOrder) recoverKey(key);
+    } else {
+      const itemPrefix = this.getItemPrefix();
+      const storageKeys: string[] = [];
+      for (let index = 0; index < localStorage.length; index += 1) {
+        const storageKey = localStorage.key(index);
+        if (storageKey?.startsWith(itemPrefix)) storageKeys.push(storageKey);
+      }
+
+      for (const storageKey of storageKeys) {
+        recoverKey(storageKey.slice(itemPrefix.length));
+      }
+    }
+
+    if (shouldSave || this.lruOrder.length > 0) {
+      this.saveToStorage();
     }
   }
 
   private saveToStorage(): void {
     try {
+      const sizeByKey: Record<string, number> = {};
+      for (const key of this.lruOrder) {
+        const size = this.sizeByKey.get(key);
+        if (size !== undefined) sizeByKey[key] = size;
+      }
+
       const data = {
+        version: CACHE_METADATA_VERSION,
         lruOrder: this.lruOrder,
+        sizeByKey,
+        totalSize: this.totalSize,
       };
       localStorage.setItem(this.storageKey, JSON.stringify(data));
     } catch (e) {
@@ -1425,19 +1561,16 @@ export class Cache {
     }
   }
 
+  private getItemPrefix(): string {
+    return `${this.storageKey}-item-`;
+  }
+
   private getItemKey(key: string): string {
-    return `${this.storageKey}-item-${key}`;
+    return `${this.getItemPrefix()}${key}`;
   }
 
   private getCurrentSize(): number {
-    let total = 0;
-    for (const key of this.lruOrder) {
-      const value = localStorage.getItem(this.getItemKey(key));
-      if (value) {
-        total += value.length;
-      }
-    }
-    return total;
+    return this.totalSize;
   }
 
   private evictLRU(): void {
@@ -1445,6 +1578,9 @@ export class Cache {
     const oldestKey = this.lruOrder.shift();
     if (oldestKey) {
       localStorage.removeItem(this.getItemKey(oldestKey));
+      const size = this.sizeByKey.get(oldestKey) ?? 0;
+      this.sizeByKey.delete(oldestKey);
+      this.totalSize = Math.max(0, this.totalSize - size);
     }
   }
 
@@ -1456,6 +1592,29 @@ export class Cache {
     }
     // Add to end (most recently used)
     this.lruOrder.push(key);
+  }
+
+  private removeTrackedKey(key: string): boolean {
+    const index = this.lruOrder.indexOf(key);
+    const trackedSize = this.sizeByKey.get(key);
+    const existed = index !== -1 || trackedSize !== undefined;
+
+    if (index !== -1) {
+      this.lruOrder.splice(index, 1);
+    }
+    if (trackedSize !== undefined) {
+      this.sizeByKey.delete(key);
+      this.totalSize = Math.max(0, this.totalSize - trackedSize);
+    }
+
+    return existed;
+  }
+
+  private trackItem(key: string, dataSize: number): void {
+    this.removeTrackedKey(key);
+    this.sizeByKey.set(key, dataSize);
+    this.totalSize += dataSize;
+    this.updateLRU(key);
   }
 
   private notifySubscribers(key: string | undefined, data: string | undefined): void {
@@ -1471,9 +1630,17 @@ export class Cache {
   get(key: string): string | undefined {
     const value = localStorage.getItem(this.getItemKey(key));
     if (value !== null) {
+      if (this.sizeByKey.get(key) !== value.length) {
+        this.removeTrackedKey(key);
+        this.sizeByKey.set(key, value.length);
+        this.totalSize += value.length;
+      }
       this.updateLRU(key);
       this.saveToStorage();
       return value;
+    }
+    if (this.removeTrackedKey(key)) {
+      this.saveToStorage();
     }
     return undefined;
   }
@@ -1483,15 +1650,14 @@ export class Cache {
     const dataSize = data.length;
 
     // Check if adding this item would exceed capacity
-    let currentSize = this.getCurrentSize();
-    while (currentSize + dataSize > this.capacity && this.lruOrder.length > 0) {
+    this.removeTrackedKey(key);
+    while (this.getCurrentSize() + dataSize > this.capacity && this.lruOrder.length > 0) {
       this.evictLRU();
-      currentSize = this.getCurrentSize();
     }
 
     // Store the item
     localStorage.setItem(itemKey, data);
-    this.updateLRU(key);
+    this.trackItem(key, dataSize);
     this.saveToStorage();
 
     // Notify subscribers
@@ -1500,14 +1666,10 @@ export class Cache {
 
   remove(key: string): boolean {
     const itemKey = this.getItemKey(key);
-    const existed = localStorage.getItem(itemKey) !== null;
+    const existed = this.removeTrackedKey(key);
 
     if (existed) {
       localStorage.removeItem(itemKey);
-      const index = this.lruOrder.indexOf(key);
-      if (index !== -1) {
-        this.lruOrder.splice(index, 1);
-      }
       this.saveToStorage();
       this.notifySubscribers(key, undefined);
     }
@@ -1516,7 +1678,7 @@ export class Cache {
   }
 
   has(key: string): boolean {
-    return localStorage.getItem(this.getItemKey(key)) !== null;
+    return this.sizeByKey.has(key);
   }
 
   get isEmpty(): boolean {
@@ -1531,6 +1693,8 @@ export class Cache {
       localStorage.removeItem(this.getItemKey(key));
     }
     this.lruOrder = [];
+    this.sizeByKey.clear();
+    this.totalSize = 0;
     this.saveToStorage();
 
     // Notify subscribers


### PR DESCRIPTION
## Summary
- Store Raycast Cache metadata as versioned `lruOrder`, `sizeByKey`, and `totalSize` data.
- Update sizes incrementally on set/get/remove/clear/eviction so eviction no longer rescans every cached localStorage item in a loop.
- Recover/migrate legacy `{ lruOrder }` metadata, missing metadata, corrupt JSON metadata, and malformed LRU metadata by rebuilding sizes from cache item keys.
- Add a focused Node harness that exercises cache behavior, LRU eviction, metadata migration/recovery, and prints localStorage read/time metrics.

## Before/After Evidence
Focused benchmark: 120 entries, 1 KiB values, eviction from 120 entries down to a 60-entry capacity.

| Scenario | Before getItem reads | After getItem reads | Before duration | After duration |
| --- | ---: | ---: | ---: | ---: |
| set-fill | 7,140 | 0 | 2.741 ms | 1.269 ms |
| get-existing | 120 | 120 | 0.371 ms | 2.982 ms |
| set-with-eviction | 5,549 | 0 | 1.238 ms | 0.102 ms |

Durations are local-run timings, so the read counts are the primary signal.

## Validation
- `node --test scripts/test-raycast-cache-size-index.mjs` passes; latest after metrics: set-fill `getItem=0`, get-existing `getItem=120`, set-with-eviction `getItem=0`.
- `pnpm run test` passes: 30 passed, 1 skipped.
- `pnpm run check:i18n` exits 0; existing Italian missing keys reported: `settings.ai.whisper.vocabulary`, `settings.extensions.appSearchScope`.
- `pnpm run build:main` passes.
- `pnpm run build:renderer` passes.
- GitHub `claude-review` check fails before review because the workflow cannot fetch an OIDC token: missing `ACTIONS_ID_TOKEN_REQUEST_URL` / likely needs `id-token: write` workflow permission.
- `pnpm exec tsc -p tsconfig.renderer.json --noEmit` still fails on existing project-wide renderer type errors unrelated to this cache change.
- Codex LSP diagnostics on `src/renderer/src/raycast-api/index.tsx` still report existing `Toast.Style` merge/type errors and `addHexAlpha` typing outside the cache block.

## Risks / Notes
- If cache metadata is absent or corrupt, the first constructor recovery may scan matching localStorage cache item keys once, then saves repaired metadata.
- `has()` now answers from cache metadata, which avoids a localStorage read but depends on the repaired/incremental index staying authoritative.
