### PR TITLE
ci(claude): fix review action on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   claude-review:
+    # Fork PRs do not receive the OIDC token/secrets required by
+    # anthropics/claude-code-action on pull_request workflows.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -41,4 +44,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## What changed
- Added a job-level guard to `.github/workflows/claude-code-review.yml` so `claude-review` runs only for same-repository pull requests.
- Left the existing `contents`, `pull-requests`, `issues`, and `id-token: write` permissions unchanged for same-repo PRs.

## Why
- `main` already grants `id-token: write`, but fork-based `pull_request` runs still cannot access the OIDC/secrets surface required by `anthropics/claude-code-action@v1`.
- PR #517 is a cross-repository PR from `JustYannicc/SuperCmd` and its `claude-review` check fails while requesting OIDC with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`.
- Using a job-level `if` makes fork PRs skip the job. GitHub reports skipped jobs as successful checks, avoiding a red required check.

## Compatibility impact
- Same-repository PRs continue to run Claude review with the existing OIDC-capable permissions.
- Fork PRs no longer run automated Claude review from the `pull_request` workflow.
- This intentionally avoids switching to `pull_request_target`, which would expose elevated base-repository credentials around untrusted fork PR content and needs a broader security design before enabling.

## How tested
- Baseline: `gh run view 28679751403 --job 85060643677 --log-failed` shows `Could not fetch an OIDC token` and `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`.
- Confirmed PR #517 is cross-repository: `JustYannicc/SuperCmd:codex/perf-grid-virtualization` into `SuperCmdLabs/SuperCmd:main`.
- Parsed all workflow YAML files with Ruby `YAML.load_file`.
- Ran upstream `actionlint` v1.7.12 on all repo workflows: pass.
- Ran `git diff --check`: pass.