### PR TITLE
perf(oauth): cap callback queue

### DIFF
--- a/scripts/test-oauth-callback-queue.mjs
+++ b/scripts/test-oauth-callback-queue.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const bridgePath = path.join(root, 'src/renderer/src/raycast-api/oauth/oauth-bridge.ts');
+let importNonce = 0;
+
+async function importOAuthBridge() {
+  const result = await build({
+    entryPoints: [bridgePath],
+    bundle: true,
+    write: false,
+    format: 'esm',
+    platform: 'node',
+    target: 'node20',
+    logLevel: 'silent',
+  });
+  const code = result.outputFiles[0].text;
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}#oauth-${importNonce++}`;
+  return import(dataUrl);
+}
+
+async function loadBridge(t) {
+  const previousWindow = globalThis.window;
+  let callback = null;
+
+  globalThis.window = {
+    electron: {
+      onOAuthCallback: (handler) => {
+        callback = handler;
+        return () => {
+          callback = null;
+        };
+      },
+    },
+  };
+
+  t.after(() => {
+    if (previousWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = previousWindow;
+    }
+  });
+
+  const bridge = await importOAuthBridge();
+  bridge.ensureOAuthCallbackBridge();
+  assert.equal(typeof callback, 'function', 'OAuth callback bridge should register a callback listener');
+
+  return {
+    bridge,
+    emit: (url) => callback(url),
+  };
+}
+
+function callbackUrl(state, code = state) {
+  const url = new URL('supercmd://oauth/callback');
+  url.searchParams.set('state', state);
+  url.searchParams.set('code', code);
+  return url.toString();
+}
+
+test('OAuth callback queue caps retained unmatched callbacks', async (t) => {
+  const { bridge, emit } = await loadBridge(t);
+  const cap = bridge.OAUTH_CALLBACK_QUEUE_MAX_SIZE;
+  const total = 1000;
+
+  assert.ok(cap < total, 'test fixture should exceed the configured callback queue cap');
+
+  for (let i = 0; i < total; i++) {
+    emit(callbackUrl(`queued-${i}`));
+  }
+
+  await assert.rejects(
+    bridge.waitForOAuthCallback('queued-0', 1),
+    /OAuth authorization timed out/,
+    'old unmatched callbacks should be evicted once the cap is exceeded'
+  );
+
+  const firstRetained = total - cap;
+  const callback = await bridge.waitForOAuthCallback(`queued-${firstRetained}`, 1);
+  assert.equal(callback.state, `queued-${firstRetained}`);
+  assert.equal(callback.code, `queued-${firstRetained}`);
+});
+
+test('OAuth callback queue prunes entries older than the callback timeout window', async (t) => {
+  let now = 1_000_000;
+  t.mock.method(Date, 'now', () => now);
+
+  const { bridge, emit } = await loadBridge(t);
+  emit(callbackUrl('stale'));
+
+  now += bridge.OAUTH_CALLBACK_TIMEOUT_MS + 1;
+  emit(callbackUrl('fresh'));
+
+  await assert.rejects(
+    bridge.waitForOAuthCallback('stale', 1),
+    /OAuth authorization timed out/,
+    'callbacks outside the timeout window should be pruned'
+  );
+
+  const callback = await bridge.waitForOAuthCallback('fresh', 1);
+  assert.equal(callback.state, 'fresh');
+  assert.equal(callback.code, 'fresh');
+});
+
+test('OAuth callback waiter resolves when a matching state arrives', async (t) => {
+  const { bridge, emit } = await loadBridge(t);
+  const pending = bridge.waitForOAuthCallback('matching-state', 100);
+
+  emit(callbackUrl('other-state'));
+  emit(callbackUrl('matching-state', 'matching-code'));
+
+  const callback = await pending;
+  assert.equal(callback.state, 'matching-state');
+  assert.equal(callback.code, 'matching-code');
+});
+
+test('OAuth callback bridge ignores malformed and non-OAuth URLs safely', async (t) => {
+  const { bridge, emit } = await loadBridge(t);
+  emit(callbackUrl('keep'));
+
+  for (let i = 0; i < bridge.OAUTH_CALLBACK_QUEUE_MAX_SIZE + 25; i++) {
+    emit(i % 2 === 0 ? `not a url ${i}` : `https://example.com/oauth/callback?state=ignored-${i}`);
+  }
+
+  const callback = await bridge.waitForOAuthCallback('keep', 1);
+  assert.equal(callback.state, 'keep');
+  assert.equal(callback.code, 'keep');
+
+  await assert.rejects(
+    bridge.waitForOAuthCallback('ignored-1', 1),
+    /OAuth authorization timed out/,
+    'non-OAuth URLs should not be retained as callbacks'
+  );
+});

--- a/src/renderer/src/raycast-api/oauth/oauth-bridge.ts
+++ b/src/renderer/src/raycast-api/oauth/oauth-bridge.ts
@@ -7,10 +7,28 @@ import { getOAuthRuntimeDeps } from './runtime-config';
 
 const OAUTH_TOKEN_KEY_PREFIX = 'sc-oauth-token:';
 const OAUTH_CLIENT_ID_OVERRIDE_PREFIX = 'sc-oauth-client-id:';
-const OAUTH_CALLBACK_TIMEOUT_MS = 3 * 60 * 1000;
+export const OAUTH_CALLBACK_TIMEOUT_MS = 3 * 60 * 1000;
+export const OAUTH_CALLBACK_QUEUE_MAX_SIZE = 256;
 
-const oauthCallbackWaiters = new Set<(url: string) => void>();
-const oauthCallbackQueue: string[] = [];
+export type OAuthCallbackResult = {
+  code?: string;
+  accessToken?: string;
+  tokenType?: string;
+  provider?: string;
+  state?: string;
+  error?: string;
+  errorDescription?: string;
+};
+
+type QueuedOAuthCallback = {
+  parsed: OAuthCallbackResult;
+  receivedAt: number;
+};
+
+type OAuthCallbackWaiter = (callback: OAuthCallbackResult) => boolean;
+
+const oauthCallbackWaiters = new Set<OAuthCallbackWaiter>();
+const oauthCallbackQueue: QueuedOAuthCallback[] = [];
 let oauthCallbackBridgeInitialized = false;
 
 export function oauthTokenKey(providerId: string): string {
@@ -27,15 +45,46 @@ export function ensureOAuthCallbackBridge() {
 
   try {
     (window as any).electron?.onOAuthCallback?.((url: string) => {
-      if (!url) return;
-      oauthCallbackQueue.push(url);
-      for (const waiter of Array.from(oauthCallbackWaiters)) {
-        waiter(url);
-      }
+      enqueueOAuthCallback(url);
     });
   } catch {
     // best-effort
   }
+}
+
+function pruneOAuthCallbackQueue(now = Date.now()) {
+  const expiresBefore = now - OAUTH_CALLBACK_TIMEOUT_MS;
+
+  let writeIndex = 0;
+  for (const callback of oauthCallbackQueue) {
+    if (callback.receivedAt >= expiresBefore) {
+      oauthCallbackQueue[writeIndex++] = callback;
+    }
+  }
+  oauthCallbackQueue.length = writeIndex;
+
+  if (oauthCallbackQueue.length > OAUTH_CALLBACK_QUEUE_MAX_SIZE) {
+    oauthCallbackQueue.splice(0, oauthCallbackQueue.length - OAUTH_CALLBACK_QUEUE_MAX_SIZE);
+  }
+}
+
+function enqueueOAuthCallback(rawUrl: string) {
+  if (!rawUrl) return;
+
+  const parsed = parseOAuthCallbackUrl(rawUrl);
+  if (!parsed) return;
+
+  const now = Date.now();
+  pruneOAuthCallbackQueue(now);
+
+  let handled = false;
+  for (const waiter of Array.from(oauthCallbackWaiters)) {
+    handled = waiter(parsed) || handled;
+  }
+  if (handled) return;
+
+  oauthCallbackQueue.push({ parsed, receivedAt: now });
+  pruneOAuthCallbackQueue(now);
 }
 
 function toBase64Url(bytes: Uint8Array): string {
@@ -95,15 +144,7 @@ export async function buildAuthorizationRequest(params: {
   };
 }
 
-export function parseOAuthCallbackUrl(rawUrl: string): {
-  code?: string;
-  accessToken?: string;
-  tokenType?: string;
-  provider?: string;
-  state?: string;
-  error?: string;
-  errorDescription?: string;
-} | null {
+export function parseOAuthCallbackUrl(rawUrl: string): OAuthCallbackResult | null {
   try {
     const parsed = new URL(rawUrl);
     if (parsed.protocol !== 'supercmd:') return null;
@@ -133,20 +174,21 @@ export function parseOAuthCallbackUrl(rawUrl: string): {
 export async function waitForOAuthCallback(
   state: string,
   timeoutMs = OAUTH_CALLBACK_TIMEOUT_MS
-): Promise<{ code?: string; accessToken?: string; tokenType?: string; provider?: string; error?: string; errorDescription?: string }> {
+): Promise<OAuthCallbackResult> {
   ensureOAuthCallbackBridge();
 
-  const stateMatches = (parsed: ReturnType<typeof parseOAuthCallbackUrl>) => {
+  const stateMatches = (parsed: OAuthCallbackResult) => {
     if (!parsed) return false;
     if (!state) return true;
     return parsed.state === state;
   };
 
+  pruneOAuthCallbackQueue();
   for (let i = 0; i < oauthCallbackQueue.length; i++) {
-    const parsed = parseOAuthCallbackUrl(oauthCallbackQueue[i]);
+    const parsed = oauthCallbackQueue[i].parsed;
     if (stateMatches(parsed)) {
       oauthCallbackQueue.splice(i, 1);
-      return parsed!;
+      return parsed;
     }
   }
 
@@ -156,12 +198,12 @@ export async function waitForOAuthCallback(
       reject(new Error('OAuth authorization timed out'));
     }, timeoutMs);
 
-    const handler = (rawUrl: string) => {
-      const parsed = parseOAuthCallbackUrl(rawUrl);
-      if (!stateMatches(parsed)) return;
+    const handler: OAuthCallbackWaiter = (parsed) => {
+      if (!stateMatches(parsed)) return false;
       clearTimeout(timer);
       oauthCallbackWaiters.delete(handler);
-      resolve(parsed!);
+      resolve(parsed);
+      return true;
     };
 
     oauthCallbackWaiters.add(handler);


### PR DESCRIPTION
## What changed

- Store OAuth callback queue entries as parsed callback records with received timestamps.
- Ignore malformed and non-OAuth callback URLs before they can enter the queue.
- Prune callbacks older than the existing OAuth callback timeout and cap retained unmatched callbacks at 256 entries.
- Add focused node:test coverage for 1000 unmatched callbacks, stale callback pruning, matching-state resolution, and malformed/non-OAuth callback handling.

## Why

Long-running app sessions could accumulate stale OAuth callback URLs because the bridge pushed every callback string into an unbounded queue and unmatched entries were retained indefinitely. The hot path is the renderer OAuth callback listener, where stale callbacks should remain available only for the existing callback wait window and should never grow without bound.

## Compatibility impact

Raycast OAuth compatibility is preserved: valid SuperCmd OAuth callback URLs still parse the same fields, queued matching states still resolve, and live waiters still resolve immediately. Non-OAuth or unparsable URLs are ignored safely instead of being retained. No user-facing strings or i18n files changed.

## How tested

- Baseline before editing: on the stack-based worker branch, code inspection showed `oauthCallbackQueue: string[]` with unconditional `push` and no cap or age pruning; the new regression uses 1000 unmatched callbacks to cover that previously unbounded retention path.
- After fix: `node --test scripts/test-oauth-callback-queue.mjs` passed on the scoped PR branch, 4/4 tests.
- Targeted TypeScript check: `./node_modules/.bin/tsc --noEmit --target ES2020 --lib ES2020,DOM,DOM.Iterable --module ESNext --moduleResolution bundler --jsx react-jsx --strict --esModuleInterop --skipLibCheck --forceConsistentCasingInFileNames --resolveJsonModule --isolatedModules src/renderer/src/raycast-api/oauth/oauth-bridge.ts` passed.
- Renderer typecheck on scoped `origin/main` branch: `./node_modules/.bin/tsc -p tsconfig.renderer.json` still fails on existing unrelated main-branch errors outside this PR, including `src/renderer/src/App.tsx`, `src/renderer/src/CameraExtension.tsx`, `src/renderer/src/components/LiquidGlassSurface.tsx`, and launcher/browser type mismatches. The stack-based implementation branch passed this renderer typecheck before the scoped cherry-pick.

## Stack validation

The issue was analyzed and implemented from `codex/perf-integration-stack`, then moved to scoped branch `codex/perf-oauth-callback-queue-cap-pr` from `origin/main` by cherry-picking only the OAuth fix commit. The upstream diff is limited to `src/renderer/src/raycast-api/oauth/oauth-bridge.ts` and `scripts/test-oauth-callback-queue.mjs`; no coordination or playbook markdown files are included.