### PR TITLE
fix(i18n): restore Italian parity checks

### DIFF
--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -3,7 +3,11 @@ import path from 'path';
 
 const localesDir = path.resolve('src/renderer/src/i18n/locales');
 const baseLocale = 'en';
-const strictLocales = new Set((process.env.SUPERCMD_STRICT_LOCALES || 'ko').split(',').map((item) => item.trim()).filter(Boolean));
+const localeFiles = fs.readdirSync(localesDir).filter((file) => file.endsWith('.json') && file !== `${baseLocale}.json`).sort();
+const defaultStrictLocales = localeFiles.map((file) => file.replace(/\.json$/, ''));
+const strictLocales = new Set(
+  (process.env.SUPERCMD_STRICT_LOCALES || defaultStrictLocales.join(',')).split(',').map((item) => item.trim()).filter(Boolean),
+);
 
 function isObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -41,7 +45,6 @@ function walk(baseNode, localeNode, currentPath, result) {
 }
 
 const baseMessages = JSON.parse(fs.readFileSync(path.join(localesDir, `${baseLocale}.json`), 'utf8'));
-const localeFiles = fs.readdirSync(localesDir).filter((file) => file.endsWith('.json') && file !== `${baseLocale}.json`);
 
 let hasStrictFailure = false;
 

--- a/src/renderer/src/i18n/locales/it.json
+++ b/src/renderer/src/i18n/locales/it.json
@@ -375,6 +375,12 @@
         "elevenlabsWarning": "STT di ElevenLabs selezionato. {action} la chiave API di ElevenLabs in Chiavi API.",
         "elevenlabsReady": "STT di ElevenLabs selezionato. La trascrizione cloud userà la tua chiave ElevenLabs.",
         "recognitionLanguage": "Lingua di riconoscimento",
+        "vocabulary": {
+          "label": "Vocabolario personalizzato",
+          "placeholder": "Kotlin, Electron, Raycast, SuperCmd…",
+          "hint": "Facoltativo. Elenca parole poco comuni, nomi o termini tecnici (separati da virgole o da nuove righe) per orientare il riconoscimento verso l'ortografia corretta.",
+          "tokenWarning": "Circa {count} token. Whisper usa all'incirca solo i primi 224: le parole oltre quel limite vengono ignorate."
+        },
         "providerInfo": {
           "parakeet": "Trascrizione offline sul dispositivo con Parakeet TDT v3. Viene eseguita su Apple Neural Engine. Richiede un riscaldamento del modello al primo utilizzo. Scarica il modello qui sotto prima di usare la dettatura.",
           "qwen3": "Trascrizione offline sul dispositivo con Qwen3 ASR. Supporta oltre 30 lingue, richiede macOS 15+ e si riscalda al primo utilizzo.",
@@ -610,6 +616,18 @@
         "opened": "Cartella degli script personalizzati aperta con uno script di esempio.",
         "openedExisting": "Cartella degli script personalizzati aperta.",
         "failed": "Impossibile aprire la cartella degli script personalizzati."
+      },
+      "appSearchScope": {
+        "title": "Ambito di ricerca delle applicazioni",
+        "description": "Cartelle in cui SuperCmd cerca le applicazioni installate da mostrare nel launcher.",
+        "add": "Aggiungi cartella",
+        "remove": "Rimuovi",
+        "empty": "Nessuna cartella aggiunta. Verranno usate le cartelle applicazioni di sistema predefinite.",
+        "added": "Cartella aggiunta all'ambito di ricerca.",
+        "removed": "Cartella rimossa dall'ambito di ricerca.",
+        "duplicate": "Cartella già presente nell'elenco.",
+        "failed": "Impossibile aggiornare l'ambito di ricerca.",
+        "restartHint": "Riavvia SuperCmd affinché le modifiche alle cartelle abbiano effetto."
       },
       "emojiPicker": {
         "enabled": "Abilita il selettore emoji",


### PR DESCRIPTION
## What changed

- Added the missing Italian translations for the Whisper vocabulary settings and application search scope settings.
- Made `scripts/check-i18n.mjs` strict for every locale file by default instead of only Korean.

## Why

The i18n parity check still exited successfully while reporting that `it.json` was missing two English keys. That made locale regressions easy to miss and left Italian users falling back for those settings labels.

## Compatibility impact

No runtime behavior changes beyond translated copy and stricter validation. The checker still supports `SUPERCMD_STRICT_LOCALES` for targeted runs.

## How tested

- Baseline on `origin/main`: `node scripts/check-i18n.mjs` exited 0 but reported `it: missing=2` for `settings.ai.whisper.vocabulary` and `settings.extensions.appSearchScope`.
- After fix: `node scripts/check-i18n.mjs` reports OK for de, es, fr, it, ja, ko, ru, zh-Hans, and zh-Hant.
- Parsed `src/renderer/src/i18n/locales/en.json` and `src/renderer/src/i18n/locales/it.json` with Node JSON.parse.
- Codex LSP diagnostics for `scripts/check-i18n.mjs`: no errors.

## Stack validation

This patch was found and validated from `codex/perf-integration-stack`, which contains the current performance fix stack. The PR branch is intentionally cherry-picked onto `origin/main` so the upstream PR diff stays scoped to this fix.