### PR TITLE
perf(background-refresh): stabilize refresh timers

### DIFF
--- a/scripts/test-background-refresh-timer-diff.mjs
+++ b/scripts/test-background-refresh-timer-diff.mjs
@@ -1,0 +1,230 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const helperPath = path.join(rootDir, 'src/renderer/src/hooks/backgroundRefreshTimers.ts');
+
+function loadHelperModule() {
+  const source = fs.readFileSync(helperPath, 'utf8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: helperPath,
+  });
+  const module = { exports: {} };
+
+  vm.runInNewContext(
+    compiled.outputText,
+    {
+      exports: module.exports,
+      module,
+      require: (specifier) => {
+        throw new Error(`Unexpected runtime import while loading timer helper: ${specifier}`);
+      },
+    },
+    { filename: helperPath }
+  );
+
+  return module.exports;
+}
+
+const {
+  getBackgroundRefreshTimerDescriptors,
+  reconcileBackgroundRefreshTimers,
+  clearBackgroundRefreshTimers,
+} = loadHelperModule();
+
+function parseIntervalToMs(interval) {
+  return {
+    '1m': 60_000,
+    '5m': 300_000,
+    '10m': 600_000,
+  }[interval] ?? null;
+}
+
+function extensionCommand(overrides = {}) {
+  return {
+    id: 'extension-weather-current',
+    title: 'Current Weather',
+    category: 'extension',
+    path: 'weather/current',
+    mode: 'no-view',
+    interval: '1m',
+    ...overrides,
+  };
+}
+
+function inlineScriptCommand(overrides = {}) {
+  return {
+    id: 'script-stock-ticker',
+    title: 'Stock Ticker',
+    category: 'script',
+    path: '/Users/example/Scripts/stocks.sh',
+    mode: 'inline',
+    interval: '5m',
+    ...overrides,
+  };
+}
+
+function descriptors(commands) {
+  return getBackgroundRefreshTimerDescriptors(commands, parseIntervalToMs);
+}
+
+function legacyReconcile(commands, activeTimers) {
+  const cleared = activeTimers.length;
+  activeTimers.length = 0;
+
+  for (const descriptor of descriptors(commands)) {
+    activeTimers.push(descriptor.key);
+  }
+
+  return { created: activeTimers.length, cleared };
+}
+
+function createHarness() {
+  const timers = new Map();
+  const created = [];
+  const cleared = [];
+  let nextTimerId = 1;
+
+  return {
+    timers,
+    created,
+    cleared,
+    reconcile(commands) {
+      return reconcileBackgroundRefreshTimers({
+        timers,
+        descriptors: descriptors(commands),
+        createTimer(descriptor) {
+          const timerId = nextTimerId++;
+          created.push({ timerId, key: descriptor.key, commandId: descriptor.command.id });
+          return timerId;
+        },
+        clearTimer(timerId) {
+          cleared.push(timerId);
+        },
+      });
+    },
+    clearAll() {
+      return clearBackgroundRefreshTimers(timers, (timerId) => {
+        cleared.push(timerId);
+      });
+    },
+  };
+}
+
+function activeTimerIds(harness) {
+  return Array.from(harness.timers.values()).map((entry) => entry.timerId);
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test('Background refresh timer diff', async (t) => {
+  await t.test('baseline legacy strategy clears and recreates unchanged background commands', () => {
+    const activeTimers = [];
+    const initialCommands = [
+      extensionCommand(),
+      inlineScriptCommand(),
+      { id: 'app-terminal', title: 'Terminal', category: 'app' },
+    ];
+    const refreshedCommands = [
+      extensionCommand({ subtitle: 'Updated metadata' }),
+      inlineScriptCommand({ subtitle: 'AAPL 210.00' }),
+      { id: 'app-terminal', title: 'Terminal', category: 'app', subtitle: 'Terminal.app' },
+    ];
+
+    const first = legacyReconcile(initialCommands, activeTimers);
+    const second = legacyReconcile(refreshedCommands, activeTimers);
+
+    console.log(
+      `[background-refresh baseline] unchanged update legacy created=${second.created} cleared=${second.cleared}`
+    );
+    assert.deepEqual(first, { created: 2, cleared: 0 });
+    assert.deepEqual(second, { created: 2, cleared: 2 });
+  });
+
+  await t.test('unchanged background commands retain their timers across command-list updates', () => {
+    const harness = createHarness();
+    const initial = harness.reconcile([
+      extensionCommand(),
+      inlineScriptCommand(),
+      { id: 'app-terminal', title: 'Terminal', category: 'app' },
+    ]);
+    const timerIdsBeforeUpdate = activeTimerIds(harness);
+
+    const update = harness.reconcile([
+      extensionCommand({ subtitle: 'Updated metadata' }),
+      inlineScriptCommand({ subtitle: 'AAPL 210.00' }),
+      { id: 'app-terminal', title: 'Terminal', category: 'app', subtitle: 'Terminal.app' },
+    ]);
+
+    console.log(
+      `[background-refresh keyed] unchanged update created=${update.created} retained=${update.retained} cleared=${update.cleared}`
+    );
+    assert.deepEqual(plain(initial), { created: 2, retained: 0, cleared: 0 });
+    assert.deepEqual(plain(update), { created: 0, retained: 2, cleared: 0 });
+    assert.deepEqual(activeTimerIds(harness), timerIdsBeforeUpdate);
+    assert.equal(harness.created.length, 2);
+    assert.equal(harness.cleared.length, 0);
+  });
+
+  await t.test('added background commands create timers and removed commands clear timers', () => {
+    const harness = createHarness();
+    const extension = extensionCommand();
+    const script = inlineScriptCommand();
+
+    assert.deepEqual(plain(harness.reconcile([extension])), { created: 1, retained: 0, cleared: 0 });
+    assert.deepEqual(plain(harness.reconcile([extension, script])), { created: 1, retained: 1, cleared: 0 });
+    assert.deepEqual(plain(harness.reconcile([script])), { created: 0, retained: 1, cleared: 1 });
+    assert.deepEqual(activeTimerIds(harness), [2]);
+    assert.deepEqual(harness.cleared, [1]);
+  });
+
+  await t.test('changed background command identity fields restart only the changed timer', () => {
+    const harness = createHarness();
+    const extension = extensionCommand();
+    const script = inlineScriptCommand();
+
+    assert.deepEqual(plain(harness.reconcile([extension, script])), { created: 2, retained: 0, cleared: 0 });
+    assert.deepEqual(plain(harness.reconcile([extensionCommand({ interval: '5m' }), script])), {
+      created: 1,
+      retained: 1,
+      cleared: 1,
+    });
+    assert.deepEqual(activeTimerIds(harness), [2, 3]);
+    assert.deepEqual(harness.cleared, [1]);
+
+    assert.deepEqual(plain(harness.reconcile([extensionCommand({ interval: '5m', mode: 'menu-bar' }), script])), {
+      created: 1,
+      retained: 1,
+      cleared: 1,
+    });
+    assert.deepEqual(activeTimerIds(harness), [2, 4]);
+    assert.deepEqual(harness.cleared, [1, 3]);
+  });
+
+  await t.test('unmount cleanup clears all remaining timers once', () => {
+    const harness = createHarness();
+
+    assert.deepEqual(plain(harness.reconcile([extensionCommand(), inlineScriptCommand()])), {
+      created: 2,
+      retained: 0,
+      cleared: 0,
+    });
+    assert.equal(harness.clearAll(), 2);
+    assert.deepEqual(activeTimerIds(harness), []);
+    assert.deepEqual(harness.cleared, [1, 2]);
+  });
+});

--- a/src/renderer/src/hooks/backgroundRefreshTimers.ts
+++ b/src/renderer/src/hooks/backgroundRefreshTimers.ts
@@ -1,0 +1,136 @@
+import type { CommandInfo } from '../../types/electron';
+
+export type BackgroundRefreshTimerKind = 'extension' | 'inline-script';
+
+export interface BackgroundRefreshTimerDescriptor {
+  key: string;
+  kind: BackgroundRefreshTimerKind;
+  command: CommandInfo;
+  intervalMs: number;
+  extensionCommand?: { extName: string; cmdName: string };
+}
+
+export interface BackgroundRefreshTimerEntry<TTimerId> {
+  timerId: TTimerId;
+}
+
+export interface BackgroundRefreshTimerReconcileResult {
+  created: number;
+  retained: number;
+  cleared: number;
+}
+
+export interface BackgroundRefreshTimerReconcileOptions<TTimerId> {
+  timers: Map<string, BackgroundRefreshTimerEntry<TTimerId>>;
+  descriptors: BackgroundRefreshTimerDescriptor[];
+  createTimer: (descriptor: BackgroundRefreshTimerDescriptor) => TTimerId;
+  clearTimer: (timerId: TTimerId) => void;
+}
+
+export function parseExtensionCommandPath(pathValue: string): { extName: string; cmdName: string } | null {
+  const rawPath = String(pathValue || '').trim();
+  const separatorIndex = rawPath.indexOf('/');
+  if (separatorIndex <= 0 || separatorIndex >= rawPath.length - 1) return null;
+
+  const extName = rawPath.slice(0, separatorIndex).trim();
+  const cmdName = rawPath.slice(separatorIndex + 1).trim();
+  if (!extName || !cmdName) return null;
+
+  return { extName, cmdName };
+}
+
+export function getBackgroundRefreshTimerKey(cmd: CommandInfo): string | null {
+  if (cmd.category === 'extension' && typeof cmd.interval === 'string' && cmd.path) {
+    const identity = parseExtensionCommandPath(cmd.path);
+    if (!identity) return null;
+
+    return [
+      'extension',
+      cmd.id,
+      `${identity.extName}/${identity.cmdName}`,
+      cmd.path.trim(),
+      cmd.mode || '',
+      cmd.interval,
+    ].join('\u0000');
+  }
+
+  if (cmd.category === 'script' && cmd.mode === 'inline' && typeof cmd.interval === 'string') {
+    return ['inline-script', cmd.id, (cmd.path || '').trim(), cmd.mode, cmd.interval].join('\u0000');
+  }
+
+  return null;
+}
+
+export function getBackgroundRefreshTimerDescriptors(
+  commands: CommandInfo[],
+  parseIntervalToMs: (interval: string) => number | null
+): BackgroundRefreshTimerDescriptor[] {
+  const descriptors: BackgroundRefreshTimerDescriptor[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const cmd of commands) {
+    const key = getBackgroundRefreshTimerKey(cmd);
+    if (!key || seenKeys.has(key) || typeof cmd.interval !== 'string') continue;
+
+    const intervalMs = parseIntervalToMs(cmd.interval);
+    if (!intervalMs) continue;
+
+    descriptors.push({
+      key,
+      kind: cmd.category === 'extension' ? 'extension' : 'inline-script',
+      command: cmd,
+      intervalMs,
+      extensionCommand: cmd.category === 'extension' ? parseExtensionCommandPath(cmd.path || '') || undefined : undefined,
+    });
+    seenKeys.add(key);
+  }
+
+  return descriptors;
+}
+
+export function reconcileBackgroundRefreshTimers<TTimerId>({
+  timers,
+  descriptors,
+  createTimer,
+  clearTimer,
+}: BackgroundRefreshTimerReconcileOptions<TTimerId>): BackgroundRefreshTimerReconcileResult {
+  const nextKeys = new Set(descriptors.map((descriptor) => descriptor.key));
+  let created = 0;
+  let retained = 0;
+  let cleared = 0;
+
+  for (const [key, entry] of Array.from(timers.entries())) {
+    if (!nextKeys.has(key)) {
+      clearTimer(entry.timerId);
+      timers.delete(key);
+      cleared += 1;
+    }
+  }
+
+  for (const descriptor of descriptors) {
+    if (timers.has(descriptor.key)) {
+      retained += 1;
+      continue;
+    }
+
+    timers.set(descriptor.key, { timerId: createTimer(descriptor) });
+    created += 1;
+  }
+
+  return { created, retained, cleared };
+}
+
+export function clearBackgroundRefreshTimers<TTimerId>(
+  timers: Map<string, BackgroundRefreshTimerEntry<TTimerId>>,
+  clearTimer: (timerId: TTimerId) => void
+): number {
+  let cleared = 0;
+
+  for (const entry of timers.values()) {
+    clearTimer(entry.timerId);
+    cleared += 1;
+  }
+
+  timers.clear();
+  return cleared;
+}

--- a/src/renderer/src/hooks/useBackgroundRefresh.ts
+++ b/src/renderer/src/hooks/useBackgroundRefresh.ts
@@ -7,13 +7,21 @@
  * - Inline script commands (category: "script", mode: "inline"): runs the script and
  *   calls fetchCommands() to refresh the subtitle shown in the launcher
  *
- * All timers are cleared and re-registered whenever the `commands` list changes.
- * This ensures newly installed or removed commands are handled correctly.
+ * Timers are keyed by stable command identity, path, mode, and interval so
+ * unchanged background commands keep their existing intervals across command
+ * list refreshes. Removed commands are cleared, and changed commands restart.
  */
 
-import { useRef, useEffect } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 import type { CommandInfo } from '../../types/electron';
 import { parseIntervalToMs } from '../utils/command-helpers';
+import {
+  clearBackgroundRefreshTimers,
+  getBackgroundRefreshTimerDescriptors,
+  reconcileBackgroundRefreshTimers,
+  type BackgroundRefreshTimerEntry,
+  type BackgroundRefreshTimerDescriptor,
+} from './backgroundRefreshTimers';
 import {
   readJsonObject,
   getScriptCmdArgsKey,
@@ -36,41 +44,20 @@ export interface UseBackgroundRefreshOptions {
 }
 
 export function useBackgroundRefresh({ commands, fetchCommands, isMenuBarCommandActive }: UseBackgroundRefreshOptions): void {
-  const intervalTimerIdsRef = useRef<number[]>([]);
+  const intervalTimersRef = useRef<Map<string, BackgroundRefreshTimerEntry<number>>>(new Map());
+  const fetchCommandsRef = useRef(fetchCommands);
+  fetchCommandsRef.current = fetchCommands;
+
   const isMenuBarCommandActiveRef = useRef(isMenuBarCommandActive);
   isMenuBarCommandActiveRef.current = isMenuBarCommandActive;
 
-  const parseExtensionCommandPath = (pathValue: string): { extName: string; cmdName: string } | null => {
-    const rawPath = String(pathValue || '').trim();
-    const separatorIndex = rawPath.indexOf('/');
-    if (separatorIndex <= 0 || separatorIndex >= rawPath.length - 1) return null;
+  const createTimer = useCallback((descriptor: BackgroundRefreshTimerDescriptor): number => {
+    const cmd = descriptor.command;
 
-    const extName = rawPath.slice(0, separatorIndex).trim();
-    const cmdName = rawPath.slice(separatorIndex + 1).trim();
-    if (!extName || !cmdName) return null;
+    if (descriptor.kind === 'extension') {
+      const { extName, cmdName } = descriptor.extensionCommand!;
 
-    return { extName, cmdName };
-  };
-
-  useEffect(() => {
-    for (const timerId of intervalTimerIdsRef.current) {
-      window.clearInterval(timerId);
-    }
-    intervalTimerIdsRef.current = [];
-
-    const extensionCommands = commands.filter(
-      (cmd) => cmd.category === 'extension' && typeof cmd.interval === 'string' && cmd.path
-    );
-
-    for (const cmd of extensionCommands) {
-      const ms = parseIntervalToMs(cmd.interval);
-      if (!ms) continue;
-
-      const identity = parseExtensionCommandPath(cmd.path || '');
-      if (!identity) continue;
-      const { extName, cmdName } = identity;
-
-      const timerId = window.setInterval(async () => {
+      return window.setInterval(async () => {
         try {
           const result = await window.electron.runExtension(extName, cmdName);
           if (!result || !result.code) return;
@@ -110,47 +97,41 @@ export function useBackgroundRefresh({ commands, fetchCommands, isMenuBarCommand
         } catch (error) {
           console.error('[BackgroundRefresh] Failed to run command:', cmd.id, error);
         }
-      }, ms);
-
-      intervalTimerIdsRef.current.push(timerId);
+      }, descriptor.intervalMs);
     }
 
-    const inlineScriptCommands = commands.filter(
-      (cmd) =>
-        cmd.category === 'script' &&
-        cmd.mode === 'inline' &&
-        typeof cmd.interval === 'string'
-    );
-    for (const cmd of inlineScriptCommands) {
-      const ms = parseIntervalToMs(cmd.interval);
-      if (!ms) continue;
-
-      const timerId = window.setInterval(async () => {
-        try {
-          const storedArgs = readJsonObject(getScriptCmdArgsKey(cmd.id));
-          const missingArgs = getMissingRequiredScriptArguments(cmd, storedArgs);
-          if (missingArgs.length > 0) return;
-          const result = await window.electron.runScriptCommand({
-            commandId: cmd.id,
-            arguments: storedArgs,
-            background: true,
-          });
-          if (result?.mode === 'inline') {
-            await fetchCommands();
-          }
-        } catch (error) {
-          console.error('[BackgroundRefresh] Failed to run script command:', cmd.id, error);
+    return window.setInterval(async () => {
+      try {
+        const storedArgs = readJsonObject(getScriptCmdArgsKey(cmd.id));
+        const missingArgs = getMissingRequiredScriptArguments(cmd, storedArgs);
+        if (missingArgs.length > 0) return;
+        const result = await window.electron.runScriptCommand({
+          commandId: cmd.id,
+          arguments: storedArgs,
+          background: true,
+        });
+        if (result?.mode === 'inline') {
+          await fetchCommandsRef.current();
         }
-      }, ms);
-
-      intervalTimerIdsRef.current.push(timerId);
-    }
-
-    return () => {
-      for (const timerId of intervalTimerIdsRef.current) {
-        window.clearInterval(timerId);
+      } catch (error) {
+        console.error('[BackgroundRefresh] Failed to run script command:', cmd.id, error);
       }
-      intervalTimerIdsRef.current = [];
+    }, descriptor.intervalMs);
+  }, []);
+
+  useEffect(() => {
+    const descriptors = getBackgroundRefreshTimerDescriptors(commands, parseIntervalToMs);
+    reconcileBackgroundRefreshTimers({
+      timers: intervalTimersRef.current,
+      descriptors,
+      createTimer,
+      clearTimer: (timerId) => window.clearInterval(timerId),
+    });
+  }, [commands, createTimer]);
+
+  useEffect(() => {
+    return () => {
+      clearBackgroundRefreshTimers(intervalTimersRef.current, (timerId) => window.clearInterval(timerId));
     };
-  }, [commands, fetchCommands]);
+  }, []);
 }


### PR DESCRIPTION
## What changed
- Added a pure background refresh timer helper that builds stable timer keys from command identity, path, mode, and interval.
- Updated `useBackgroundRefresh` to reconcile keyed timers instead of clearing every interval on command-list or callback updates.
- Kept the extension and inline-script tick callbacks intact, with refs for the latest `fetchCommands` and menu-bar activity checks.
- Added regression coverage for unchanged, added, removed, changed, and unmount-cleared background timers.

## Why
Inline script refreshes can call `fetchCommands()`, which updates app command state. The previous hook cleanup cleared and recreated every background interval whenever that command list changed, even when background command identity/path/mode/interval did not change.

Baseline measurement from the new focused test shows the legacy unchanged-update behavior as `created=2 cleared=2`. The keyed reconcile path for the same unchanged update reports `created=0 retained=2 cleared=0`.

## Compatibility impact
- No-view and menu-bar extension refresh behavior is preserved: interval ticks still run the extension bundle, hydrate preferences, skip missing prefs/args, and dispatch `sc-launch-extension-bundle` with background launch options only for `no-view` or active `menu-bar` commands.
- Inline script behavior is preserved: interval ticks still read stored args, skip missing required args, run with `background: true`, and refresh commands when the result mode is `inline`.
- Removed commands clear their timers, and changed identity/path/mode/interval restarts only the changed timer.

## How tested
- `node --test scripts/test-background-refresh-timer-diff.mjs` passed.
  - Legacy unchanged update metric: `created=2 cleared=2`.
  - Keyed unchanged update metric: `created=0 retained=2 cleared=0`.
- `node --test 'scripts/test-*.mjs'` passed: 30 pass, 1 skipped live Electron test.
- LSP diagnostics for `src/renderer/src/hooks/useBackgroundRefresh.ts` and `src/renderer/src/hooks/backgroundRefreshTimers.ts`: no diagnostics.
- `./node_modules/.bin/tsc -p tsconfig.main.json && cp src/main/emoji-data.json dist/main/emoji-data.json` passed.
- `./node_modules/.bin/vite build` passed.
- `node scripts/check-i18n.mjs` completed; it still reports existing Italian locale gaps unrelated to this no-string change.
- `./node_modules/.bin/tsc -p tsconfig.renderer.json` still fails on existing unrelated renderer type errors outside this change.
- `node scripts/build-native.mjs` still fails before this code path because the native addon cannot resolve `node-addon-api`.
