### PR TITLE
perf(background): dedupe no-view extension runs

### DIFF
--- a/scripts/test-background-no-view-dedupe.mjs
+++ b/scripts/test-background-no-view-dedupe.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import assert from 'assert/strict';
+import fs from 'fs';
+import path from 'path';
+import test from 'node:test';
+import vm from 'vm';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+const moduleCache = new Map();
+
+function loadTsModule(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  if (moduleCache.has(resolvedPath)) return moduleCache.get(resolvedPath).exports;
+
+  const source = fs.readFileSync(resolvedPath, 'utf8');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    },
+    fileName: resolvedPath,
+  });
+
+  const module = { exports: {} };
+  moduleCache.set(resolvedPath, module);
+  const localRequire = (request) => {
+    if (request.startsWith('.')) {
+      const candidate = path.resolve(path.dirname(resolvedPath), request);
+      for (const suffix of ['', '.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.tsx']) {
+        const nextPath = `${candidate}${suffix}`;
+        if (fs.existsSync(nextPath) && fs.statSync(nextPath).isFile()) {
+          if (nextPath.endsWith('.ts') || nextPath.endsWith('.tsx')) return loadTsModule(nextPath);
+          return require(nextPath);
+        }
+      }
+    }
+    return require(request);
+  };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require: localRequire,
+    console,
+    Date,
+    Math,
+    String,
+    Number,
+    Set,
+    Map,
+    Object,
+    Array,
+    RegExp,
+  };
+  vm.runInNewContext(transpiled.outputText, sandbox, { filename: resolvedPath });
+  return module.exports;
+}
+
+const {
+  enqueueBackgroundNoViewRun,
+  getBackgroundNoViewRunIdentity,
+  removeBackgroundNoViewRun,
+} = loadTsModule('src/renderer/src/utils/background-no-view-runs.ts');
+
+function runIdentity(bundle) {
+  return `${bundle.extensionName || bundle.extName || ''}/${bundle.commandName || bundle.cmdName || ''}`;
+}
+
+function legacyQueueNoViewBundleRun(prev, bundle, launchType = 'background', reportStatus = false, now = Date.now) {
+  const runId = `${runIdentity(bundle)}/${now()}`;
+  return [...prev, { runId, bundle, launchType, reportStatus }];
+}
+
+function simulateRepeatedBackgroundTicks({ enqueue, ticks, intervalMs }) {
+  const bundle = {
+    code: 'export default async function Command() {}',
+    mode: 'no-view',
+    title: 'Refresh Widgets',
+    extensionName: 'widgets',
+    commandName: 'refresh',
+  };
+  let runs = [];
+  const tickTimes = Array.from({ length: ticks }, (_, index) => index * intervalMs);
+  for (const elapsedMs of tickTimes) {
+    runs = enqueue(runs, bundle, 'background', false, () => elapsedMs);
+  }
+  return {
+    runs,
+    ticks,
+    intervalMs,
+    elapsedMs: tickTimes.at(-1) ?? 0,
+  };
+}
+
+function simulateDedupedBackgroundTicks({ ticks, intervalMs }) {
+  const bundle = {
+    code: 'export default async function Command() {}',
+    mode: 'no-view',
+    title: 'Refresh Widgets',
+    extName: 'widgets',
+    cmdName: 'refresh',
+    extensionName: 'widgets',
+    commandName: 'refresh',
+  };
+  let runs = [];
+  let enqueued = 0;
+  const tickTimes = Array.from({ length: ticks }, (_, index) => index * intervalMs);
+  for (const elapsedMs of tickTimes) {
+    const result = enqueueBackgroundNoViewRun(runs, bundle, 'background', false, () => elapsedMs);
+    runs = result.runs;
+    if (result.enqueued) enqueued += 1;
+  }
+  return {
+    runs,
+    enqueued,
+    skipped: ticks - enqueued,
+    ticks,
+    intervalMs,
+    elapsedMs: tickTimes.at(-1) ?? 0,
+  };
+}
+
+function testBundle(overrides = {}) {
+  return {
+    code: 'export default async function Command() {}',
+    mode: 'no-view',
+    title: 'Refresh Widgets',
+    extName: 'widgets',
+    cmdName: 'refresh',
+    ...overrides,
+  };
+}
+
+test('baseline: legacy background no-view queue accepts overlapping duplicate ticks', () => {
+  const metrics = simulateRepeatedBackgroundTicks({
+    enqueue: legacyQueueNoViewBundleRun,
+    ticks: 3,
+    intervalMs: 25,
+  });
+
+  console.log(
+    `[baseline] background no-view duplicate ticks: ticks=${metrics.ticks} intervalMs=${metrics.intervalMs} elapsedMs=${metrics.elapsedMs} queued=${metrics.runs.length}`
+  );
+
+  assert.equal(metrics.runs.length, 3);
+  assert.deepEqual(metrics.runs.map((run) => runIdentity(run.bundle)), [
+    'widgets/refresh',
+    'widgets/refresh',
+    'widgets/refresh',
+  ]);
+});
+
+test('background no-view queue dedupes overlapping ticks for the same extension command', () => {
+  const metrics = simulateDedupedBackgroundTicks({
+    ticks: 3,
+    intervalMs: 25,
+  });
+
+  console.log(
+    `[after] background no-view duplicate ticks: ticks=${metrics.ticks} intervalMs=${metrics.intervalMs} elapsedMs=${metrics.elapsedMs} queued=${metrics.runs.length} skipped=${metrics.skipped}`
+  );
+
+  assert.equal(metrics.enqueued, 1);
+  assert.equal(metrics.skipped, 2);
+  assert.equal(metrics.runs.length, 1);
+  assert.equal(getBackgroundNoViewRunIdentity(metrics.runs[0].bundle), 'widgets/refresh');
+});
+
+test('background no-view identity matches legacy and hydrated bundle fields', () => {
+  const legacyFields = testBundle();
+  const hydratedFields = {
+    code: legacyFields.code,
+    mode: legacyFields.mode,
+    title: legacyFields.title,
+    extensionName: 'widgets',
+    commandName: 'refresh',
+  };
+
+  const first = enqueueBackgroundNoViewRun([], legacyFields, 'background', false, () => 0);
+  assert.equal(first.enqueued, true);
+
+  const duplicate = enqueueBackgroundNoViewRun(first.runs, hydratedFields, 'background', false, () => 25);
+  assert.equal(duplicate.enqueued, false);
+  assert.equal(duplicate.runs.length, 1);
+});
+
+test('user-initiated no-view launches are not deduped', () => {
+  const bundle = testBundle();
+  let runs = [];
+  for (const elapsedMs of [0, 25, 50]) {
+    const result = enqueueBackgroundNoViewRun(runs, bundle, 'userInitiated', false, () => elapsedMs);
+    assert.equal(result.enqueued, true);
+    runs = result.runs;
+  }
+
+  assert.equal(runs.length, 3);
+  assert.deepEqual(Array.from(runs, (run) => run.launchType), [
+    'userInitiated',
+    'userInitiated',
+    'userInitiated',
+  ]);
+});
+
+test('background no-view launch skips while same command is already in flight', () => {
+  const bundle = testBundle({
+    extensionName: 'widgets',
+    commandName: 'refresh',
+  });
+  const userLaunch = enqueueBackgroundNoViewRun([], bundle, 'userInitiated', false, () => 0);
+  assert.equal(userLaunch.enqueued, true);
+
+  const backgroundTick = enqueueBackgroundNoViewRun(userLaunch.runs, bundle, 'background', false, () => 25);
+  assert.equal(backgroundTick.enqueued, false);
+  assert.equal(backgroundTick.runs.length, 1);
+
+  const explicitLaunch = enqueueBackgroundNoViewRun(backgroundTick.runs, bundle, 'userInitiated', false, () => 50);
+  assert.equal(explicitLaunch.enqueued, true);
+  assert.equal(explicitLaunch.runs.length, 2);
+});
+
+test('clearing a background no-view run allows the next background tick to enqueue', () => {
+  const bundle = testBundle({
+    extensionName: 'widgets',
+    commandName: 'refresh',
+  });
+
+  for (const reason of ['success', 'error', 'unmount']) {
+    const first = enqueueBackgroundNoViewRun([], bundle, 'background', false, () => 0);
+    assert.equal(first.enqueued, true, reason);
+
+    const overlapping = enqueueBackgroundNoViewRun(first.runs, bundle, 'background', false, () => 25);
+    assert.equal(overlapping.enqueued, false, reason);
+    assert.equal(overlapping.runs.length, 1, reason);
+
+    const cleared = removeBackgroundNoViewRun(overlapping.runs, overlapping.runs[0].runId);
+    assert.equal(cleared.length, 0, reason);
+
+    const afterClear = enqueueBackgroundNoViewRun(cleared, bundle, 'background', false, () => 50);
+    assert.equal(afterClear.enqueued, true, reason);
+    assert.equal(afterClear.runs.length, 1, reason);
+  }
+});

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -111,6 +111,7 @@ import {
   MAX_INLINE_QUICK_LINK_ARGUMENTS,
   getQuickLinkIdFromCommandId,
 } from './utils/launcher-misc';
+import { enqueueBackgroundNoViewRun } from './utils/background-no-view-runs';
 import {
   WEB_SEARCH_ROOT_BANG_PREFIX,
   buildBangSearchUrl,
@@ -310,8 +311,9 @@ const App: React.FC = () => {
     launchType: 'userInitiated' | 'background' = 'userInitiated',
     reportStatus = false
   ) => {
-    const runId = `${bundle.extensionName || bundle.extName}/${bundle.commandName || bundle.cmdName}/${Date.now()}`;
-    setBackgroundNoViewRuns((prev) => [...prev, { runId, bundle, launchType, reportStatus }]);
+    setBackgroundNoViewRuns((prev) =>
+      enqueueBackgroundNoViewRun(prev, bundle, launchType, reportStatus).runs
+    );
   }, [setBackgroundNoViewRuns]);
 
   const onExitAiMode = useCallback(() => {

--- a/src/renderer/src/components/HiddenExtensionRunners.tsx
+++ b/src/renderer/src/components/HiddenExtensionRunners.tsx
@@ -1,7 +1,8 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo } from 'react';
 import ExtensionView from '../ExtensionView';
 import type { BackgroundNoViewRun, MenuBarEntry } from '../hooks/useMenuBarExtensions';
 import { NOOP_ON_CLOSE } from '../utils/launcher-misc';
+import { removeBackgroundNoViewRun } from '../utils/background-no-view-runs';
 
 type HiddenExtensionRunnersProps = {
   menuBarExtensions: MenuBarEntry[];
@@ -9,11 +10,55 @@ type HiddenExtensionRunnersProps = {
   setBackgroundNoViewRuns: React.Dispatch<React.SetStateAction<BackgroundNoViewRun[]>>;
 };
 
+type BackgroundNoViewRunnerProps = {
+  run: BackgroundNoViewRun;
+  onRunFinished: (runId: string) => void;
+};
+
+const BackgroundNoViewRunner: React.FC<BackgroundNoViewRunnerProps> = ({ run, onRunFinished }) => {
+  const closeRun = useCallback(() => {
+    onRunFinished(run.runId);
+  }, [onRunFinished, run.runId]);
+
+  return (
+    <ExtensionView
+      code={run.bundle.code}
+      title={run.bundle.title}
+      mode="no-view"
+      extensionName={(run.bundle as any).extensionName || run.bundle.extName}
+      extensionDisplayName={(run.bundle as any).extensionDisplayName}
+      extensionIconDataUrl={(run.bundle as any).extensionIconDataUrl}
+      commandName={(run.bundle as any).commandName || run.bundle.cmdName}
+      assetsPath={(run.bundle as any).assetsPath}
+      supportPath={(run.bundle as any).supportPath}
+      owner={(run.bundle as any).owner}
+      preferences={(run.bundle as any).preferences}
+      preferenceDefinitions={(run.bundle as any).preferenceDefinitions}
+      launchArguments={(run.bundle as any).launchArguments}
+      launchContext={(run.bundle as any).launchContext}
+      fallbackText={(run.bundle as any).fallbackText}
+      launchType={run.launchType}
+      reportStatus={run.reportStatus}
+      onClose={closeRun}
+    />
+  );
+};
+
 const HiddenExtensionRunners: React.FC<HiddenExtensionRunnersProps> = ({
   menuBarExtensions,
   backgroundNoViewRuns,
   setBackgroundNoViewRuns,
 }) => {
+  const onBackgroundNoViewRunFinished = useCallback((runId: string) => {
+    setBackgroundNoViewRuns((prev) => removeBackgroundNoViewRun(prev, runId));
+  }, [setBackgroundNoViewRuns]);
+
+  useEffect(() => {
+    return () => {
+      setBackgroundNoViewRuns((prev) => (prev.length === 0 ? prev : []));
+    };
+  }, [setBackgroundNoViewRuns]);
+
   const menuBarRunner = useMemo(() => {
     if (menuBarExtensions.length === 0) return null;
     return (
@@ -49,33 +94,15 @@ const HiddenExtensionRunners: React.FC<HiddenExtensionRunnersProps> = ({
     return (
       <div style={{ display: 'none', position: 'absolute', width: 0, height: 0, overflow: 'hidden', pointerEvents: 'none' }}>
         {backgroundNoViewRuns.map((run) => (
-          <ExtensionView
+          <BackgroundNoViewRunner
             key={`bg-no-view-${run.runId}`}
-            code={run.bundle.code}
-            title={run.bundle.title}
-            mode="no-view"
-            extensionName={(run.bundle as any).extensionName || run.bundle.extName}
-            extensionDisplayName={(run.bundle as any).extensionDisplayName}
-            extensionIconDataUrl={(run.bundle as any).extensionIconDataUrl}
-            commandName={(run.bundle as any).commandName || run.bundle.cmdName}
-            assetsPath={(run.bundle as any).assetsPath}
-            supportPath={(run.bundle as any).supportPath}
-            owner={(run.bundle as any).owner}
-            preferences={(run.bundle as any).preferences}
-            preferenceDefinitions={(run.bundle as any).preferenceDefinitions}
-            launchArguments={(run.bundle as any).launchArguments}
-            launchContext={(run.bundle as any).launchContext}
-            fallbackText={(run.bundle as any).fallbackText}
-            launchType={run.launchType}
-            reportStatus={run.reportStatus}
-            onClose={() => {
-              setBackgroundNoViewRuns((prev) => prev.filter((item) => item.runId !== run.runId));
-            }}
+            run={run}
+            onRunFinished={onBackgroundNoViewRunFinished}
           />
         ))}
       </div>
     );
-  }, [backgroundNoViewRuns, setBackgroundNoViewRuns]);
+  }, [backgroundNoViewRuns, onBackgroundNoViewRunFinished]);
 
   return (
     <>

--- a/src/renderer/src/hooks/useMenuBarExtensions.ts
+++ b/src/renderer/src/hooks/useMenuBarExtensions.ts
@@ -19,18 +19,13 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react';
 import type { ExtensionBundle } from '../../types/electron';
+import type { BackgroundNoViewRun } from '../utils/background-no-view-runs';
+
+export type { BackgroundNoViewRun } from '../utils/background-no-view-runs';
 
 export interface MenuBarEntry {
   key: string;
   bundle: ExtensionBundle;
-}
-
-export interface BackgroundNoViewRun {
-  runId: string;
-  bundle: ExtensionBundle;
-  launchType: 'userInitiated' | 'background';
-  /** When true, execution status is mirrored to the system status-bar badge. */
-  reportStatus?: boolean;
 }
 
 export interface UseMenuBarExtensionsReturn {

--- a/src/renderer/src/utils/background-no-view-runs.ts
+++ b/src/renderer/src/utils/background-no-view-runs.ts
@@ -1,0 +1,67 @@
+import type { ExtensionBundle } from '../../types/electron';
+
+export type BackgroundNoViewLaunchType = 'userInitiated' | 'background';
+
+export interface BackgroundNoViewRun {
+  runId: string;
+  bundle: ExtensionBundle;
+  launchType: BackgroundNoViewLaunchType;
+  /** When true, execution status is mirrored to the system status-bar badge. */
+  reportStatus?: boolean;
+}
+
+export interface BackgroundNoViewQueueResult {
+  runs: BackgroundNoViewRun[];
+  enqueued: boolean;
+}
+
+export function getBackgroundNoViewRunIdentity(bundle: Partial<ExtensionBundle>): string | null {
+  const extName = String(bundle.extName || bundle.extensionName || '').trim();
+  const cmdName = String(bundle.cmdName || bundle.commandName || '').trim();
+  if (!extName || !cmdName) return null;
+  return `${extName}/${cmdName}`;
+}
+
+export function enqueueBackgroundNoViewRun(
+  prev: BackgroundNoViewRun[],
+  bundle: ExtensionBundle,
+  launchType: BackgroundNoViewLaunchType = 'userInitiated',
+  reportStatus = false,
+  now: () => number = Date.now
+): BackgroundNoViewQueueResult {
+  const identity = getBackgroundNoViewRunIdentity(bundle);
+  if (
+    launchType === 'background' &&
+    identity &&
+    prev.some((run) => getBackgroundNoViewRunIdentity(run.bundle) === identity)
+  ) {
+    return { runs: prev, enqueued: false };
+  }
+
+  const runIdPrefix =
+    identity ||
+    `${String(bundle.extName || bundle.extensionName || '').trim()}/${String(
+      bundle.cmdName || bundle.commandName || ''
+    ).trim()}`;
+
+  return {
+    runs: [
+      ...prev,
+      {
+        runId: `${runIdPrefix}/${now()}`,
+        bundle,
+        launchType,
+        reportStatus,
+      },
+    ],
+    enqueued: true,
+  };
+}
+
+export function removeBackgroundNoViewRun(
+  prev: BackgroundNoViewRun[],
+  runId: string
+): BackgroundNoViewRun[] {
+  const next = prev.filter((run) => run.runId !== runId);
+  return next.length === prev.length ? prev : next;
+}


### PR DESCRIPTION
## Summary
- Add a shared background no-view run queue helper that dedupes background launches by extension/command identity while preserving repeated user-initiated launches.
- Wire App queueing through the helper and keep hidden runner cleanup on success/error via onClose plus queue clearing if the hidden runner container unmounts.
- Add a focused regression simulation for overlapping ticks, mixed legacy/hydrated identity fields, explicit user launches, and cleanup/re-enqueue paths.

## Root Cause
Background interval ticks dispatch hidden no-view extension bundles without checking whether the same extension command is already in flight, so long-running commands can accumulate duplicate hidden ExtensionView runners.

## Before / After Evidence
- Baseline simulation before behavior edit: `[baseline] background no-view duplicate ticks: ticks=3 intervalMs=25 elapsedMs=50 queued=3`.
- After helper wiring: `[after] background no-view duplicate ticks: ticks=3 intervalMs=25 elapsedMs=50 queued=1 skipped=2`.

## Validation
- `node --test scripts/test-background-no-view-dedupe.mjs` passes 6 tests.
- `node --test scripts/test-*.mjs` passes 30 tests, skips 1 live Electron test.
- `node scripts/check-i18n.mjs` exits 0; it still reports the existing non-strict `it` locale missing keys for `settings.ai.whisper.vocabulary` and `settings.extensions.appSearchScope`.
- `./node_modules/.bin/tsc -p tsconfig.main.json` passes.
- `./node_modules/.bin/vite build` passes.
- Codex LSP diagnostics are clean on `src/renderer/src/utils/background-no-view-runs.ts`, `src/renderer/src/components/HiddenExtensionRunners.tsx`, and `src/renderer/src/hooks/useMenuBarExtensions.ts`.

## Known Limitations / Risks
- `./node_modules/.bin/tsc -p tsconfig.renderer.json` still fails on pre-existing project-wide renderer type errors outside this patch, including `src/renderer/src/App.tsx:759` and `src/renderer/src/App.tsx:1081`.
- `node scripts/build-native.mjs` is blocked in this local environment because `npx` is disabled and the fallback `pnpm dlx node-gyp` cannot resolve `node-addon-api` for `src/native/native-helpers-addon`.
- `pnpm test` is blocked by the local pnpm install/build-script approval hook, so validation used the underlying Node test command directly.