### PR TITLE
perf(exec): clear command timeout handles

### DIFF
--- a/scripts/test-exec-command-timeout-cleanup.mjs
+++ b/scripts/test-exec-command-timeout-cleanup.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importTs } from './lib/ts-import.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { runExecCommand } = await importTs(path.join(root, 'src/main/exec-command.ts'));
+
+function createTimerHarness() {
+  let nextId = 1;
+  const active = new Map();
+  const cleared = [];
+
+  return {
+    setTimeout(callback, ms) {
+      const id = nextId++;
+      active.set(id, { callback, ms });
+      return id;
+    },
+    clearTimeout(id) {
+      cleared.push(id);
+      active.delete(id);
+    },
+    runNext() {
+      const next = active.entries().next();
+      if (next.done) return false;
+      const [id, timer] = next.value;
+      active.delete(id);
+      timer.callback();
+      return true;
+    },
+    get activeCount() {
+      return active.size;
+    },
+    get cleared() {
+      return cleared;
+    },
+  };
+}
+
+function createFakeProc() {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = {
+    writes: [],
+    ended: false,
+    write(value) {
+      this.writes.push(value);
+    },
+    end() {
+      this.ended = true;
+    },
+  };
+  proc.killCount = 0;
+  proc.kill = () => {
+    proc.killCount += 1;
+  };
+  return proc;
+}
+
+function createHarness() {
+  const timer = createTimerHarness();
+  const spawned = [];
+  const dependencies = {
+    spawn(command, args, options) {
+      const proc = createFakeProc();
+      spawned.push({ command, args, options, proc });
+      return proc;
+    },
+    existsSync() {
+      return true;
+    },
+    env: { PATH: '/test/bin' },
+    cwd: () => '/test/cwd',
+    setTimeout: timer.setTimeout,
+    clearTimeout: timer.clearTimeout,
+  };
+
+  return {
+    timer,
+    spawned,
+    run(command = '/bin/test-command', args = ['--flag'], options) {
+      return runExecCommand(command, args, options, dependencies);
+    },
+  };
+}
+
+test('exec-command timeout cleanup', async (t) => {
+  await t.test('clears timeout handle when process closes before timeout', async () => {
+    const harness = createHarness();
+    const promise = harness.run();
+    const { proc } = harness.spawned[0];
+
+    proc.stdout.emit('data', Buffer.from('done'));
+    proc.stderr.emit('data', Buffer.from('warn'));
+    proc.emit('close', 0);
+
+    assert.deepEqual(await promise, { stdout: 'done', stderr: 'warn', exitCode: 0 });
+    assert.equal(harness.timer.activeCount, 0);
+    assert.equal(harness.timer.cleared.length, 1);
+    assert.equal(proc.killCount, 0);
+  });
+
+  await t.test('clears timeout handle when process errors before timeout', async () => {
+    const harness = createHarness();
+    const promise = harness.run();
+    const { proc } = harness.spawned[0];
+
+    proc.stderr.emit('data', Buffer.from('partial stderr'));
+    proc.emit('error', new Error('spawn failed'));
+
+    assert.deepEqual(await promise, { stdout: '', stderr: 'spawn failed', exitCode: 1 });
+    assert.equal(harness.timer.activeCount, 0);
+    assert.equal(harness.timer.cleared.length, 1);
+    assert.equal(proc.killCount, 0);
+  });
+
+  await t.test('kills process and resolves with timeout result on timeout path', async () => {
+    const harness = createHarness();
+    const promise = harness.run();
+    const { proc } = harness.spawned[0];
+
+    proc.stdout.emit('data', Buffer.from('before-timeout'));
+    assert.equal(harness.timer.runNext(), true);
+
+    assert.deepEqual(await promise, {
+      stdout: 'before-timeout',
+      stderr: 'Command timed out',
+      exitCode: 124,
+    });
+    assert.equal(proc.killCount, 1);
+    assert.equal(harness.timer.activeCount, 0);
+    assert.equal(harness.timer.cleared.length, 1);
+  });
+
+  await t.test('settles once when close, error, and timeout race', async () => {
+    const harness = createHarness();
+    const promise = harness.run();
+    const { proc } = harness.spawned[0];
+
+    proc.emit('close', 7);
+    proc.emit('error', new Error('late error'));
+    assert.equal(harness.timer.runNext(), false);
+
+    assert.deepEqual(await promise, { stdout: '', stderr: '', exitCode: 7 });
+    assert.equal(harness.timer.activeCount, 0);
+    assert.equal(harness.timer.cleared.length, 1);
+    assert.equal(proc.killCount, 0);
+  });
+});

--- a/src/main/exec-command.ts
+++ b/src/main/exec-command.ts
@@ -1,0 +1,157 @@
+import * as fs from 'fs';
+import { execFileSync as defaultExecFileSync, spawn as defaultSpawn } from 'child_process';
+
+export type ExecCommandOptions = {
+  shell?: boolean | string;
+  input?: string;
+  env?: Record<string, string>;
+  cwd?: string;
+};
+
+export type ExecCommandResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+type ExecCommandProcess = {
+  stdout?: {
+    on(event: 'data', listener: (data: Buffer) => void): void;
+  };
+  stderr?: {
+    on(event: 'data', listener: (data: Buffer) => void): void;
+  };
+  stdin?: {
+    write(input: string): void;
+    end(): void;
+  };
+  on(event: 'close', listener: (code: number | null) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+  kill(): unknown;
+};
+
+type ExecFileSyncLike = (
+  file: string,
+  args?: readonly string[],
+  options?: Record<string, unknown>
+) => string | Buffer;
+
+type ExecCommandDependencies = {
+  spawn?: (command: string, args: string[], options: Record<string, unknown>) => ExecCommandProcess;
+  execFileSync?: ExecFileSyncLike;
+  existsSync?: (path: fs.PathLike) => boolean;
+  env?: NodeJS.ProcessEnv;
+  cwd?: () => string;
+  setTimeout?: typeof setTimeout;
+  clearTimeout?: typeof clearTimeout;
+};
+
+const EXEC_COMMAND_TIMEOUT_MS = 300000;
+
+function resolveExecutablePath(input: string, dependencies: Required<Pick<ExecCommandDependencies, 'execFileSync' | 'existsSync'>>): string {
+  if (!input || typeof input !== 'string') return input;
+  if (!input.includes('/') && !input.includes('\\')) return input;
+  if (!input.startsWith('/')) return input;
+  if (dependencies.existsSync(input)) return input;
+  try {
+    const base = input.split('/').filter(Boolean).pop() || '';
+    if (!base) return input;
+    const lookup = String(
+      dependencies.execFileSync(
+        '/bin/zsh',
+        ['-lc', `command -v -- ${JSON.stringify(base)} 2>/dev/null || true`],
+        { encoding: 'utf-8' }
+      )
+    ).trim();
+    if (lookup && dependencies.existsSync(lookup)) return lookup;
+  } catch {}
+  return input;
+}
+
+export function runExecCommand(
+  command: string,
+  args: string[],
+  options?: ExecCommandOptions,
+  dependencies: ExecCommandDependencies = {}
+): Promise<ExecCommandResult> {
+  const spawn = dependencies.spawn ?? defaultSpawn;
+  const execFileSync = dependencies.execFileSync ?? defaultExecFileSync;
+  const existsSync = dependencies.existsSync ?? fs.existsSync.bind(fs);
+  const env = dependencies.env ?? process.env;
+  const cwd = dependencies.cwd ?? process.cwd.bind(process);
+  const scheduleTimeout = dependencies.setTimeout ?? setTimeout;
+  const cancelTimeout = dependencies.clearTimeout ?? clearTimeout;
+
+  return new Promise((resolve) => {
+    try {
+      const normalizedCommand = resolveExecutablePath(command, { execFileSync, existsSync });
+      // Augment PATH so extensions can find brew, npm, nvm, etc. even when
+      // the app is launched from the Dock (where macOS strips the login PATH).
+      const extraPaths = [
+        '/opt/homebrew/bin', '/opt/homebrew/sbin',
+        '/usr/local/bin', '/usr/local/sbin',
+        '/usr/bin', '/usr/sbin', '/bin', '/sbin',
+      ];
+      const currentPath = (options?.env?.PATH ?? env.PATH ?? '');
+      const augmentedPath = [
+        ...extraPaths,
+        ...currentPath.split(':').filter(Boolean),
+      ].filter((v, i, a) => a.indexOf(v) === i).join(':');
+      const spawnOptions: Record<string, unknown> = {
+        shell: options?.shell ?? false,
+        env: { ...env, ...options?.env, PATH: augmentedPath },
+        cwd: options?.cwd || cwd(),
+      };
+
+      const proc = options?.shell
+        ? spawn([normalizedCommand, ...args].join(' '), [], { ...spawnOptions, shell: true })
+        : spawn(normalizedCommand, args, spawnOptions);
+
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+
+      const finish = (result: ExecCommandResult) => {
+        if (settled) return;
+        settled = true;
+        if (timeout) {
+          cancelTimeout(timeout);
+          timeout = null;
+        }
+        resolve(result);
+      };
+
+      proc.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      if (options?.input && proc.stdin) {
+        proc.stdin.write(options.input);
+        proc.stdin.end();
+      }
+
+      proc.on('close', (code: number | null) => {
+        finish({ stdout, stderr, exitCode: code ?? 0 });
+      });
+
+      proc.on('error', (err: Error) => {
+        finish({ stdout, stderr: err.message, exitCode: 1 });
+      });
+
+      // Timeout after 5 minutes - allows long-running commands (brew install, npm install, etc.)
+      timeout = scheduleTimeout(() => {
+        try {
+          proc.kill();
+        } catch {}
+        finish({ stdout, stderr: stderr || 'Command timed out', exitCode: 124 });
+      }, EXEC_COMMAND_TIMEOUT_MS);
+    } catch (e: any) {
+      resolve({ stdout: '', stderr: e?.message || 'Failed to execute command', exitCode: 1 });
+    }
+  });
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -218,6 +218,7 @@ import {
   importRaycastConfigFromFile,
   previewRaycastConfigImport,
 } from './raycast-config-import';
+import { runExecCommand, type ExecCommandOptions } from './exec-command';
 
 import { initialize as initAptabase, trackEvent } from "@aptabase/electron/main";
 
@@ -15384,91 +15385,9 @@ app.whenReady().then(async () => {
       _event: any,
       command: string,
       args: string[],
-      options?: { shell?: boolean | string; input?: string; env?: Record<string, string>; cwd?: string }
+      options?: ExecCommandOptions
     ) => {
-      const { spawn, execFile } = require('child_process');
-      const fs = require('fs');
-
-      return new Promise((resolve) => {
-        try {
-          const resolveExecutablePath = (input: string): string => {
-            if (!input || typeof input !== 'string') return input;
-            if (!input.includes('/') && !input.includes('\\')) return input;
-            if (!input.startsWith('/')) return input;
-            if (fs.existsSync(input)) return input;
-            try {
-              const base = input.split('/').filter(Boolean).pop() || '';
-              if (!base) return input;
-              const lookup = execFileSync('/bin/zsh', ['-lc', `command -v -- ${JSON.stringify(base)} 2>/dev/null || true`], { encoding: 'utf-8' }).trim();
-              if (lookup && fs.existsSync(lookup)) return lookup;
-            } catch {}
-            return input;
-          };
-
-          const execFileSync = require('child_process').execFileSync;
-          const normalizedCommand = resolveExecutablePath(command);
-          // Augment PATH so extensions can find brew, npm, nvm, etc. even when
-          // the app is launched from the Dock (where macOS strips the login PATH).
-          const extraPaths = [
-            '/opt/homebrew/bin', '/opt/homebrew/sbin',
-            '/usr/local/bin', '/usr/local/sbin',
-            '/usr/bin', '/usr/sbin', '/bin', '/sbin',
-          ];
-          const currentPath = (options?.env?.PATH ?? process.env.PATH ?? '');
-          const augmentedPath = [
-            ...extraPaths,
-            ...currentPath.split(':').filter(Boolean),
-          ].filter((v, i, a) => a.indexOf(v) === i).join(':');
-          const spawnOptions: any = {
-            shell: options?.shell ?? false,
-            env: { ...process.env, ...options?.env, PATH: augmentedPath },
-            cwd: options?.cwd || process.cwd(),
-          };
-
-          let proc: any;
-          if (options?.shell) {
-            // When shell is true, join command and args
-            const fullCommand = [normalizedCommand, ...args].join(' ');
-            proc = spawn(fullCommand, [], { ...spawnOptions, shell: true });
-          } else {
-            proc = spawn(normalizedCommand, args, spawnOptions);
-          }
-
-          let stdout = '';
-          let stderr = '';
-
-          proc.stdout?.on('data', (data: Buffer) => {
-            stdout += data.toString();
-          });
-
-          proc.stderr?.on('data', (data: Buffer) => {
-            stderr += data.toString();
-          });
-
-          if (options?.input && proc.stdin) {
-            proc.stdin.write(options.input);
-            proc.stdin.end();
-          }
-
-          proc.on('close', (code: number | null) => {
-            resolve({ stdout, stderr, exitCode: code ?? 0 });
-          });
-
-          proc.on('error', (err: Error) => {
-            resolve({ stdout, stderr: err.message, exitCode: 1 });
-          });
-
-          // Timeout after 5 minutes — allows long-running commands (brew install, npm install, etc.)
-          setTimeout(() => {
-            try {
-              proc.kill();
-            } catch {}
-            resolve({ stdout, stderr: stderr || 'Command timed out', exitCode: 124 });
-          }, 300000);
-        } catch (e: any) {
-          resolve({ stdout: '', stderr: e?.message || 'Failed to execute command', exitCode: 1 });
-        }
-      });
+      return runExecCommand(command, args, options);
     }
   );
 


### PR DESCRIPTION
## What changed

- Moved the `exec-command` runner into `src/main/exec-command.ts` so its process/timer lifecycle can be exercised without booting Electron.
- Added a single guarded finish path that clears the 300000ms timeout for close, error, and timeout completion paths and ignores late duplicate events.
- Added regression coverage for close-before-timeout, error-before-timeout, timeout kill behavior, and close/error/timeout races.

## Why

Every `exec-command` invocation created a 5-minute timeout, but successful close and spawn-error paths never cleared it. A baseline fake child-process harness reproduced the leak with `activeTimeouts=1` after both close-before-timeout and error-before-timeout.

## Compatibility impact

The IPC result shape and behavior are preserved: close still returns collected stdout/stderr with the exit code, error still returns the error message with exit code 1, and timeout still kills the process and returns exit code 124 with the previous timeout stderr behavior.

## How tested

- Baseline before edit: fake child-process harness showed `activeTimeouts=1` after close-before-timeout and error-before-timeout.
- After fix: `node --test scripts/test-exec-command-timeout-cleanup.mjs` confirms close/error paths clear the timer and timeout/race paths settle once.
- `node --test scripts/test-exec-command-timeout-cleanup.mjs`
- `./node_modules/.bin/tsc -p tsconfig.main.json`
- `node --test scripts/test-exec-command-timeout-cleanup.mjs scripts/test-browser-search-lag-fix.mjs scripts/test-renderer-crash-recovery.mjs scripts/test-renderer-error-boundary.mjs scripts/test-root-search-ranking.mjs`
- Codex LSP diagnostics on `src/main/exec-command.ts` and `src/main/main.ts`: no errors.

## Stack validation

This issue was found and validated from `codex/perf-integration-stack`, which contains the current performance fix stack. The PR branch is intentionally scoped against `origin/main`; the same patch was also applied cleanly to the integration stack and validated there with `./node_modules/.bin/tsc -p tsconfig.main.json` plus focused stack tests.
