### PR TITLE
perf(icons): coalesce file icon IPC

### DIFF
--- a/scripts/test-icon-runtime-file-icon-cache.mjs
+++ b/scripts/test-icon-runtime-file-icon-cache.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const targetFile = path.join(root, 'src/renderer/src/raycast-api/icon-runtime-render.tsx');
+let importNonce = 0;
+
+const REACT_EFFECT_STUB = `
+const noop = () => {};
+const createElement = (type, props, ...children) => ({ type, props: { ...(props || {}), children } });
+class Component {
+  constructor(props) {
+    this.props = props || {};
+    this.state = {};
+  }
+  setState(update) {
+    this.state = { ...this.state, ...(typeof update === 'function' ? update(this.state, this.props) : update) };
+  }
+}
+const createContext = (value) => ({
+  Consumer: ({ children }) => typeof children === 'function' ? children(value) : children,
+  Provider: ({ children }) => children,
+  _currentValue: value,
+});
+const React = {
+  Component,
+  PureComponent: Component,
+  Fragment: Symbol.for('react.fragment'),
+  createContext,
+  createElement,
+  createRef: () => ({ current: null }),
+  forwardRef: (render) => render,
+  lazy: (loader) => loader,
+  memo: (component) => component,
+  startTransition: (callback) => callback(),
+  useCallback: (callback) => callback,
+  useContext: (context) => context?._currentValue,
+  useEffect: (effect) => {
+    effect();
+  },
+  useId: () => 'test-id',
+  useLayoutEffect: noop,
+  useMemo: (factory) => factory(),
+  useReducer: (reducer, initialArg, init) => [init ? init(initialArg) : initialArg, noop],
+  useRef: (value) => ({ current: value }),
+  useState: (initial) => [typeof initial === 'function' ? initial() : initial, noop],
+};
+module.exports = React;
+module.exports.default = React;
+module.exports.__esModule = true;
+`;
+
+const REACT_DOM_SERVER_STUB = `
+export function renderToStaticMarkup() {
+  return "";
+}
+`;
+
+const JSX_RUNTIME_STUB = `
+const Fragment = Symbol.for('react.fragment');
+const jsx = (type, props, key) => ({ type, key, props: props || {} });
+module.exports = { Fragment, jsx, jsxs: jsx };
+module.exports.default = module.exports;
+module.exports.__esModule = true;
+`;
+
+const PHOSPHOR_STUB = `
+module.exports = {};
+module.exports.default = module.exports;
+module.exports.__esModule = true;
+`;
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function installBrowserGlobals(electron) {
+  const document = {
+    documentElement: {
+      classList: {
+        contains: () => false,
+      },
+    },
+    body: {
+      appendChild: () => {},
+      removeChild: () => {},
+    },
+    createElement: () => ({
+      style: {},
+      setAttribute: () => {},
+      appendChild: () => {},
+      remove: () => {},
+    }),
+  };
+
+  globalThis.document = document;
+  globalThis.window = {
+    document,
+    electron,
+    matchMedia: () => ({ matches: true }),
+    getComputedStyle: () => ({
+      color: 'rgb(255, 255, 255)',
+      getPropertyValue: () => '',
+    }),
+  };
+}
+
+function exposeIconRuntimeRenderHooksPlugin() {
+  const normalizedTarget = path.normalize(targetFile);
+  return {
+    name: 'expose-icon-runtime-render-test-hooks',
+    setup(buildApi) {
+      buildApi.onLoad({ filter: /icon-runtime-render\.tsx$/ }, async (args) => {
+        if (path.normalize(args.path) !== normalizedTarget) return undefined;
+        const source = await fs.readFile(args.path, 'utf8');
+        return {
+          contents: `${source}
+export const __testIconRuntimeRender = {
+  FILE_ICON_CACHE_MAX_ENTRIES,
+  FileIcon,
+  fileIconCache,
+  inFlightFileIconRequests,
+  loadFileIconDataUrl,
+  readCachedFileIcon,
+  renderIcon,
+  clearFileIconCaches: () => {
+    fileIconCache.clear();
+    inFlightFileIconRequests.clear();
+  },
+  cacheStats: () => ({
+    cacheSize: fileIconCache.size,
+    inFlightSize: inFlightFileIconRequests.size,
+    keys: Array.from(fileIconCache.keys()),
+    limit: FILE_ICON_CACHE_MAX_ENTRIES,
+  }),
+};
+`,
+          loader: 'tsx',
+          resolveDir: path.dirname(args.path),
+        };
+      });
+    },
+  };
+}
+
+function iconRuntimeStubPlugin() {
+  const stubs = new Map([
+    ['@phosphor-icons/react', PHOSPHOR_STUB],
+    ['react', REACT_EFFECT_STUB],
+    ['react-dom/server', REACT_DOM_SERVER_STUB],
+    ['react/jsx-dev-runtime', JSX_RUNTIME_STUB],
+    ['react/jsx-runtime', JSX_RUNTIME_STUB],
+  ]);
+
+  return {
+    name: 'icon-runtime-file-cache-stubs',
+    setup(buildApi) {
+      buildApi.onResolve({ filter: /.*/ }, (args) => {
+        if (!stubs.has(args.path)) return null;
+        return { path: args.path, namespace: 'icon-runtime-file-cache-stub' };
+      });
+
+      buildApi.onLoad({ filter: /.*/, namespace: 'icon-runtime-file-cache-stub' }, (args) => ({
+        contents: stubs.get(args.path) || '',
+        loader: 'js',
+      }));
+    },
+  };
+}
+
+async function importIconRuntimeHarness(electron = {}) {
+  installBrowserGlobals(electron);
+  const result = await build({
+    absWorkingDir: root,
+    entryPoints: [targetFile],
+    bundle: true,
+    write: false,
+    format: 'esm',
+    platform: 'node',
+    target: 'node20',
+    jsx: 'automatic',
+    logLevel: 'silent',
+    banner: {
+      js: 'var window = globalThis.window; var document = globalThis.document;',
+    },
+    plugins: [iconRuntimeStubPlugin(), exposeIconRuntimeRenderHooksPlugin()],
+  });
+  const dataUrl = [
+    'data:text/javascript;base64,',
+    Buffer.from(result.outputFiles[0].text).toString('base64'),
+    `#icon-runtime-file-cache-${importNonce++}`,
+  ].join('');
+  const module = await import(dataUrl);
+  const runtime = module.__testIconRuntimeRender;
+  assert.ok(runtime, 'expected icon runtime render test hooks to be exposed');
+  runtime.clearFileIconCaches();
+  return runtime;
+}
+
+test('file icon runtime cache', async (t) => {
+  await t.test('coalesces 100 concurrently mounted identical file icons into one IPC call', async () => {
+    const filePath = '/tmp/supercmd-same-file.txt';
+    const dataUrl = 'data:image/png;base64,same-file';
+    const gate = deferred();
+    let calls = 0;
+
+    const runtime = await importIconRuntimeHarness({
+      getFileIconDataUrl(requestedPath, size) {
+        calls += 1;
+        assert.equal(requestedPath, filePath);
+        assert.equal(size, 20);
+        return gate.promise;
+      },
+      statSync: () => ({ exists: true, isDirectory: false }),
+    });
+
+    for (let index = 0; index < 100; index += 1) {
+      runtime.FileIcon({ filePath, className: 'w-4 h-4' });
+    }
+
+    assert.equal(calls, 1);
+    assert.equal(runtime.cacheStats().inFlightSize, 1);
+
+    const pending = Array.from(runtime.inFlightFileIconRequests.values())[0];
+    gate.resolve(dataUrl);
+    await pending;
+
+    assert.equal(runtime.cacheStats().cacheSize, 1);
+    assert.equal(runtime.cacheStats().inFlightSize, 0);
+    assert.equal(runtime.readCachedFileIcon(filePath), dataUrl);
+
+    assert.equal(await runtime.loadFileIconDataUrl(filePath), dataUrl);
+    assert.equal(calls, 1, 'cached file icon should not issue another IPC call');
+  });
+
+  await t.test('does not keep rejected IPC results as permanent negative cache entries', async () => {
+    const filePath = '/tmp/supercmd-late-success.txt';
+    const recoveredDataUrl = 'data:image/png;base64,recovered';
+    let calls = 0;
+
+    const runtime = await importIconRuntimeHarness({
+      async getFileIconDataUrl() {
+        calls += 1;
+        if (calls === 1) throw new Error('temporary icon IPC failure');
+        return recoveredDataUrl;
+      },
+    });
+
+    assert.equal(await runtime.loadFileIconDataUrl(filePath), null);
+    assert.equal(calls, 1);
+    assert.equal(runtime.cacheStats().cacheSize, 0);
+    assert.equal(runtime.cacheStats().inFlightSize, 0);
+
+    assert.equal(await runtime.loadFileIconDataUrl(filePath), recoveredDataUrl);
+    assert.equal(calls, 2);
+    assert.equal(runtime.cacheStats().cacheSize, 1);
+  });
+
+  await t.test('caps unique file icon cache entries and evicts least recently used paths', async () => {
+    let calls = 0;
+    const runtime = await importIconRuntimeHarness({
+      async getFileIconDataUrl(filePath) {
+        calls += 1;
+        return `data:image/png;base64,${Buffer.from(filePath).toString('base64')}`;
+      },
+    });
+
+    const { limit } = runtime.cacheStats();
+    assert.ok(limit < 5_000, 'test expects a bounded cache below the old 5k growth case');
+
+    for (let index = 0; index < limit; index += 1) {
+      await runtime.loadFileIconDataUrl(`/tmp/supercmd-icon-${index}`);
+    }
+    assert.equal(runtime.cacheStats().cacheSize, limit);
+
+    const firstPath = '/tmp/supercmd-icon-0';
+    const secondPath = '/tmp/supercmd-icon-1';
+    const overflowPath = `/tmp/supercmd-icon-${limit}`;
+    assert.ok(runtime.readCachedFileIcon(firstPath), 'reading should refresh LRU order');
+
+    await runtime.loadFileIconDataUrl(overflowPath);
+
+    const afterOverflow = runtime.cacheStats();
+    assert.equal(afterOverflow.cacheSize, limit);
+    assert.equal(calls, limit + 1);
+    assert.ok(afterOverflow.keys.includes(firstPath), 'recently read path should survive overflow');
+    assert.ok(!afterOverflow.keys.includes(secondPath), 'least recently used path should be evicted');
+    assert.ok(afterOverflow.keys.includes(overflowPath), 'new path should be cached');
+
+    for (let index = limit + 1; index < 5_000; index += 1) {
+      await runtime.loadFileIconDataUrl(`/tmp/supercmd-icon-${index}`);
+    }
+
+    assert.equal(runtime.cacheStats().cacheSize, limit);
+  });
+
+  await t.test('leaves non-file image icons on the existing render path without IPC', async () => {
+    let calls = 0;
+    const runtime = await importIconRuntimeHarness({
+      async getFileIconDataUrl() {
+        calls += 1;
+        return 'data:image/png;base64,file-icon';
+      },
+    });
+
+    const remoteIcon = runtime.renderIcon('https://example.com/icon.png', 'w-5 h-5');
+
+    assert.equal(calls, 0);
+    assert.equal(remoteIcon?.props?.src, 'https://example.com/icon.png');
+    assert.equal(remoteIcon?.props?.className, 'w-5 h-5');
+  });
+});

--- a/src/renderer/src/raycast-api/icon-runtime-render.tsx
+++ b/src/renderer/src/raycast-api/icon-runtime-render.tsx
@@ -7,30 +7,81 @@ import React, { useEffect, useState } from 'react';
 import { isRaycastIconName, renderPhosphorIcon } from './icon-runtime-phosphor';
 import { isEmojiOrSymbol, renderTintedAssetIcon, resolveIconSrc, resolveTintColor } from './icon-runtime-assets';
 
+const FILE_ICON_CACHE_MAX_ENTRIES = 1024;
 const fileIconCache = new Map<string, string | null>();
+const inFlightFileIconRequests = new Map<string, Promise<string | null>>();
+
+function peekCachedFileIcon(filePath: string): string | null | undefined {
+  if (!fileIconCache.has(filePath)) return undefined;
+  return fileIconCache.get(filePath) ?? null;
+}
+
+function readCachedFileIcon(filePath: string): string | null | undefined {
+  const cached = peekCachedFileIcon(filePath);
+  if (cached === undefined) return undefined;
+  fileIconCache.delete(filePath);
+  fileIconCache.set(filePath, cached);
+  return cached;
+}
+
+function writeCachedFileIcon(filePath: string, src: string | null) {
+  if (fileIconCache.has(filePath)) fileIconCache.delete(filePath);
+  fileIconCache.set(filePath, src);
+
+  while (fileIconCache.size > FILE_ICON_CACHE_MAX_ENTRIES) {
+    const oldestKey = fileIconCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    fileIconCache.delete(oldestKey);
+  }
+}
+
+function loadFileIconDataUrl(filePath: string): Promise<string | null> {
+  const cached = readCachedFileIcon(filePath);
+  if (cached !== undefined) return Promise.resolve(cached);
+
+  const pending = inFlightFileIconRequests.get(filePath);
+  if (pending) return pending;
+
+  const getFileIconDataUrl = typeof window !== 'undefined'
+    ? (window as any).electron?.getFileIconDataUrl
+    : undefined;
+  if (typeof getFileIconDataUrl !== 'function') return Promise.resolve(null);
+
+  let request: Promise<string | null>;
+  try {
+    request = Promise.resolve(getFileIconDataUrl(filePath, 20))
+      .then((iconSrc: string | null | undefined) => {
+        const normalized = iconSrc || null;
+        writeCachedFileIcon(filePath, normalized);
+        return normalized;
+      })
+      .catch(() => null)
+      .finally(() => {
+        inFlightFileIconRequests.delete(filePath);
+      });
+  } catch {
+    return Promise.resolve(null);
+  }
+
+  inFlightFileIconRequests.set(filePath, request);
+  return request;
+}
 
 function FileIcon({ filePath, className }: { filePath: string; className: string }) {
-  const [src, setSrc] = useState<string | null>(() => fileIconCache.get(filePath) ?? null);
+  const [src, setSrc] = useState<string | null>(() => peekCachedFileIcon(filePath) ?? null);
 
   useEffect(() => {
     let cancelled = false;
-    const cached = fileIconCache.get(filePath);
+    const cached = readCachedFileIcon(filePath);
     if (cached !== undefined) {
       setSrc(cached);
       return;
     }
 
-    (window as any).electron?.getFileIconDataUrl?.(filePath, 20)
-      .then((iconSrc: string | null) => {
-        if (cancelled) return;
-        fileIconCache.set(filePath, iconSrc || null);
-        setSrc(iconSrc || null);
-      })
-      .catch(() => {
-        if (cancelled) return;
-        fileIconCache.set(filePath, null);
-        setSrc(null);
-      });
+    loadFileIconDataUrl(filePath).then((iconSrc) => {
+      if (cancelled) return;
+      setSrc(iconSrc);
+    });
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## What changed

- Added path-keyed in-flight coalescing around Raycast file icon IPC requests so concurrent identical file icons share one `getFileIconDataUrl` call.
- Replaced the unbounded renderer `fileIconCache` with a 1024-entry LRU cache for successful data URLs and resolved null fallbacks.
- Kept rejected IPC failures retryable by avoiding permanent negative cache writes on rejection.
- Added a self-contained `node:test` harness for concurrent duplicate icons, rejection recovery, LRU eviction, and non-file image icon behavior.

## Why

The file icon runtime lived on a hot render path for Raycast list/grid items. Before this change, duplicate mounted file icons could all observe a cache miss before the first IPC call resolved, so identical icons fanned out into repeated `getFileIconDataUrl` IPC calls. The cache was also a module-level `Map` with no cap, so browsing or rendering many unique paths retained every icon result for the life of the renderer.

Baseline mock-render harness for the pre-fix request/cache logic reported `sameMountedIcons=100`, `sameIpcCalls=100`, `uniqueMountedIcons=5000`, `uniqueIpcCalls=5000`, and `uniqueCacheEntries=5000`.

## Compatibility impact

Raycast icon rendering semantics are preserved. File icons still render the same data URL image when available, and still fall back to the existing document/folder glyph while loading or after unavailable icons. Cached file icons may remain stale, matching the existing tolerance. Non-file icon paths continue through the existing remote/image/Phosphor handling. No user-facing strings or locale files changed.

## How tested

- Baseline before fix: `node -e <mock old FileIcon request/cache harness>` -> `{"sameMountedIcons":100,"sameIpcCalls":100,"uniqueMountedIcons":5000,"uniqueIpcCalls":5000,"uniqueCacheEntries":5000}`.
- After fix on scoped branch: `node --test scripts/test-icon-runtime-file-icon-cache.mjs` -> pass; asserts 100 concurrent identical mounts call IPC once, rejected IPC retries later, 5,000 unique paths stay capped at 1,024 cache entries with LRU eviction, and non-file image icons do not call file icon IPC.
- Scoped diff check: `git diff --check origin/main...HEAD` -> pass.
- Renderer typecheck on scoped `origin/main` branch: `./node_modules/.bin/tsc -p tsconfig.renderer.json --noEmit` was attempted and is blocked by existing unrelated `origin/main` errors, including `src/renderer/src/App.tsx`, `src/renderer/src/CameraExtension.tsx`, `src/renderer/src/components/LiquidGlassSurface.tsx`, and other pre-existing renderer type issues outside this PR diff.

## Stack validation

The runtime fix was developed and validated from `codex/perf-integration-stack`, which contains the active performance stack. Before creating this scoped `origin/main` PR branch, the stack-based worker branch passed:

- `node --test scripts/test-icon-runtime-file-icon-cache.mjs`
- `node --test scripts/test-icon-asset-cache.mjs scripts/test-icon-runtime-phosphor-cache.mjs`
- `./node_modules/.bin/tsc -p tsconfig.renderer.json --noEmit`
- `git diff --check`

The upstream PR branch `codex/perf-file-icon-cache-coalesce-pr` was created from `origin/main` and contains only the file-icon runtime/test diff.
