### PR TITLE
fix(pnpm): approve native build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  electron: true
+  esbuild: true
+  extract-file-icon: true
+  node-window-manager: true


### PR DESCRIPTION
## What changed
- Added `pnpm-workspace.yaml` with pnpm 11 `allowBuilds` approvals for `electron`, `esbuild`, `extract-file-icon`, and `node-window-manager`.
- Kept the diff scoped to pnpm approval metadata; no npm lockfile changes.

## Why
- pnpm 11 blocks installs and command wrappers when native build scripts are detected but not approved.
- The affected commands were failing before their requested scripts could run with `[ERR_PNPM_IGNORED_BUILDS]` for Electron, esbuild, extract-file-icon, and node-window-manager.

## Compatibility impact
- No application runtime code changes.
- Allows only the listed native dependencies to run their install/rebuild scripts during pnpm installs.
- npm-based installs are unchanged.

## How tested
- Removed generated `node_modules`, `pnpm-lock.yaml`, and `dist` before validation.
- `pnpm install` passed noninteractively and ran approved native build/postinstall steps.
- `pnpm exec tsc -p tsconfig.main.json --noEmit` passed.
- `pnpm run check:i18n` passed; it still reports existing Italian missing keys: `settings.ai.whisper.vocabulary`, `settings.extensions.appSearchScope`.
- `pnpm test` passed: 27 tests.
- `pnpm run build` completed `build:main` and `build:renderer`, then failed in `build:native` because `src/native/native-helpers-addon/binding.gyp` cannot resolve `node-addon-api` under pnpm strict layout.

## Stack validation
- Clean branch created from `origin/main`; the previous integration-stack branch was not used as the PR head.
- Cherry-picked only the pnpm/native-builds fix commit.
- `git diff --stat origin/main..HEAD`: `pnpm-workspace.yaml | 5 +++++`.