### PR TITLE
perf(runtime): reduce extension and menubar churn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Test
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/test.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/test.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run node test suite
+        run: npm test

--- a/scripts/measure-extension-bundle-cache.mjs
+++ b/scripts/measure-extension-bundle-cache.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { build } from 'esbuild';
+import { performance } from 'node:perf_hooks';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const iterations = Number.parseInt(process.env.SUPERCMD_EXTENSION_BUNDLE_MEASURE_ITERATIONS || '20', 10);
+
+export function createFixture() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-extension-bundle-cache-'));
+  const userDataDir = path.join(tmpDir, 'userData');
+  const extensionsDir = path.join(userDataDir, 'extensions');
+  const extDir = path.join(extensionsDir, 'bundle-cache-fixture');
+  const buildDir = path.join(extDir, '.sc-build');
+
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(extDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'bundle-cache-fixture',
+        title: 'Bundle Cache Fixture',
+        description: 'Fixture for extension bundle cache measurement',
+        owner: 'codex',
+        commands: [
+          {
+            name: 'background',
+            title: 'Background',
+            description: 'No-view command',
+            mode: 'no-view',
+            preferences: [
+              {
+                name: 'freshCommandPref',
+                title: 'Fresh Command Pref',
+                type: 'textfield',
+                default: 'default-command',
+              },
+            ],
+          },
+          {
+            name: 'menu',
+            title: 'Menu',
+            description: 'Menu-bar command',
+            mode: 'menu-bar',
+          },
+        ],
+        preferences: [
+          {
+            name: 'freshExtensionPref',
+            title: 'Fresh Extension Pref',
+            type: 'textfield',
+            default: 'default-extension',
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+  fs.writeFileSync(path.join(buildDir, 'background.js'), 'module.exports = { name: "background" };\n');
+  fs.writeFileSync(path.join(buildDir, 'menu.js'), 'module.exports = { name: "menu" };\n');
+
+  return { tmpDir, userDataDir, extDir };
+}
+
+export async function bundleExtensionRunner(userDataDir) {
+  const outFile = path.join(
+    os.tmpdir(),
+    `sc-extension-runner-measure-${process.pid}-${Date.now()}.cjs`
+  );
+
+  const stubModule = (filter, source) => ({
+    name: `stub-${filter}`,
+    setup(pluginBuild) {
+      pluginBuild.onResolve({ filter }, () => ({
+        path: filter.source,
+        namespace: `stub-${filter.source}`,
+      }));
+      pluginBuild.onLoad({ filter: /.*/, namespace: `stub-${filter.source}` }, () => ({
+        contents: source,
+        loader: 'js',
+      }));
+    },
+  });
+
+  await build({
+    entryPoints: [path.join(root, 'src/main/extension-runner.ts')],
+    outfile: outFile,
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    target: 'node20',
+    logLevel: 'silent',
+    plugins: [
+      stubModule(
+        /^electron$/,
+        `
+          module.exports = {
+            app: {
+              getPath(name) {
+                if (name === 'userData') return ${JSON.stringify(userDataDir)};
+                return ${JSON.stringify(userDataDir)};
+              }
+            }
+          };
+        `
+      ),
+      stubModule(
+        /extension-preferences-store$/,
+        `
+          module.exports = {
+            getExtensionPreferences(extName, cmdName) {
+              const values = globalThis.__extensionPreferenceValues || {};
+              if (cmdName) return values[extName + '/' + cmdName] || {};
+              return values[extName] || {};
+            }
+          };
+        `
+      ),
+      stubModule(
+        /settings-store$/,
+        `
+          module.exports = {
+            loadSettings() {
+              return { customExtensionFolders: [] };
+            }
+          };
+        `
+      ),
+    ],
+  });
+
+  return outFile;
+}
+
+export function createCounters(extDir) {
+  const counters = {
+    readFileSync: 0,
+    packageJsonReads: 0,
+    bundleReads: 0,
+    jsonParseCalls: 0,
+    existsSync: 0,
+    statSync: 0,
+    readdirSync: 0,
+  };
+  const restore = [];
+  const packageJsonPath = path.join(extDir, 'package.json');
+  const buildDir = path.join(extDir, '.sc-build');
+
+  const patch = (target, key, wrapper) => {
+    const original = target[key];
+    target[key] = wrapper(original);
+    restore.push(() => {
+      target[key] = original;
+    });
+  };
+
+  patch(fs, 'readFileSync', (original) => function patchedReadFileSync(filePath, ...args) {
+    const normalizedPath = typeof filePath === 'string' ? filePath : String(filePath);
+    counters.readFileSync++;
+    if (path.resolve(normalizedPath) === packageJsonPath) counters.packageJsonReads++;
+    if (path.resolve(normalizedPath).startsWith(buildDir + path.sep)) counters.bundleReads++;
+    return original.call(this, filePath, ...args);
+  });
+  patch(fs, 'existsSync', (original) => function patchedExistsSync(filePath) {
+    counters.existsSync++;
+    return original.call(this, filePath);
+  });
+  patch(fs, 'statSync', (original) => function patchedStatSync(filePath, ...args) {
+    counters.statSync++;
+    return original.call(this, filePath, ...args);
+  });
+  patch(fs, 'readdirSync', (original) => function patchedReaddirSync(filePath, ...args) {
+    counters.readdirSync++;
+    return original.call(this, filePath, ...args);
+  });
+  patch(JSON, 'parse', (original) => function patchedJsonParse(source, ...args) {
+    counters.jsonParseCalls++;
+    return original.call(this, source, ...args);
+  });
+
+  return {
+    counters,
+    restore() {
+      while (restore.length > 0) restore.pop()();
+    },
+  };
+}
+
+export async function measure(label, extDir, fn) {
+  const { counters, restore } = createCounters(extDir);
+  const started = performance.now();
+  try {
+    await fn();
+  } finally {
+    counters.elapsedMs = Number((performance.now() - started).toFixed(3));
+    restore();
+  }
+  return { label, iterations, ...counters };
+}
+
+async function main() {
+  const fixture = createFixture();
+  let bundledRunner;
+  try {
+    bundledRunner = await bundleExtensionRunner(fixture.userDataDir);
+    const runner = require(bundledRunner);
+
+    globalThis.__extensionPreferenceValues = {
+      'bundle-cache-fixture': { freshExtensionPref: 'stored-extension-1' },
+      'bundle-cache-fixture/background': { freshCommandPref: 'stored-command-1' },
+    };
+
+    const noView = await measure('repeated-getExtensionBundle-no-view', fixture.extDir, async () => {
+      for (let i = 0; i < iterations; i++) {
+        const bundle = await runner.getExtensionBundle('bundle-cache-fixture', 'background');
+        assert.equal(bundle.mode, 'no-view');
+        assert.equal(bundle.preferences.freshExtensionPref, 'stored-extension-1');
+        assert.equal(bundle.preferences.freshCommandPref, 'stored-command-1');
+      }
+    });
+
+    const menuBar = await measure('repeated-menu-bar-background-prep', fixture.extDir, async () => {
+      for (let i = 0; i < iterations; i++) {
+        const commands = runner
+          .discoverInstalledExtensionCommands()
+          .filter((command) => command.mode === 'menu-bar');
+        assert.equal(commands.length, 1);
+        const bundle = await runner.getExtensionBundle(commands[0].extName, commands[0].cmdName);
+        assert.equal(bundle.mode, 'menu-bar');
+      }
+    });
+
+    console.log(JSON.stringify({ iterations, measurements: [noView, menuBar] }, null, 2));
+  } finally {
+    try {
+      if (bundledRunner) fs.unlinkSync(bundledRunner);
+    } catch {}
+    try {
+      fs.rmSync(fixture.tmpDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/measure-extension-wrapper-cache.mjs
+++ b/scripts/measure-extension-wrapper-cache.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import { performance } from 'node:perf_hooks';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importTs } from './lib/ts-import.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  clearCompiledExtensionWrapperCache,
+  EXTENSION_WRAPPER_ARGUMENTS,
+  getCompiledExtensionWrapper,
+  getCompiledExtensionWrapperCacheStats,
+} = await importTs(path.join(root, 'src/renderer/src/utils/extension-wrapper-cache.ts'));
+
+const ITERATIONS = Number.parseInt(process.env.SUPERCMD_WRAPPER_MEASURE_ITERATIONS || '1000', 10);
+
+function patchSchemeDynamicImports(sourceCode) {
+  return String(sourceCode || '').replace(
+    /\bimport\(\s*(["'])(swift:[^"']+|rust:[^"']+)\1\s*\)/g,
+    (_match, quote, specifier) => `__scDynamicImport(${quote}${specifier}${quote})`
+  );
+}
+
+function createFixtureExtensionCode() {
+  const body = `
+Object.defineProperty(exports, "__esModule", { value: true });
+const React = require("react");
+let moduleScopedCounter = 0;
+moduleScopedCounter += 1;
+const pendingTimer = setTimeout(() => {}, 60000);
+exports.default = function FixtureCommand() {
+  return {
+    reactVersion: React.version,
+    moduleScopedCounter,
+    pendingTimerType: typeof pendingTimer
+  };
+};
+`;
+  return body + '\n'.repeat(20) + '// filler '.repeat(250);
+}
+
+function createRunEnv() {
+  const moduleExports = {};
+  const fakeModule = { exports: moduleExports };
+  const timers = new Set();
+  const trackTimeout = (cb, ms, ...rest) => {
+    const id = setTimeout(cb, ms, ...rest);
+    timers.add(id);
+    return id;
+  };
+  const trackClearTimeout = (id) => {
+    timers.delete(id);
+    clearTimeout(id);
+  };
+  const fakeRequire = (name) => {
+    if (name === 'react') return { version: '18.2.0' };
+    return {};
+  };
+
+  return {
+    args: [
+      moduleExports,
+      fakeRequire,
+      fakeModule,
+      '/extension/index.js',
+      '/extension',
+      { env: {} },
+      Buffer,
+      globalThis,
+      globalThis,
+      (fn, ...args) => trackTimeout(() => fn(...args), 0),
+      trackClearTimeout,
+      () => 0,
+      () => {},
+      trackTimeout,
+      trackClearTimeout,
+      () => 0,
+      () => {},
+      undefined,
+      async () => ({}),
+    ],
+    fakeModule,
+    cleanup: () => {
+      timers.forEach((id) => clearTimeout(id));
+      timers.clear();
+    },
+    getTimerCount: () => timers.size,
+  };
+}
+
+function measureUncachedLoads(code, iterations) {
+  let wrapperCreationCount = 0;
+  let wrapperCreationMs = 0;
+  let executionMs = 0;
+  let leakedTimerPeak = 0;
+
+  for (let i = 0; i < iterations; i++) {
+    const executableCode = patchSchemeDynamicImports(code);
+
+    const compileStart = performance.now();
+    const wrapper = new Function(...EXTENSION_WRAPPER_ARGUMENTS, executableCode);
+    wrapperCreationMs += performance.now() - compileStart;
+    wrapperCreationCount++;
+
+    const env = createRunEnv();
+    const executionStart = performance.now();
+    wrapper(...env.args);
+    executionMs += performance.now() - executionStart;
+    leakedTimerPeak = Math.max(leakedTimerPeak, env.getTimerCount());
+    env.cleanup();
+
+    if (typeof env.fakeModule.exports.default !== 'function') {
+      throw new Error('Fixture did not export a function');
+    }
+  }
+
+  return {
+    iterations,
+    wrapperCreationCount,
+    wrapperCreationMs,
+    executionMs,
+    totalLoadMs: wrapperCreationMs + executionMs,
+    leakedTimerPeak,
+  };
+}
+
+function measureCachedLoads(code, iterations) {
+  clearCompiledExtensionWrapperCache();
+
+  let cacheLookupMs = 0;
+  let executionMs = 0;
+  let leakedTimerPeak = 0;
+
+  for (let i = 0; i < iterations; i++) {
+    const executableCode = patchSchemeDynamicImports(code);
+
+    const cacheStart = performance.now();
+    const { wrapper } = getCompiledExtensionWrapper({
+      extensionIdentity: 'fixture-owner/fixture-extension/fixture-command',
+      code,
+      executableCode,
+    });
+    cacheLookupMs += performance.now() - cacheStart;
+
+    const env = createRunEnv();
+    const executionStart = performance.now();
+    wrapper(...env.args);
+    executionMs += performance.now() - executionStart;
+    leakedTimerPeak = Math.max(leakedTimerPeak, env.getTimerCount());
+    env.cleanup();
+
+    if (typeof env.fakeModule.exports.default !== 'function') {
+      throw new Error('Fixture did not export a function');
+    }
+  }
+
+  const stats = getCompiledExtensionWrapperCacheStats();
+  return {
+    iterations,
+    wrapperCreationCount: stats.wrapperCreationCount,
+    wrapperCreationMs: stats.wrapperCreationMs,
+    cacheHits: stats.hits,
+    cacheMisses: stats.misses,
+    cacheLookupMs,
+    executionMs,
+    totalLoadMs: cacheLookupMs + executionMs,
+    leakedTimerPeak,
+  };
+}
+
+const fixtureCode = createFixtureExtensionCode();
+
+console.log(JSON.stringify({
+  scenario: 'extension-wrapper-cache',
+  codeLength: fixtureCode.length,
+  uncached: measureUncachedLoads(fixtureCode, ITERATIONS),
+  cached: measureCachedLoads(fixtureCode, ITERATIONS),
+}, null, 2));

--- a/scripts/test-abortable-promise-hooks.mjs
+++ b/scripts/test-abortable-promise-hooks.mjs
@@ -1,0 +1,378 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+let activeHost = null;
+
+const fakeReact = {
+  useCallback: (...args) => activeHost.useCallback(...args),
+  useEffect: (...args) => activeHost.useEffect(...args),
+  useMemo: (...args) => activeHost.useMemo(...args),
+  useRef: (...args) => activeHost.useRef(...args),
+  useState: (...args) => activeHost.useState(...args),
+};
+
+const moduleCache = new Map();
+
+function loadTsModule(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  if (moduleCache.has(resolvedPath)) return moduleCache.get(resolvedPath).exports;
+
+  const source = fs.readFileSync(resolvedPath, 'utf8');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    },
+    fileName: resolvedPath,
+  });
+
+  const module = { exports: {} };
+  moduleCache.set(resolvedPath, module);
+  const localRequire = (request) => {
+    if (request === 'react') return fakeReact;
+    if (request.startsWith('.')) {
+      const candidate = path.resolve(path.dirname(resolvedPath), request);
+      for (const suffix of ['', '.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.tsx']) {
+        const nextPath = `${candidate}${suffix}`;
+        if (fs.existsSync(nextPath) && fs.statSync(nextPath).isFile()) {
+          if (nextPath.endsWith('.ts') || nextPath.endsWith('.tsx')) return loadTsModule(nextPath);
+          return require(nextPath);
+        }
+      }
+    }
+    return require(request);
+  };
+
+  const sandbox = {
+    AbortController,
+    Array,
+    console,
+    Date,
+    Error,
+    JSON,
+    Map,
+    Math,
+    module,
+    Object,
+    Promise,
+    queueMicrotask,
+    RegExp,
+    require: localRequire,
+    setTimeout,
+    clearTimeout,
+    String,
+    Symbol,
+    URL,
+    exports: module.exports,
+  };
+  vm.runInNewContext(transpiled.outputText, sandbox, { filename: resolvedPath });
+  return module.exports;
+}
+
+class HookHost {
+  constructor(renderHook) {
+    this.renderHook = renderHook;
+    this.hookIndex = 0;
+    this.hooks = [];
+    this.pendingEffects = [];
+    this.output = undefined;
+    this.isRendering = false;
+    this.isFlushingEffects = false;
+    this.needsRender = false;
+    this.unmounted = false;
+  }
+
+  render() {
+    if (this.unmounted) return this.output;
+    this.hookIndex = 0;
+    this.pendingEffects = [];
+    this.isRendering = true;
+    const previousHost = activeHost;
+    activeHost = this;
+    try {
+      this.output = this.renderHook();
+    } finally {
+      activeHost = previousHost;
+      this.isRendering = false;
+    }
+    this.flushEffects();
+    return this.output;
+  }
+
+  flushEffects() {
+    this.isFlushingEffects = true;
+    try {
+      for (const { index, effect } of this.pendingEffects) {
+        const record = this.hooks[index];
+        if (record.cleanup) record.cleanup();
+        const cleanup = effect();
+        record.cleanup = typeof cleanup === 'function' ? cleanup : undefined;
+      }
+    } finally {
+      this.isFlushingEffects = false;
+    }
+
+    if (this.needsRender && !this.unmounted) {
+      this.needsRender = false;
+      this.render();
+    }
+  }
+
+  scheduleRender() {
+    if (this.unmounted) return;
+    if (this.isRendering || this.isFlushingEffects) {
+      this.needsRender = true;
+      return;
+    }
+    this.render();
+  }
+
+  useState(initialValue) {
+    const index = this.hookIndex++;
+    if (!this.hooks[index]) {
+      this.hooks[index] = {
+        state: typeof initialValue === 'function' ? initialValue() : initialValue,
+      };
+    }
+    const setState = (nextValue) => {
+      const record = this.hooks[index];
+      const next = typeof nextValue === 'function' ? nextValue(record.state) : nextValue;
+      if (Object.is(record.state, next)) return;
+      record.state = next;
+      this.scheduleRender();
+    };
+    return [this.hooks[index].state, setState];
+  }
+
+  useRef(initialValue) {
+    const index = this.hookIndex++;
+    if (!this.hooks[index]) {
+      this.hooks[index] = { current: initialValue };
+    }
+    return this.hooks[index];
+  }
+
+  useEffect(effect, deps) {
+    const index = this.hookIndex++;
+    const record = this.hooks[index] || {};
+    const changed = !record.deps || !depsEqual(record.deps, deps);
+    this.hooks[index] = { ...record, deps };
+    if (changed) {
+      this.pendingEffects.push({ index, effect });
+    }
+  }
+
+  useCallback(callback, deps) {
+    return this.useMemo(() => callback, deps);
+  }
+
+  useMemo(factory, deps) {
+    const index = this.hookIndex++;
+    const record = this.hooks[index];
+    if (record && depsEqual(record.deps, deps)) return record.value;
+    const value = factory();
+    this.hooks[index] = { value, deps };
+    return value;
+  }
+
+  unmount() {
+    this.unmounted = true;
+    for (const record of this.hooks) {
+      if (record?.cleanup) {
+        record.cleanup();
+        record.cleanup = undefined;
+      }
+    }
+  }
+}
+
+function depsEqual(previousDeps, nextDeps) {
+  if (!previousDeps || !nextDeps || previousDeps.length !== nextDeps.length) return false;
+  return previousDeps.every((value, index) => Object.is(value, nextDeps[index]));
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function currentController(abortable) {
+  const controller = abortable.current;
+  assert.ok(controller instanceof AbortController, 'abortable.current should be an AbortController for each run');
+  return controller;
+}
+
+const { usePromise } = loadTsModule('src/renderer/src/raycast-api/hooks/use-promise.ts');
+const { useCachedPromise } = loadTsModule('src/renderer/src/raycast-api/hooks/use-cached-promise.ts');
+
+test('usePromise aborts the previous abortable run before revalidate starts another run', async () => {
+  const abortable = { current: null };
+  const controllers = [];
+  const pending = [];
+  const fn = () => {
+    controllers.push(currentController(abortable));
+    const run = deferred();
+    pending.push(run);
+    return run.promise;
+  };
+  const host = new HookHost(() => usePromise(fn, [], { abortable }));
+
+  host.render();
+  await flushAsync();
+  assert.equal(controllers.length, 1);
+
+  host.output.revalidate();
+  await flushAsync();
+
+  assert.equal(controllers.length, 2);
+  assert.equal(controllers[0].signal.aborted, true);
+  assert.notEqual(controllers[1], controllers[0]);
+  assert.equal(controllers[1].signal.aborted, false);
+
+  host.unmount();
+});
+
+test('useCachedPromise aborts the previous abortable run before revalidate starts another run', async () => {
+  const abortable = { current: null };
+  const controllers = [];
+  const pending = [];
+  const fn = () => {
+    controllers.push(currentController(abortable));
+    const run = deferred();
+    pending.push(run);
+    return run.promise;
+  };
+  const host = new HookHost(() => useCachedPromise(fn, [], { abortable }));
+
+  host.render();
+  await flushAsync();
+  assert.equal(controllers.length, 1);
+
+  host.output.revalidate();
+  await flushAsync();
+
+  assert.equal(controllers.length, 2);
+  assert.equal(controllers[0].signal.aborted, true);
+  assert.notEqual(controllers[1], controllers[0]);
+  assert.equal(controllers[1].signal.aborted, false);
+
+  host.unmount();
+});
+
+test('usePromise aborts active abortable work on unmount and clears the abortable ref', async () => {
+  const abortable = { current: null };
+  const controllers = [];
+  const fn = () => {
+    controllers.push(currentController(abortable));
+    return deferred().promise;
+  };
+  const host = new HookHost(() => usePromise(fn, [], { abortable }));
+
+  host.render();
+  await flushAsync();
+  host.unmount();
+
+  assert.equal(controllers.length, 1);
+  assert.equal(controllers[0].signal.aborted, true);
+  assert.equal(abortable.current, null);
+});
+
+test('useCachedPromise aborts active abortable work on unmount and clears the abortable ref', async () => {
+  const abortable = { current: null };
+  const controllers = [];
+  const fn = () => {
+    controllers.push(currentController(abortable));
+    return deferred().promise;
+  };
+  const host = new HookHost(() => useCachedPromise(fn, [], { abortable }));
+
+  host.render();
+  await flushAsync();
+  host.unmount();
+
+  assert.equal(controllers.length, 1);
+  assert.equal(controllers[0].signal.aborted, true);
+  assert.equal(abortable.current, null);
+});
+
+test('usePromise keeps the latest abortable result when an older aborted run resolves later', async () => {
+  const abortable = { current: null };
+  const pending = [];
+  const onDataCalls = [];
+  const fn = () => {
+    currentController(abortable);
+    const run = deferred();
+    pending.push(run);
+    return run.promise;
+  };
+  const host = new HookHost(() => usePromise(fn, [], { abortable, onData: (data) => onDataCalls.push(data) }));
+
+  host.render();
+  await flushAsync();
+  host.output.revalidate();
+  await flushAsync();
+
+  pending[1].resolve('latest');
+  await flushAsync();
+  assert.equal(host.output.data, 'latest');
+  assert.deepEqual(onDataCalls, ['latest']);
+
+  pending[0].resolve('stale');
+  await flushAsync();
+  assert.equal(host.output.data, 'latest');
+  assert.deepEqual(onDataCalls, ['latest']);
+
+  host.unmount();
+});
+
+test('useCachedPromise keeps the latest abortable result when an older aborted run resolves later', async () => {
+  const abortable = { current: null };
+  const pending = [];
+  const onDataCalls = [];
+  const fn = () => {
+    currentController(abortable);
+    const run = deferred();
+    pending.push(run);
+    return run.promise;
+  };
+  const host = new HookHost(() => useCachedPromise(fn, [], { abortable, onData: (data) => onDataCalls.push(data) }));
+
+  host.render();
+  await flushAsync();
+  host.output.revalidate();
+  await flushAsync();
+
+  pending[1].resolve('latest');
+  await flushAsync();
+  assert.equal(host.output.data, 'latest');
+  assert.deepEqual(onDataCalls, ['latest']);
+
+  pending[0].resolve('stale');
+  await flushAsync();
+  assert.equal(host.output.data, 'latest');
+  assert.deepEqual(onDataCalls, ['latest']);
+
+  host.unmount();
+});

--- a/scripts/test-background-no-view-dedupe.mjs
+++ b/scripts/test-background-no-view-dedupe.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import assert from 'assert/strict';
+import fs from 'fs';
+import path from 'path';
+import test from 'node:test';
+import vm from 'vm';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+const moduleCache = new Map();
+
+function loadTsModule(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  if (moduleCache.has(resolvedPath)) return moduleCache.get(resolvedPath).exports;
+
+  const source = fs.readFileSync(resolvedPath, 'utf8');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    },
+    fileName: resolvedPath,
+  });
+
+  const module = { exports: {} };
+  moduleCache.set(resolvedPath, module);
+  const localRequire = (request) => {
+    if (request.startsWith('.')) {
+      const candidate = path.resolve(path.dirname(resolvedPath), request);
+      for (const suffix of ['', '.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.tsx']) {
+        const nextPath = `${candidate}${suffix}`;
+        if (fs.existsSync(nextPath) && fs.statSync(nextPath).isFile()) {
+          if (nextPath.endsWith('.ts') || nextPath.endsWith('.tsx')) return loadTsModule(nextPath);
+          return require(nextPath);
+        }
+      }
+    }
+    return require(request);
+  };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require: localRequire,
+    console,
+    Date,
+    Math,
+    String,
+    Number,
+    Set,
+    Map,
+    Object,
+    Array,
+    RegExp,
+  };
+  vm.runInNewContext(transpiled.outputText, sandbox, { filename: resolvedPath });
+  return module.exports;
+}
+
+const {
+  enqueueBackgroundNoViewRun,
+  getBackgroundNoViewRunIdentity,
+  removeBackgroundNoViewRun,
+} = loadTsModule('src/renderer/src/utils/background-no-view-runs.ts');
+
+function runIdentity(bundle) {
+  return `${bundle.extensionName || bundle.extName || ''}/${bundle.commandName || bundle.cmdName || ''}`;
+}
+
+function legacyQueueNoViewBundleRun(prev, bundle, launchType = 'background', reportStatus = false, now = Date.now) {
+  const runId = `${runIdentity(bundle)}/${now()}`;
+  return [...prev, { runId, bundle, launchType, reportStatus }];
+}
+
+function simulateRepeatedBackgroundTicks({ enqueue, ticks, intervalMs }) {
+  const bundle = {
+    code: 'export default async function Command() {}',
+    mode: 'no-view',
+    title: 'Refresh Widgets',
+    extensionName: 'widgets',
+    commandName: 'refresh',
+  };
+  let runs = [];
+  const tickTimes = Array.from({ length: ticks }, (_, index) => index * intervalMs);
+  for (const elapsedMs of tickTimes) {
+    runs = enqueue(runs, bundle, 'background', false, () => elapsedMs);
+  }
+  return {
+    runs,
+    ticks,
+    intervalMs,
+    elapsedMs: tickTimes.at(-1) ?? 0,
+  };
+}
+
+function simulateDedupedBackgroundTicks({ ticks, intervalMs }) {
+  const bundle = {
+    code: 'export default async function Command() {}',
+    mode: 'no-view',
+    title: 'Refresh Widgets',
+    extName: 'widgets',
+    cmdName: 'refresh',
+    extensionName: 'widgets',
+    commandName: 'refresh',
+  };
+  let runs = [];
+  let enqueued = 0;
+  const tickTimes = Array.from({ length: ticks }, (_, index) => index * intervalMs);
+  for (const elapsedMs of tickTimes) {
+    const result = enqueueBackgroundNoViewRun(runs, bundle, 'background', false, () => elapsedMs);
+    runs = result.runs;
+    if (result.enqueued) enqueued += 1;
+  }
+  return {
+    runs,
+    enqueued,
+    skipped: ticks - enqueued,
+    ticks,
+    intervalMs,
+    elapsedMs: tickTimes.at(-1) ?? 0,
+  };
+}
+
+function testBundle(overrides = {}) {
+  return {
+    code: 'export default async function Command() {}',
+    mode: 'no-view',
+    title: 'Refresh Widgets',
+    extName: 'widgets',
+    cmdName: 'refresh',
+    ...overrides,
+  };
+}
+
+test('baseline: legacy background no-view queue accepts overlapping duplicate ticks', () => {
+  const metrics = simulateRepeatedBackgroundTicks({
+    enqueue: legacyQueueNoViewBundleRun,
+    ticks: 3,
+    intervalMs: 25,
+  });
+
+  console.log(
+    `[baseline] background no-view duplicate ticks: ticks=${metrics.ticks} intervalMs=${metrics.intervalMs} elapsedMs=${metrics.elapsedMs} queued=${metrics.runs.length}`
+  );
+
+  assert.equal(metrics.runs.length, 3);
+  assert.deepEqual(metrics.runs.map((run) => runIdentity(run.bundle)), [
+    'widgets/refresh',
+    'widgets/refresh',
+    'widgets/refresh',
+  ]);
+});
+
+test('background no-view queue dedupes overlapping ticks for the same extension command', () => {
+  const metrics = simulateDedupedBackgroundTicks({
+    ticks: 3,
+    intervalMs: 25,
+  });
+
+  console.log(
+    `[after] background no-view duplicate ticks: ticks=${metrics.ticks} intervalMs=${metrics.intervalMs} elapsedMs=${metrics.elapsedMs} queued=${metrics.runs.length} skipped=${metrics.skipped}`
+  );
+
+  assert.equal(metrics.enqueued, 1);
+  assert.equal(metrics.skipped, 2);
+  assert.equal(metrics.runs.length, 1);
+  assert.equal(getBackgroundNoViewRunIdentity(metrics.runs[0].bundle), 'widgets/refresh');
+});
+
+test('background no-view identity matches legacy and hydrated bundle fields', () => {
+  const legacyFields = testBundle();
+  const hydratedFields = {
+    code: legacyFields.code,
+    mode: legacyFields.mode,
+    title: legacyFields.title,
+    extensionName: 'widgets',
+    commandName: 'refresh',
+  };
+
+  const first = enqueueBackgroundNoViewRun([], legacyFields, 'background', false, () => 0);
+  assert.equal(first.enqueued, true);
+
+  const duplicate = enqueueBackgroundNoViewRun(first.runs, hydratedFields, 'background', false, () => 25);
+  assert.equal(duplicate.enqueued, false);
+  assert.equal(duplicate.runs.length, 1);
+});
+
+test('user-initiated no-view launches are not deduped', () => {
+  const bundle = testBundle();
+  let runs = [];
+  for (const elapsedMs of [0, 25, 50]) {
+    const result = enqueueBackgroundNoViewRun(runs, bundle, 'userInitiated', false, () => elapsedMs);
+    assert.equal(result.enqueued, true);
+    runs = result.runs;
+  }
+
+  assert.equal(runs.length, 3);
+  assert.deepEqual(Array.from(runs, (run) => run.launchType), [
+    'userInitiated',
+    'userInitiated',
+    'userInitiated',
+  ]);
+});
+
+test('background no-view launch skips while same command is already in flight', () => {
+  const bundle = testBundle({
+    extensionName: 'widgets',
+    commandName: 'refresh',
+  });
+  const userLaunch = enqueueBackgroundNoViewRun([], bundle, 'userInitiated', false, () => 0);
+  assert.equal(userLaunch.enqueued, true);
+
+  const backgroundTick = enqueueBackgroundNoViewRun(userLaunch.runs, bundle, 'background', false, () => 25);
+  assert.equal(backgroundTick.enqueued, false);
+  assert.equal(backgroundTick.runs.length, 1);
+
+  const explicitLaunch = enqueueBackgroundNoViewRun(backgroundTick.runs, bundle, 'userInitiated', false, () => 50);
+  assert.equal(explicitLaunch.enqueued, true);
+  assert.equal(explicitLaunch.runs.length, 2);
+});
+
+test('clearing a background no-view run allows the next background tick to enqueue', () => {
+  const bundle = testBundle({
+    extensionName: 'widgets',
+    commandName: 'refresh',
+  });
+
+  for (const reason of ['success', 'error', 'unmount']) {
+    const first = enqueueBackgroundNoViewRun([], bundle, 'background', false, () => 0);
+    assert.equal(first.enqueued, true, reason);
+
+    const overlapping = enqueueBackgroundNoViewRun(first.runs, bundle, 'background', false, () => 25);
+    assert.equal(overlapping.enqueued, false, reason);
+    assert.equal(overlapping.runs.length, 1, reason);
+
+    const cleared = removeBackgroundNoViewRun(overlapping.runs, overlapping.runs[0].runId);
+    assert.equal(cleared.length, 0, reason);
+
+    const afterClear = enqueueBackgroundNoViewRun(cleared, bundle, 'background', false, () => 50);
+    assert.equal(afterClear.enqueued, true, reason);
+    assert.equal(afterClear.runs.length, 1, reason);
+  }
+});

--- a/scripts/test-background-refresh-timer-diff.mjs
+++ b/scripts/test-background-refresh-timer-diff.mjs
@@ -1,0 +1,230 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const helperPath = path.join(rootDir, 'src/renderer/src/hooks/backgroundRefreshTimers.ts');
+
+function loadHelperModule() {
+  const source = fs.readFileSync(helperPath, 'utf8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: helperPath,
+  });
+  const module = { exports: {} };
+
+  vm.runInNewContext(
+    compiled.outputText,
+    {
+      exports: module.exports,
+      module,
+      require: (specifier) => {
+        throw new Error(`Unexpected runtime import while loading timer helper: ${specifier}`);
+      },
+    },
+    { filename: helperPath }
+  );
+
+  return module.exports;
+}
+
+const {
+  getBackgroundRefreshTimerDescriptors,
+  reconcileBackgroundRefreshTimers,
+  clearBackgroundRefreshTimers,
+} = loadHelperModule();
+
+function parseIntervalToMs(interval) {
+  return {
+    '1m': 60_000,
+    '5m': 300_000,
+    '10m': 600_000,
+  }[interval] ?? null;
+}
+
+function extensionCommand(overrides = {}) {
+  return {
+    id: 'extension-weather-current',
+    title: 'Current Weather',
+    category: 'extension',
+    path: 'weather/current',
+    mode: 'no-view',
+    interval: '1m',
+    ...overrides,
+  };
+}
+
+function inlineScriptCommand(overrides = {}) {
+  return {
+    id: 'script-stock-ticker',
+    title: 'Stock Ticker',
+    category: 'script',
+    path: '/Users/example/Scripts/stocks.sh',
+    mode: 'inline',
+    interval: '5m',
+    ...overrides,
+  };
+}
+
+function descriptors(commands) {
+  return getBackgroundRefreshTimerDescriptors(commands, parseIntervalToMs);
+}
+
+function legacyReconcile(commands, activeTimers) {
+  const cleared = activeTimers.length;
+  activeTimers.length = 0;
+
+  for (const descriptor of descriptors(commands)) {
+    activeTimers.push(descriptor.key);
+  }
+
+  return { created: activeTimers.length, cleared };
+}
+
+function createHarness() {
+  const timers = new Map();
+  const created = [];
+  const cleared = [];
+  let nextTimerId = 1;
+
+  return {
+    timers,
+    created,
+    cleared,
+    reconcile(commands) {
+      return reconcileBackgroundRefreshTimers({
+        timers,
+        descriptors: descriptors(commands),
+        createTimer(descriptor) {
+          const timerId = nextTimerId++;
+          created.push({ timerId, key: descriptor.key, commandId: descriptor.command.id });
+          return timerId;
+        },
+        clearTimer(timerId) {
+          cleared.push(timerId);
+        },
+      });
+    },
+    clearAll() {
+      return clearBackgroundRefreshTimers(timers, (timerId) => {
+        cleared.push(timerId);
+      });
+    },
+  };
+}
+
+function activeTimerIds(harness) {
+  return Array.from(harness.timers.values()).map((entry) => entry.timerId);
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test('Background refresh timer diff', async (t) => {
+  await t.test('baseline legacy strategy clears and recreates unchanged background commands', () => {
+    const activeTimers = [];
+    const initialCommands = [
+      extensionCommand(),
+      inlineScriptCommand(),
+      { id: 'app-terminal', title: 'Terminal', category: 'app' },
+    ];
+    const refreshedCommands = [
+      extensionCommand({ subtitle: 'Updated metadata' }),
+      inlineScriptCommand({ subtitle: 'AAPL 210.00' }),
+      { id: 'app-terminal', title: 'Terminal', category: 'app', subtitle: 'Terminal.app' },
+    ];
+
+    const first = legacyReconcile(initialCommands, activeTimers);
+    const second = legacyReconcile(refreshedCommands, activeTimers);
+
+    console.log(
+      `[background-refresh baseline] unchanged update legacy created=${second.created} cleared=${second.cleared}`
+    );
+    assert.deepEqual(first, { created: 2, cleared: 0 });
+    assert.deepEqual(second, { created: 2, cleared: 2 });
+  });
+
+  await t.test('unchanged background commands retain their timers across command-list updates', () => {
+    const harness = createHarness();
+    const initial = harness.reconcile([
+      extensionCommand(),
+      inlineScriptCommand(),
+      { id: 'app-terminal', title: 'Terminal', category: 'app' },
+    ]);
+    const timerIdsBeforeUpdate = activeTimerIds(harness);
+
+    const update = harness.reconcile([
+      extensionCommand({ subtitle: 'Updated metadata' }),
+      inlineScriptCommand({ subtitle: 'AAPL 210.00' }),
+      { id: 'app-terminal', title: 'Terminal', category: 'app', subtitle: 'Terminal.app' },
+    ]);
+
+    console.log(
+      `[background-refresh keyed] unchanged update created=${update.created} retained=${update.retained} cleared=${update.cleared}`
+    );
+    assert.deepEqual(plain(initial), { created: 2, retained: 0, cleared: 0 });
+    assert.deepEqual(plain(update), { created: 0, retained: 2, cleared: 0 });
+    assert.deepEqual(activeTimerIds(harness), timerIdsBeforeUpdate);
+    assert.equal(harness.created.length, 2);
+    assert.equal(harness.cleared.length, 0);
+  });
+
+  await t.test('added background commands create timers and removed commands clear timers', () => {
+    const harness = createHarness();
+    const extension = extensionCommand();
+    const script = inlineScriptCommand();
+
+    assert.deepEqual(plain(harness.reconcile([extension])), { created: 1, retained: 0, cleared: 0 });
+    assert.deepEqual(plain(harness.reconcile([extension, script])), { created: 1, retained: 1, cleared: 0 });
+    assert.deepEqual(plain(harness.reconcile([script])), { created: 0, retained: 1, cleared: 1 });
+    assert.deepEqual(activeTimerIds(harness), [2]);
+    assert.deepEqual(harness.cleared, [1]);
+  });
+
+  await t.test('changed background command identity fields restart only the changed timer', () => {
+    const harness = createHarness();
+    const extension = extensionCommand();
+    const script = inlineScriptCommand();
+
+    assert.deepEqual(plain(harness.reconcile([extension, script])), { created: 2, retained: 0, cleared: 0 });
+    assert.deepEqual(plain(harness.reconcile([extensionCommand({ interval: '5m' }), script])), {
+      created: 1,
+      retained: 1,
+      cleared: 1,
+    });
+    assert.deepEqual(activeTimerIds(harness), [2, 3]);
+    assert.deepEqual(harness.cleared, [1]);
+
+    assert.deepEqual(plain(harness.reconcile([extensionCommand({ interval: '5m', mode: 'menu-bar' }), script])), {
+      created: 1,
+      retained: 1,
+      cleared: 1,
+    });
+    assert.deepEqual(activeTimerIds(harness), [2, 4]);
+    assert.deepEqual(harness.cleared, [1, 3]);
+  });
+
+  await t.test('unmount cleanup clears all remaining timers once', () => {
+    const harness = createHarness();
+
+    assert.deepEqual(plain(harness.reconcile([extensionCommand(), inlineScriptCommand()])), {
+      created: 2,
+      retained: 0,
+      cleared: 0,
+    });
+    assert.equal(harness.clearAll(), 2);
+    assert.deepEqual(activeTimerIds(harness), []);
+    assert.deepEqual(harness.cleared, [1, 2]);
+  });
+});

--- a/scripts/test-exec-command-timeout-cleanup.mjs
+++ b/scripts/test-exec-command-timeout-cleanup.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importTs } from './lib/ts-import.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { runExecCommand } = await importTs(path.join(root, 'src/main/exec-command.ts'));
+
+function createTimerHarness() {
+  let nextId = 1;
+  const active = new Map();
+  const cleared = [];
+
+  return {
+    setTimeout(callback, ms) {
+      const id = nextId++;
+      active.set(id, { callback, ms });
+      return id;
+    },
+    clearTimeout(id) {
+      cleared.push(id);
+      active.delete(id);
+    },
+    runNext() {
+      const next = active.entries().next();
+      if (next.done) return false;
+      const [id, timer] = next.value;
+      active.delete(id);
+      timer.callback();
+      return true;
+    },
+    get activeCount() {
+      return active.size;
+    },
+    get cleared() {
+      return cleared;
+    },
+  };
+}
+
+function createFakeProc() {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = {
+    writes: [],
+    ended: false,
+    write(value) {
+      this.writes.push(value);
+    },
+    end() {
+      this.ended = true;
+    },
+  };
+  proc.killCount = 0;
+  proc.kill = () => {
+    proc.killCount += 1;
+  };
+  return proc;
+}
+
+function createHarness() {
+  const timer = createTimerHarness();
+  const spawned = [];
+  const dependencies = {
+    spawn(command, args, options) {
+      const proc = createFakeProc();
+      spawned.push({ command, args, options, proc });
+      return proc;
+    },
+    existsSync() {
+      return true;
+    },
+    env: { PATH: '/test/bin' },
+    cwd: () => '/test/cwd',
+    setTimeout: timer.setTimeout,
+    clearTimeout: timer.clearTimeout,
+  };
+
+  return {
+    timer,
+    spawned,
+    run(command = '/bin/test-command', args = ['--flag'], options) {
+      return runExecCommand(command, args, options, dependencies);
+    },
+  };
+}
+
+test('exec-command timeout cleanup', async (t) => {
+  await t.test('clears timeout handle when process closes before timeout', async () => {
+    const harness = createHarness();
+    const promise = harness.run();
+    const { proc } = harness.spawned[0];
+
+    proc.stdout.emit('data', Buffer.from('done'));
+    proc.stderr.emit('data', Buffer.from('warn'));
+    proc.emit('close', 0);
+
+    assert.deepEqual(await promise, { stdout: 'done', stderr: 'warn', exitCode: 0 });
+    assert.equal(harness.timer.activeCount, 0);
+    assert.equal(harness.timer.cleared.length, 1);
+    assert.equal(proc.killCount, 0);
+  });
+
+  await t.test('clears timeout handle when process errors before timeout', async () => {
+    const harness = createHarness();
+    const promise = harness.run();
+    const { proc } = harness.spawned[0];
+
+    proc.stderr.emit('data', Buffer.from('partial stderr'));
+    proc.emit('error', new Error('spawn failed'));
+
+    assert.deepEqual(await promise, { stdout: '', stderr: 'spawn failed', exitCode: 1 });
+    assert.equal(harness.timer.activeCount, 0);
+    assert.equal(harness.timer.cleared.length, 1);
+    assert.equal(proc.killCount, 0);
+  });
+
+  await t.test('kills process and resolves with timeout result on timeout path', async () => {
+    const harness = createHarness();
+    const promise = harness.run();
+    const { proc } = harness.spawned[0];
+
+    proc.stdout.emit('data', Buffer.from('before-timeout'));
+    assert.equal(harness.timer.runNext(), true);
+
+    assert.deepEqual(await promise, {
+      stdout: 'before-timeout',
+      stderr: 'Command timed out',
+      exitCode: 124,
+    });
+    assert.equal(proc.killCount, 1);
+    assert.equal(harness.timer.activeCount, 0);
+    assert.equal(harness.timer.cleared.length, 1);
+  });
+
+  await t.test('settles once when close, error, and timeout race', async () => {
+    const harness = createHarness();
+    const promise = harness.run();
+    const { proc } = harness.spawned[0];
+
+    proc.emit('close', 7);
+    proc.emit('error', new Error('late error'));
+    assert.equal(harness.timer.runNext(), false);
+
+    assert.deepEqual(await promise, { stdout: '', stderr: '', exitCode: 7 });
+    assert.equal(harness.timer.activeCount, 0);
+    assert.equal(harness.timer.cleared.length, 1);
+    assert.equal(proc.killCount, 0);
+  });
+});

--- a/scripts/test-extension-bundle-cache.mjs
+++ b/scripts/test-extension-bundle-cache.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import {
+  bundleExtensionRunner,
+  createCounters,
+  createFixture,
+} from './measure-extension-bundle-cache.mjs';
+
+const require = createRequire(import.meta.url);
+
+function updatedFixtureManifest() {
+  return {
+    name: 'bundle-cache-fixture',
+    title: 'Bundle Cache Fixture',
+    description: 'Fixture for extension bundle cache measurement',
+    owner: 'codex',
+    commands: [
+      {
+        name: 'background',
+        title: 'Background Updated',
+        description: 'No-view command',
+        mode: 'no-view',
+        preferences: [
+          {
+            name: 'freshCommandPref',
+            title: 'Fresh Command Pref',
+            type: 'textfield',
+            default: 'default-command',
+          },
+        ],
+      },
+      {
+        name: 'menu',
+        title: 'Menu',
+        description: 'Menu-bar command',
+        mode: 'menu-bar',
+      },
+    ],
+    preferences: [
+      {
+        name: 'freshExtensionPref',
+        title: 'Fresh Extension Pref',
+        type: 'textfield',
+        default: 'default-extension',
+      },
+    ],
+  };
+}
+
+test('extension bundle cache hits and invalidates by file stats', async () => {
+  const fixture = createFixture();
+  const bundledRunner = await bundleExtensionRunner(fixture.userDataDir);
+  const runner = require(bundledRunner);
+  const { counters, restore } = createCounters(fixture.extDir);
+
+  try {
+    globalThis.__extensionPreferenceValues = {
+      'bundle-cache-fixture': { freshExtensionPref: 'stored-extension-1' },
+      'bundle-cache-fixture/background': { freshCommandPref: 'stored-command-1' },
+    };
+
+    const first = await runner.getExtensionBundle('bundle-cache-fixture', 'background');
+    assert.equal(first.title, 'Background');
+    assert.match(first.code, /background/);
+    assert.equal(first.preferences.freshExtensionPref, 'stored-extension-1');
+    assert.equal(first.preferences.freshCommandPref, 'stored-command-1');
+    assert.equal(counters.packageJsonReads, 1);
+    assert.equal(counters.bundleReads, 1);
+    assert.equal(counters.jsonParseCalls, 1);
+    assert.equal(counters.readdirSync, 1);
+
+    const afterFirst = { ...counters };
+    globalThis.__extensionPreferenceValues = {
+      'bundle-cache-fixture': { freshExtensionPref: 'stored-extension-2' },
+      'bundle-cache-fixture/background': { freshCommandPref: 'stored-command-2' },
+    };
+
+    const second = await runner.getExtensionBundle('bundle-cache-fixture', 'background');
+    assert.equal(second.preferences.freshExtensionPref, 'stored-extension-2');
+    assert.equal(second.preferences.freshCommandPref, 'stored-command-2');
+    assert.equal(counters.packageJsonReads, afterFirst.packageJsonReads);
+    assert.equal(counters.bundleReads, afterFirst.bundleReads);
+    assert.equal(counters.jsonParseCalls, afterFirst.jsonParseCalls);
+    assert.equal(counters.readdirSync, afterFirst.readdirSync);
+
+    const bundlePath = path.join(fixture.extDir, '.sc-build', 'background.js');
+    fs.writeFileSync(bundlePath, 'module.exports = { name: "background", version: 2 };\n');
+    const beforeBundleInvalidation = { ...counters };
+    const third = await runner.getExtensionBundle('bundle-cache-fixture', 'background');
+    assert.match(third.code, /version: 2/);
+    assert.equal(counters.bundleReads, beforeBundleInvalidation.bundleReads + 1);
+    assert.equal(counters.packageJsonReads, beforeBundleInvalidation.packageJsonReads);
+
+    const manifestPath = path.join(fixture.extDir, 'package.json');
+    fs.writeFileSync(manifestPath, JSON.stringify(updatedFixtureManifest(), null, 2));
+    const beforeManifestInvalidation = { ...counters };
+    const fourth = await runner.getExtensionBundle('bundle-cache-fixture', 'background');
+    assert.equal(fourth.title, 'Background Updated');
+    assert.equal(counters.packageJsonReads, beforeManifestInvalidation.packageJsonReads + 1);
+    assert.equal(counters.jsonParseCalls, beforeManifestInvalidation.jsonParseCalls + 1);
+    assert.equal(counters.bundleReads, beforeManifestInvalidation.bundleReads);
+  } finally {
+    restore();
+    try { fs.unlinkSync(bundledRunner); } catch {}
+    try { fs.rmSync(fixture.tmpDir, { recursive: true, force: true }); } catch {}
+  }
+});

--- a/scripts/test-extension-sync-facade.mjs
+++ b/scripts/test-extension-sync-facade.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+
+import assert from 'assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createRequire } from 'module';
+import { performance } from 'perf_hooks';
+import vm from 'vm';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+const ROOT = process.cwd();
+const EXTENSION_VIEW_PATH = path.join(ROOT, 'src/renderer/src/ExtensionView.tsx');
+const SYNC_METHODS = ['execCommandSync', 'fileExistsSync', 'readFileSync', 'statSync'];
+
+function parseArgs() {
+  const args = new Set(process.argv.slice(2));
+  const modeArg = process.argv.find((arg) => arg.startsWith('--mode=')) || '--mode=both';
+  const mode = modeArg.slice('--mode='.length);
+  if (!['fallback', 'node', 'both'].includes(mode)) {
+    throw new Error(`Unsupported --mode value: ${mode}`);
+  }
+  return {
+    mode,
+    assertNodeDirect: !args.has('--report-only') || args.has('--assert-node-direct'),
+  };
+}
+
+function createLocalStorage() {
+  const store = new Map();
+  return {
+    get length() {
+      return store.size;
+    },
+    key(index) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    getItem(key) {
+      return store.has(String(key)) ? store.get(String(key)) : null;
+    },
+    setItem(key, value) {
+      store.set(String(key), String(value));
+    },
+    removeItem(key) {
+      store.delete(String(key));
+    },
+    clear() {
+      store.clear();
+    },
+  };
+}
+
+function createSyncIpcProbe() {
+  const entries = [];
+  const counts = Object.fromEntries(SYNC_METHODS.map((name) => [name, 0]));
+  const timeMs = Object.fromEntries(SYNC_METHODS.map((name) => [name, 0]));
+
+  function record(name, fn) {
+    const started = performance.now();
+    try {
+      return fn();
+    } finally {
+      const elapsed = performance.now() - started;
+      counts[name] += 1;
+      timeMs[name] += elapsed;
+      entries.push({ name, elapsedMs: elapsed });
+    }
+  }
+
+  function snapshot() {
+    return {
+      counts: { ...counts },
+      timeMs: { ...timeMs },
+      totalCount: Object.values(counts).reduce((sum, value) => sum + value, 0),
+      totalTimeMs: Object.values(timeMs).reduce((sum, value) => sum + value, 0),
+    };
+  }
+
+  function delta(before) {
+    const after = snapshot();
+    const deltaCounts = {};
+    const deltaTimeMs = {};
+    for (const name of SYNC_METHODS) {
+      deltaCounts[name] = after.counts[name] - before.counts[name];
+      deltaTimeMs[name] = after.timeMs[name] - before.timeMs[name];
+    }
+    return {
+      counts: deltaCounts,
+      timeMs: deltaTimeMs,
+      totalCount: Object.values(deltaCounts).reduce((sum, value) => sum + value, 0),
+      totalTimeMs: Object.values(deltaTimeMs).reduce((sum, value) => sum + value, 0),
+    };
+  }
+
+  return { entries, record, snapshot, delta };
+}
+
+function statPayload(filePath) {
+  const stat = fs.statSync(filePath);
+  return {
+    exists: true,
+    isDirectory: stat.isDirectory(),
+    isFile: stat.isFile(),
+    size: stat.size,
+    mode: stat.mode,
+    uid: stat.uid,
+    gid: stat.gid,
+    dev: stat.dev,
+    ino: stat.ino,
+    nlink: stat.nlink,
+    atimeMs: stat.atimeMs,
+    mtimeMs: stat.mtimeMs,
+    ctimeMs: stat.ctimeMs,
+    birthtimeMs: stat.birthtimeMs,
+  };
+}
+
+function createElectronFacade(probe) {
+  return {
+    execCommandSync(command, args = [], options = {}) {
+      return probe.record('execCommandSync', () => {
+        if (command === '/bin/ls' && args[0] === '-A1') {
+          return {
+            stdout: fs.readdirSync(args[1]).join('\n'),
+            stderr: '',
+            exitCode: 0,
+          };
+        }
+        const childProcess = require('child_process');
+        const result = childProcess.spawnSync(command, args, {
+          shell: options.shell ?? false,
+          env: { ...process.env, ...options.env },
+          cwd: options.cwd || process.cwd(),
+          input: options.input,
+          encoding: 'utf8',
+        });
+        return {
+          stdout: result.stdout || '',
+          stderr: result.stderr || '',
+          exitCode: typeof result.status === 'number' ? result.status : result.error ? 1 : 0,
+        };
+      });
+    },
+    fileExistsSync(filePath) {
+      return probe.record('fileExistsSync', () => fs.existsSync(filePath));
+    },
+    readFileSync(filePath) {
+      return probe.record('readFileSync', () => {
+        try {
+          return { data: fs.readFileSync(filePath, 'utf8'), error: null };
+        } catch (error) {
+          return { data: null, error: error instanceof Error ? error.message : String(error) };
+        }
+      });
+    },
+    statSync(filePath) {
+      return probe.record('statSync', () => {
+        try {
+          return statPayload(filePath);
+        } catch {
+          return { exists: false, isDirectory: false, isFile: false, size: 0 };
+        }
+      });
+    },
+  };
+}
+
+function extractFsFacadeSource() {
+  const source = fs.readFileSync(EXTENSION_VIEW_PATH, 'utf8');
+  const start = source.indexOf('const _bufferMarker');
+  const end = source.indexOf('// ── path stub', start);
+  assert.notEqual(start, -1, 'Could not locate Buffer/fs facade start marker');
+  assert.notEqual(end, -1, 'Could not locate fs facade end marker');
+  return source.slice(start, end);
+}
+
+function loadFsFacade({ nodeAvailable, electron, localStorage }) {
+  const source = `
+    const USE_REAL_NODE_BUILTINS = ${nodeAvailable ? 'true' : 'false'};
+    const _realNodeRequire = ${nodeAvailable ? '__REAL_NODE_REQUIRE' : 'undefined'};
+    const _realNodeProcess = ${nodeAvailable ? '__REAL_NODE_PROCESS' : 'undefined'};
+    const noop = () => {};
+    const noopAsync = (..._args) => Promise.resolve();
+    const noopCb = (...args) => {
+      const cb = args[args.length - 1];
+      if (typeof cb === 'function') cb(null);
+    };
+    ${extractFsFacadeSource()}
+    globalThis.__extensionSyncFacadeHarness = { fsStub, commandPathCache };
+  `;
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: EXTENSION_VIEW_PATH,
+  });
+  const sandbox = {
+    __REAL_NODE_REQUIRE: nodeAvailable ? require : undefined,
+    __REAL_NODE_PROCESS: nodeAvailable ? process : undefined,
+    console,
+    localStorage,
+    window: {
+      electron,
+      __scNodeRequire: nodeAvailable ? require : undefined,
+    },
+    performance,
+    TextEncoder,
+    TextDecoder,
+    URL,
+    Uint8Array,
+    ArrayBuffer,
+    DataView,
+    Blob: globalThis.Blob,
+    File: globalThis.File,
+    ReadableStream: globalThis.ReadableStream,
+    WritableStream: globalThis.WritableStream,
+    TransformStream: globalThis.TransformStream,
+    atob: (value) => Buffer.from(value, 'base64').toString('binary'),
+    btoa: (value) => Buffer.from(value, 'binary').toString('base64'),
+    setTimeout,
+    clearTimeout,
+    queueMicrotask,
+    Promise,
+    Date,
+    Error,
+    Map,
+    Set,
+    Symbol,
+    Object,
+    Array,
+    String,
+    Number,
+    Boolean,
+    RegExp,
+    Math,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(transpiled.outputText, sandbox, { filename: EXTENSION_VIEW_PATH });
+  return sandbox.__extensionSyncFacadeHarness.fsStub;
+}
+
+function writeFixtureTree() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'supercmd-extension-sync-facade-'));
+  const nestedDir = path.join(dir, 'nested');
+  fs.mkdirSync(nestedDir);
+  fs.writeFileSync(path.join(dir, 'real.txt'), 'real text', 'utf8');
+  fs.writeFileSync(path.join(dir, 'shadow.txt'), 'real shadow', 'utf8');
+  fs.writeFileSync(path.join(nestedDir, 'child.txt'), 'child text', 'utf8');
+  return dir;
+}
+
+function runScenario(mode) {
+  const probe = createSyncIpcProbe();
+  const localStorage = createLocalStorage();
+  const electron = createElectronFacade(probe);
+  const tmpDir = writeFixtureTree();
+  const fsStub = loadFsFacade({
+    nodeAvailable: mode === 'node',
+    electron,
+    localStorage,
+  });
+
+  try {
+    const realFile = path.join(tmpDir, 'real.txt');
+    const shadowFile = path.join(tmpDir, 'shadow.txt');
+    const virtualFile = path.join(tmpDir, 'virtual.txt');
+
+    fsStub.writeFileSync(shadowFile, 'virtual shadow');
+    fsStub.writeFileSync(virtualFile, 'virtual only');
+
+    const beforeVirtual = probe.snapshot();
+    assert.equal(fsStub.readFileSync(shadowFile, 'utf8'), 'virtual shadow');
+    assert.equal(fsStub.existsSync(shadowFile), true);
+    assert.equal(fsStub.statSync(shadowFile).size, 'virtual shadow'.length);
+    const virtualDelta = probe.delta(beforeVirtual);
+    assert.equal(virtualDelta.totalCount, 0, 'virtual/localStorage operations must not hit sync IPC');
+
+    const beforeReal = probe.snapshot();
+    assert.equal(fsStub.existsSync(realFile), true);
+    assert.equal(fsStub.statSync(realFile).isFile(), true);
+    assert.equal(fsStub.readFileSync(realFile, 'utf8'), 'real text');
+    assert.doesNotThrow(() => fsStub.accessSync(realFile));
+    const entries = fsStub.readdirSync(tmpDir, { withFileTypes: true });
+    assert.ok(entries.some((entry) => String(entry.name) === 'real.txt' && entry.isFile()));
+    assert.ok(entries.some((entry) => String(entry.name) === 'nested' && entry.isDirectory()));
+    assert.ok(entries.some((entry) => String(entry.name) === 'virtual.txt' && entry.isFile()));
+    const realDelta = probe.delta(beforeReal);
+
+    return {
+      mode,
+      realPathOps: realDelta,
+      virtualPathOps: virtualDelta,
+      total: probe.snapshot(),
+    };
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function formatCounts(result) {
+  return SYNC_METHODS
+    .map((name) => `${name}=${result.realPathOps.counts[name]}`)
+    .join(', ');
+}
+
+const { mode, assertNodeDirect } = parseArgs();
+const modes = mode === 'both' ? ['fallback', 'node'] : [mode];
+const results = modes.map((entry) => runScenario(entry));
+
+for (const result of results) {
+  const elapsed = result.realPathOps.totalTimeMs.toFixed(3);
+  console.log(
+    `[extension-sync-facade:${result.mode}] real path ops sync IPC calls: ${result.realPathOps.totalCount} (${formatCounts(result)}), sync IPC time: ${elapsed}ms`
+  );
+  console.log(
+    `[extension-sync-facade:${result.mode}] virtual precedence sync IPC calls: ${result.virtualPathOps.totalCount}`
+  );
+}
+
+const fallbackResult = results.find((result) => result.mode === 'fallback');
+if (fallbackResult) {
+  assert.ok(
+    fallbackResult.realPathOps.totalCount > 0,
+    'fallback mode should exercise the sync IPC path for real filesystem operations'
+  );
+}
+
+const nodeResult = results.find((result) => result.mode === 'node');
+if (assertNodeDirect && nodeResult) {
+  assert.equal(
+    nodeResult.realPathOps.totalCount,
+    0,
+    'node mode should avoid sync IPC for representative real filesystem operations'
+  );
+}

--- a/scripts/test-extension-sync-facade.mjs
+++ b/scripts/test-extension-sync-facade.mjs
@@ -176,6 +176,25 @@ function extractFsFacadeSource() {
   return source.slice(start, end);
 }
 
+function assertFacadeFallthroughWiring() {
+  const source = fs.readFileSync(EXTENSION_VIEW_PATH, 'utf8');
+  const helperIndex = source.indexOf('function getSuperCmdBuiltinFacade');
+  assert.notEqual(helperIndex, -1, 'fakeRequire should use a facade helper with real-node fallthrough');
+  assert.notEqual(
+    source.indexOf('new Proxy(facade', helperIndex),
+    -1,
+    'SuperCmd fs/child_process facades should proxy missing members to real Node modules'
+  );
+
+  const fakeRequireIndex = source.indexOf('const fakeRequire: any = (name: string): any =>');
+  const facadeCallIndex = source.indexOf('getSuperCmdBuiltinFacade(name)', fakeRequireIndex);
+  const realRequireIndex = source.indexOf('tryRealNodeRequire(name)', fakeRequireIndex);
+  assert.ok(
+    fakeRequireIndex !== -1 && facadeCallIndex !== -1 && realRequireIndex !== -1 && facadeCallIndex < realRequireIndex,
+    'fakeRequire should resolve SuperCmd fs/child_process facades before generic real require'
+  );
+}
+
 function loadFsFacade({ nodeAvailable, electron, localStorage }) {
   const source = `
     const USE_REAL_NODE_BUILTINS = ${nodeAvailable ? 'true' : 'false'};
@@ -307,6 +326,7 @@ function formatCounts(result) {
 }
 
 const { mode, assertNodeDirect } = parseArgs();
+assertFacadeFallthroughWiring();
 const modes = mode === 'both' ? ['fallback', 'node'] : [mode];
 const results = modes.map((entry) => runScenario(entry));
 

--- a/scripts/test-extension-wrapper-cache.mjs
+++ b/scripts/test-extension-wrapper-cache.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importTs } from './lib/ts-import.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  clearCompiledExtensionWrapperCache,
+  getCompiledExtensionWrapper,
+  getCompiledExtensionWrapperCacheStats,
+} = await importTs(path.join(root, 'src/renderer/src/utils/extension-wrapper-cache.ts'));
+
+function createRunEnv() {
+  const moduleExports = {};
+  const fakeModule = { exports: moduleExports };
+  const timers = new Set();
+  const trackTimeout = (cb, ms, ...rest) => {
+    const id = setTimeout(cb, ms, ...rest);
+    timers.add(id);
+    return id;
+  };
+  const trackClearTimeout = (id) => {
+    timers.delete(id);
+    clearTimeout(id);
+  };
+
+  return {
+    fakeModule,
+    timers,
+    args: [
+      moduleExports,
+      () => ({}),
+      fakeModule,
+      '/extension/index.js',
+      '/extension',
+      { env: {} },
+      Buffer,
+      globalThis,
+      globalThis,
+      (fn, ...args) => trackTimeout(() => fn(...args), 0),
+      trackClearTimeout,
+      () => 0,
+      () => {},
+      trackTimeout,
+      trackClearTimeout,
+      () => 0,
+      () => {},
+      undefined,
+      async () => ({}),
+    ],
+    cleanup: () => {
+      timers.forEach((id) => clearTimeout(id));
+      timers.clear();
+    },
+  };
+}
+
+function runWrapper(wrapper) {
+  const env = createRunEnv();
+  wrapper(...env.args);
+  return env;
+}
+
+test('Extension wrapper cache', async (t) => {
+  await t.test('reuses the compiled wrapper for the same extension code', () => {
+    clearCompiledExtensionWrapperCache();
+    const code = 'exports.default = function Command() { return "ok"; };';
+
+    const first = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code,
+    });
+    const second = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code,
+    });
+
+    assert.equal(first.cacheHit, false);
+    assert.equal(second.cacheHit, true);
+    assert.strictEqual(second.wrapper, first.wrapper);
+    assert.equal(getCompiledExtensionWrapperCacheStats().wrapperCreationCount, 1);
+  });
+
+  await t.test('invalidates when code changes even if the length is unchanged', () => {
+    clearCompiledExtensionWrapperCache();
+    const codeA = 'exports.default = function Command() { return "a"; };';
+    const codeB = 'exports.default = function Command() { return "b"; };';
+    assert.equal(codeA.length, codeB.length, 'fixture code must keep equal length');
+
+    const first = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code: codeA,
+    });
+    const changed = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code: codeB,
+    });
+
+    assert.equal(first.cacheHit, false);
+    assert.equal(changed.cacheHit, false);
+    assert.notEqual(changed.cacheKey, first.cacheKey);
+    assert.notStrictEqual(changed.wrapper, first.wrapper);
+
+    const envA = runWrapper(first.wrapper);
+    const envB = runWrapper(changed.wrapper);
+    try {
+      assert.equal(envA.fakeModule.exports.default(), 'a');
+      assert.equal(envB.fakeModule.exports.default(), 'b');
+    } finally {
+      envA.cleanup();
+      envB.cleanup();
+    }
+  });
+
+  await t.test('keeps module exports and timer handles fresh across cached runs', () => {
+    clearCompiledExtensionWrapperCache();
+    const code = `
+let moduleScopedCounter = 0;
+moduleScopedCounter += 1;
+const timerId = setTimeout(() => {}, 60000);
+exports.default = {
+  moduleScopedCounter,
+  timerId,
+  previousTouchedValue: exports.touched
+};
+exports.touched = "mutated";
+`;
+
+    const first = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code,
+    });
+    const second = getCompiledExtensionWrapper({
+      extensionIdentity: 'owner/extension/command',
+      code,
+    });
+    assert.equal(second.cacheHit, true);
+    assert.strictEqual(second.wrapper, first.wrapper);
+
+    const envA = runWrapper(second.wrapper);
+    const envB = runWrapper(second.wrapper);
+    try {
+      assert.notStrictEqual(envA.fakeModule.exports, envB.fakeModule.exports);
+      assert.equal(envA.fakeModule.exports.default.moduleScopedCounter, 1);
+      assert.equal(envB.fakeModule.exports.default.moduleScopedCounter, 1);
+      assert.equal(envA.fakeModule.exports.default.previousTouchedValue, undefined);
+      assert.equal(envB.fakeModule.exports.default.previousTouchedValue, undefined);
+      assert.equal(envA.timers.size, 1);
+      assert.equal(envB.timers.size, 1);
+      assert.notStrictEqual(
+        envA.fakeModule.exports.default.timerId,
+        envB.fakeModule.exports.default.timerId
+      );
+    } finally {
+      envA.cleanup();
+      envB.cleanup();
+    }
+
+    assert.equal(envA.timers.size, 0);
+    assert.equal(envB.timers.size, 0);
+  });
+});

--- a/scripts/test-inline-args-write-coalesce.mjs
+++ b/scripts/test-inline-args-write-coalesce.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { build } from 'esbuild';
+
+const bundledPreferences = await build({
+  entryPoints: ['src/renderer/src/utils/extension-preferences.ts'],
+  bundle: true,
+  write: false,
+  format: 'esm',
+  platform: 'browser',
+  logLevel: 'silent',
+});
+
+const bundledPreferencesUrl =
+  'data:text/javascript;base64,' + Buffer.from(bundledPreferences.outputFiles[0].text).toString('base64');
+
+let moduleCounter = 0;
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function copyPayload(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function loadPreferencesWithMocks() {
+  const storage = new Map();
+  const commandArgumentWrites = [];
+
+  globalThis.localStorage = {
+    getItem: (key) => (storage.has(key) ? storage.get(key) : null),
+    setItem: (key, value) => {
+      storage.set(key, String(value));
+    },
+    removeItem: (key) => {
+      storage.delete(key);
+    },
+    key: (index) => Array.from(storage.keys())[index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  };
+  globalThis.window = {
+    electron: {
+      saveExtensionCommandArguments: async (args) => {
+        commandArgumentWrites.push(copyPayload(args));
+        return {};
+      },
+      saveExtensionPreferences: async (args) => {
+        return {};
+      },
+    },
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    dispatchEvent: () => true,
+  };
+  globalThis.CustomEvent = class CustomEvent {
+    constructor(type, init) {
+      this.type = type;
+      this.detail = init?.detail;
+    }
+  };
+
+  moduleCounter += 1;
+  const preferences = await import(`${bundledPreferencesUrl}#test-${moduleCounter}`);
+  return { preferences, storage, commandArgumentWrites };
+}
+
+test('inline command argument settings mirror coalesces rapid writes', async () => {
+  const { preferences, storage, commandArgumentWrites } = await loadPreferencesWithMocks();
+  const key = preferences.getCmdArgsKey('coalesce-extension', 'no-view-command');
+  const values = ['s', 'se', 'sea', 'sear', 'searc', 'search', 'search ', 'search t', 'search te', 'search tex', 'search text'];
+
+  for (const value of values) {
+    preferences.writeJsonObject(
+      key,
+      { query: value },
+      { commandArgumentSettingsSync: 'debounced' }
+    );
+  }
+
+  assert.equal(JSON.parse(storage.get(key)).query, 'search text');
+  assert.equal(commandArgumentWrites.length, 0);
+
+  await wait(preferences.COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS + 50);
+
+  assert.equal(commandArgumentWrites.length, 1);
+  assert.deepEqual(commandArgumentWrites[0], {
+    extName: 'coalesce-extension',
+    cmdName: 'no-view-command',
+    values: { query: 'search text' },
+  });
+});
+
+test('launch flush writes pending inline command arguments immediately once', async () => {
+  const { preferences, commandArgumentWrites } = await loadPreferencesWithMocks();
+  const key = preferences.getCmdArgsKey('flush-extension', 'no-view-command');
+
+  preferences.writeJsonObject(
+    key,
+    { query: 'stale' },
+    { commandArgumentSettingsSync: 'debounced' }
+  );
+  preferences.writeJsonObject(
+    key,
+    { query: 'fresh at launch' },
+    { commandArgumentSettingsSync: 'debounced' }
+  );
+
+  await preferences.flushCommandArgumentSettingsSync(key);
+
+  assert.equal(commandArgumentWrites.length, 1);
+  assert.deepEqual(commandArgumentWrites[0], {
+    extName: 'flush-extension',
+    cmdName: 'no-view-command',
+    values: { query: 'fresh at launch' },
+  });
+
+  await wait(preferences.COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS + 50);
+  assert.equal(commandArgumentWrites.length, 1);
+});
+
+test('immediate command argument writes cancel pending debounced settings sync', async () => {
+  const { preferences, commandArgumentWrites } = await loadPreferencesWithMocks();
+  const key = preferences.getCmdArgsKey('submit-extension', 'no-view-command');
+
+  preferences.writeJsonObject(
+    key,
+    { query: 'pending inline value' },
+    { commandArgumentSettingsSync: 'debounced' }
+  );
+  preferences.writeJsonObject(key, { query: 'submitted value' });
+
+  assert.equal(commandArgumentWrites.length, 1);
+  assert.deepEqual(commandArgumentWrites[0], {
+    extName: 'submit-extension',
+    cmdName: 'no-view-command',
+    values: { query: 'submitted value' },
+  });
+
+  await wait(preferences.COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS + 50);
+  assert.equal(commandArgumentWrites.length, 1);
+});

--- a/scripts/test-menubar-payload-cache.mjs
+++ b/scripts/test-menubar-payload-cache.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { importTs } from './lib/ts-import.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  createMenuBarVisiblePayloadHashCache,
+  shouldSendMenuBarVisiblePayload,
+} = await importTs(path.join(root, 'src/renderer/src/raycast-api/menubar-runtime-payload-cache.ts'));
+
+function makePayload(overrides = {}) {
+  return {
+    extId: 'demo/timer',
+    iconPath: undefined,
+    iconDataUrl: undefined,
+    iconEmoji: '*',
+    iconTemplate: undefined,
+    iconBitmapScale: undefined,
+    fallbackIconDataUrl: '',
+    title: 'Timer',
+    tooltip: 'Timer status',
+    items: [
+      {
+        type: 'item',
+        id: '__mbi_1',
+        title: 'Start',
+        subtitle: 'Ready',
+        tooltip: 'Start timer',
+        disabled: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+test('MenuBarExtra visible payload cache', async (t) => {
+  await t.test('skips equivalent renderer sends while action maps stay current', () => {
+    const cache = createMenuBarVisiblePayloadHashCache();
+    let updateSends = 0;
+    let actionMapUpdates = 0;
+
+    for (let i = 0; i < 3; i += 1) {
+      const actions = new Map([['__mbi_1', () => i]]);
+      actionMapUpdates += actions.size;
+      if (shouldSendMenuBarVisiblePayload(cache, makePayload())) {
+        updateSends += 1;
+      }
+    }
+
+    t.diagnostic(`equivalent registrations: before=3 sends, after=${updateSends} send`);
+    assert.equal(updateSends, 1, 'only the first equivalent visible payload crosses IPC');
+    assert.equal(actionMapUpdates, 3, 'action maps still refresh for every registration pass');
+  });
+
+  await t.test('sends again when visible tray or menu fields change', () => {
+    const cache = createMenuBarVisiblePayloadHashCache();
+    assert.equal(shouldSendMenuBarVisiblePayload(cache, makePayload()), true, 'initial payload sends');
+    assert.equal(shouldSendMenuBarVisiblePayload(cache, makePayload()), false, 'equivalent payload is skipped');
+    assert.equal(shouldSendMenuBarVisiblePayload(cache, makePayload({ title: 'Timer Running' })), true, 'title change sends');
+    assert.equal(shouldSendMenuBarVisiblePayload(cache, makePayload({ iconEmoji: '>' })), true, 'icon change sends');
+    assert.equal(shouldSendMenuBarVisiblePayload(cache, makePayload({
+      items: [{ type: 'item', id: '__mbi_1', title: 'Pause', disabled: false }],
+    })), true, 'menu item change sends');
+  });
+
+  await t.test('parent refreshes actions before skipping unchanged visible payloads', () => {
+    const parentSource = fs.readFileSync(
+      path.join(root, 'src/renderer/src/raycast-api/menubar-runtime-parent.tsx'),
+      'utf8',
+    );
+    const actionIndex = parentSource.indexOf('setMenuBarActions(extId');
+    const cacheIndex = parentSource.indexOf('shouldSendMenuBarVisiblePayload(');
+    const updateIndex = parentSource.indexOf('updateMenuBar?.(payload)');
+
+    assert.ok(actionIndex >= 0, 'parent updates the action map');
+    assert.ok(cacheIndex >= 0, 'parent checks the visible payload cache');
+    assert.ok(updateIndex >= 0, 'parent sends the cached payload object');
+    assert.ok(actionIndex < cacheIndex, 'actions update before unchanged payloads are skipped');
+    assert.ok(cacheIndex < updateIndex, 'IPC send happens only after the cache check');
+  });
+});

--- a/scripts/test-menubar-storage-remounts.mjs
+++ b/scripts/test-menubar-storage-remounts.mjs
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function depsChanged(prevDeps, nextDeps) {
+  if (!prevDeps || !nextDeps || prevDeps.length !== nextDeps.length) return true;
+  return nextDeps.some((dep, index) => !Object.is(dep, prevDeps[index]));
+}
+
+function createReactHookHarness() {
+  const hooks = [];
+  const effects = [];
+  let hookIndex = 0;
+  let pendingEffects = [];
+
+  const react = {
+    useState(initialValue) {
+      const index = hookIndex++;
+      if (!hooks[index]) {
+        hooks[index] = {
+          value: typeof initialValue === 'function' ? initialValue() : initialValue,
+        };
+      }
+      const setState = (nextValue) => {
+        hooks[index].value =
+          typeof nextValue === 'function' ? nextValue(hooks[index].value) : nextValue;
+      };
+      return [hooks[index].value, setState];
+    },
+
+    useRef(initialValue) {
+      const index = hookIndex++;
+      if (!hooks[index]) hooks[index] = { current: initialValue };
+      return hooks[index];
+    },
+
+    useCallback(callback, deps) {
+      const index = hookIndex++;
+      const slot = hooks[index];
+      if (!slot || depsChanged(slot.deps, deps)) {
+        hooks[index] = { value: callback, deps };
+      }
+      return hooks[index].value;
+    },
+
+    useEffect(effect, deps) {
+      const index = hookIndex++;
+      const slot = effects[index];
+      if (!slot || depsChanged(slot.deps, deps)) {
+        pendingEffects.push({ index, effect, deps });
+      }
+    },
+  };
+
+  function flushEffects() {
+    const toRun = pendingEffects;
+    pendingEffects = [];
+    for (const next of toRun) {
+      const prev = effects[next.index];
+      if (typeof prev?.cleanup === 'function') prev.cleanup();
+      effects[next.index] = {
+        deps: next.deps,
+        cleanup: next.effect() || undefined,
+      };
+    }
+  }
+
+  return {
+    react,
+    render(callback) {
+      hookIndex = 0;
+      const result = callback();
+      flushEffects();
+      return result;
+    },
+    cleanup() {
+      for (const effect of effects) {
+        if (typeof effect?.cleanup === 'function') effect.cleanup();
+      }
+    },
+  };
+}
+
+function installWindowHarness() {
+  const listeners = new Map();
+  const removedMenuBars = [];
+
+  const win = {
+    electron: {
+      removeMenuBar(extId) {
+        removedMenuBars.push(extId);
+      },
+      onExtensionPreferencesUpdated() {
+        return () => {};
+      },
+    },
+    addEventListener(type, listener) {
+      const next = listeners.get(type) || new Set();
+      next.add(listener);
+      listeners.set(type, next);
+    },
+    removeEventListener(type, listener) {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatchEvent(event) {
+      for (const listener of listeners.get(event.type) || []) {
+        listener(event);
+      }
+      return true;
+    },
+  };
+
+  globalThis.window = win;
+  globalThis.CustomEvent = class TestCustomEvent {
+    constructor(type, init = {}) {
+      this.type = type;
+      this.detail = init.detail;
+    }
+  };
+
+  return {
+    removedMenuBars,
+    restore() {
+      delete globalThis.window;
+      delete globalThis.CustomEvent;
+    },
+  };
+}
+
+function loadTsModule(filePath, stubs = {}) {
+  const resolvedPath = path.resolve(root, filePath);
+  const source = fs.readFileSync(resolvedPath, 'utf8');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      jsx: ts.JsxEmit.ReactJSX,
+      esModuleInterop: true,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    },
+    fileName: resolvedPath,
+  });
+
+  const module = { exports: {} };
+  const localRequire = (request) => {
+    if (request in stubs) return stubs[request];
+    if (request.startsWith('.')) {
+      const candidate = path.resolve(path.dirname(resolvedPath), request);
+      for (const suffix of ['', '.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.tsx']) {
+        const nextPath = `${candidate}${suffix}`;
+        if (fs.existsSync(nextPath) && fs.statSync(nextPath).isFile()) {
+          return loadTsModule(path.relative(root, nextPath), stubs);
+        }
+      }
+    }
+    return require(request);
+  };
+
+  vm.runInNewContext(transpiled.outputText, {
+    module,
+    exports: module.exports,
+    require: localRequire,
+    console,
+    window: globalThis.window,
+    CustomEvent: globalThis.CustomEvent,
+    Date,
+    Math,
+  }, { filename: resolvedPath });
+
+  return module.exports;
+}
+
+function makeBundle(extName, cmdName) {
+  return {
+    code: 'module.exports = function Command() { return null; }',
+    title: cmdName,
+    extName,
+    cmdName,
+    extensionName: extName,
+    commandName: cmdName,
+  };
+}
+
+function findEntry(entries, extName, cmdName) {
+  return entries.find((entry) => {
+    const entryExt = entry.bundle.extName || entry.bundle.extensionName;
+    const entryCmd = entry.bundle.cmdName || entry.bundle.commandName;
+    return entryExt === extName && entryCmd === cmdName;
+  });
+}
+
+function createMenuBarSubject() {
+  const windowHarness = installWindowHarness();
+  const reactHarness = createReactHookHarness();
+  const { useMenuBarExtensions } = loadTsModule('src/renderer/src/hooks/useMenuBarExtensions.ts', {
+    react: reactHarness.react,
+  });
+
+  let current = reactHarness.render(() => useMenuBarExtensions());
+
+  return {
+    get current() {
+      return current;
+    },
+    rerender() {
+      current = reactHarness.render(() => useMenuBarExtensions());
+      return current;
+    },
+    cleanup() {
+      reactHarness.cleanup();
+      windowHarness.restore();
+    },
+  };
+}
+
+test('menu-bar storage refresh behavior', async (t) => {
+  await t.test('emitted storage events keep extensionName compatibility and include command origin', () => {
+    const windowHarness = installWindowHarness();
+    const events = [];
+    globalThis.window.addEventListener('sc-extension-storage-changed', (event) => {
+      events.push(event.detail);
+    });
+
+    const { configureStorageEvents, emitExtensionStorageChanged } = loadTsModule(
+      'src/renderer/src/raycast-api/storage-events.ts'
+    );
+
+    configureStorageEvents({
+      getExtensionContext: () => ({
+        extensionName: 'Demo',
+        commandName: 'Menu',
+        commandMode: 'menu-bar',
+      }),
+    });
+    emitExtensionStorageChanged();
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].extensionName, 'Demo');
+    assert.equal(events[0].commandName, 'Menu');
+    assert.equal(events[0].commandMode, 'menu-bar');
+    windowHarness.restore();
+  });
+
+  await t.test('self-originated menu-bar storage writes do not remount the writer', () => {
+    const subject = createMenuBarSubject();
+    try {
+      subject.current.upsertMenuBarExtension(makeBundle('Demo', 'Menu'));
+      subject.rerender();
+      const before = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
+      assert.ok(before, 'menu-bar command should be mounted');
+
+      globalThis.window.dispatchEvent(
+        new CustomEvent('sc-extension-storage-changed', {
+          detail: {
+            extensionName: 'Demo',
+            commandName: 'Menu',
+            commandMode: 'menu-bar',
+          },
+        })
+      );
+      subject.rerender();
+
+      const after = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
+      assert.equal(after, before, 'the writer keeps its ExtensionView key');
+    } finally {
+      subject.cleanup();
+    }
+  });
+
+  await t.test('sibling menu-bar commands still remount for same-extension writes', () => {
+    const subject = createMenuBarSubject();
+    try {
+      subject.current.upsertMenuBarExtension(makeBundle('Demo', 'Writer'));
+      subject.current.upsertMenuBarExtension(makeBundle('Demo', 'Reader'));
+      subject.rerender();
+      const writerBefore = findEntry(subject.current.menuBarExtensions, 'Demo', 'Writer')?.key;
+      const readerBefore = findEntry(subject.current.menuBarExtensions, 'Demo', 'Reader')?.key;
+
+      globalThis.window.dispatchEvent(
+        new CustomEvent('sc-extension-storage-changed', {
+          detail: {
+            extensionName: 'Demo',
+            commandName: 'Writer',
+            commandMode: 'menu-bar',
+          },
+        })
+      );
+      subject.rerender();
+
+      const writerAfter = findEntry(subject.current.menuBarExtensions, 'Demo', 'Writer')?.key;
+      const readerAfter = findEntry(subject.current.menuBarExtensions, 'Demo', 'Reader')?.key;
+      assert.equal(writerAfter, writerBefore, 'writer is not remounted');
+      assert.notEqual(readerAfter, readerBefore, 'sibling command is refreshed');
+    } finally {
+      subject.cleanup();
+    }
+  });
+
+  await t.test('external storage updates without origin metadata still remount every command', () => {
+    const subject = createMenuBarSubject();
+    try {
+      subject.current.upsertMenuBarExtension(makeBundle('Demo', 'Menu'));
+      subject.rerender();
+      const before = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
+
+      globalThis.window.dispatchEvent(
+        new CustomEvent('sc-extension-storage-changed', {
+          detail: { extensionName: 'Demo' },
+        })
+      );
+      subject.rerender();
+
+      const after = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
+      assert.notEqual(after, before, 'external update refreshes the mounted command');
+    } finally {
+      subject.cleanup();
+    }
+  });
+});

--- a/scripts/test-menubar-storage-remounts.mjs
+++ b/scripts/test-menubar-storage-remounts.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 const require = createRequire(import.meta.url);
 const ts = require('typescript');
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const MENU_BAR_HOOK_PATH = path.join(root, 'src/renderer/src/hooks/useMenuBarExtensions.ts');
 
 function depsChanged(prevDeps, nextDeps) {
   if (!prevDeps || !nextDeps || prevDeps.length !== nextDeps.length) return true;
@@ -224,6 +225,25 @@ function createMenuBarSubject() {
 }
 
 test('menu-bar storage refresh behavior', async (t) => {
+  await t.test('remount throttle timestamp is recorded before React state updates', () => {
+    const source = fs.readFileSync(MENU_BAR_HOOK_PATH, 'utf8');
+    const remountIndex = source.indexOf('const remountMenuBarExtensionsForExtension');
+    const timestampAssignment = 'menuBarRemountTimestampsRef.current[normalized] = now;';
+    const timestampIndex = source.indexOf(timestampAssignment, remountIndex);
+    const setStateIndex = source.indexOf('setMenuBarExtensions((prev) =>', remountIndex);
+    assert.ok(timestampIndex !== -1, 'remount throttle should record the timestamp synchronously');
+    assert.ok(setStateIndex !== -1, 'remount function should update menu-bar entries');
+    assert.ok(
+      timestampIndex < setStateIndex,
+      'synchronous storage events should be throttled before React flushes queued state updates'
+    );
+    assert.equal(
+      source.match(new RegExp(timestampAssignment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'))?.length,
+      1,
+      'timestamp mutation should not also happen inside the state updater'
+    );
+  });
+
   await t.test('emitted storage events keep extensionName compatibility and include command origin', () => {
     const windowHarness = installWindowHarness();
     const events = [];
@@ -273,6 +293,42 @@ test('menu-bar storage refresh behavior', async (t) => {
       const after = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
       assert.equal(after, before, 'the writer keeps its ExtensionView key');
     } finally {
+      subject.cleanup();
+    }
+  });
+
+  await t.test('self-originated no-op writes do not throttle the next external refresh', () => {
+    const subject = createMenuBarSubject();
+    const originalNow = Date.now;
+    try {
+      let now = 1_000;
+      Date.now = () => now;
+      subject.current.upsertMenuBarExtension(makeBundle('Demo', 'Menu'));
+      subject.rerender();
+      const before = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
+      assert.ok(before, 'menu-bar command should be mounted');
+
+      globalThis.window.dispatchEvent(
+        new CustomEvent('sc-extension-storage-changed', {
+          detail: {
+            extensionName: 'Demo',
+            commandName: 'Menu',
+            commandMode: 'menu-bar',
+          },
+        })
+      );
+      now += 50;
+      globalThis.window.dispatchEvent(
+        new CustomEvent('sc-extension-storage-changed', {
+          detail: { extensionName: 'Demo' },
+        })
+      );
+      subject.rerender();
+
+      const after = findEntry(subject.current.menuBarExtensions, 'Demo', 'Menu')?.key;
+      assert.notEqual(after, before, 'the external update still refreshes immediately after a no-op self write');
+    } finally {
+      Date.now = originalNow;
       subject.cleanup();
     }
   });

--- a/scripts/test-oauth-callback-queue.mjs
+++ b/scripts/test-oauth-callback-queue.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const bridgePath = path.join(root, 'src/renderer/src/raycast-api/oauth/oauth-bridge.ts');
+let importNonce = 0;
+
+async function importOAuthBridge() {
+  const result = await build({
+    entryPoints: [bridgePath],
+    bundle: true,
+    write: false,
+    format: 'esm',
+    platform: 'node',
+    target: 'node20',
+    logLevel: 'silent',
+  });
+  const code = result.outputFiles[0].text;
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}#oauth-${importNonce++}`;
+  return import(dataUrl);
+}
+
+async function loadBridge(t) {
+  const previousWindow = globalThis.window;
+  let callback = null;
+
+  globalThis.window = {
+    electron: {
+      onOAuthCallback: (handler) => {
+        callback = handler;
+        return () => {
+          callback = null;
+        };
+      },
+    },
+  };
+
+  t.after(() => {
+    if (previousWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = previousWindow;
+    }
+  });
+
+  const bridge = await importOAuthBridge();
+  bridge.ensureOAuthCallbackBridge();
+  assert.equal(typeof callback, 'function', 'OAuth callback bridge should register a callback listener');
+
+  return {
+    bridge,
+    emit: (url) => callback(url),
+  };
+}
+
+function callbackUrl(state, code = state) {
+  const url = new URL('supercmd://oauth/callback');
+  url.searchParams.set('state', state);
+  url.searchParams.set('code', code);
+  return url.toString();
+}
+
+test('OAuth callback queue caps retained unmatched callbacks', async (t) => {
+  const { bridge, emit } = await loadBridge(t);
+  const cap = bridge.OAUTH_CALLBACK_QUEUE_MAX_SIZE;
+  const total = 1000;
+
+  assert.ok(cap < total, 'test fixture should exceed the configured callback queue cap');
+
+  for (let i = 0; i < total; i++) {
+    emit(callbackUrl(`queued-${i}`));
+  }
+
+  await assert.rejects(
+    bridge.waitForOAuthCallback('queued-0', 1),
+    /OAuth authorization timed out/,
+    'old unmatched callbacks should be evicted once the cap is exceeded'
+  );
+
+  const firstRetained = total - cap;
+  const callback = await bridge.waitForOAuthCallback(`queued-${firstRetained}`, 1);
+  assert.equal(callback.state, `queued-${firstRetained}`);
+  assert.equal(callback.code, `queued-${firstRetained}`);
+});
+
+test('OAuth callback queue prunes entries older than the callback timeout window', async (t) => {
+  let now = 1_000_000;
+  t.mock.method(Date, 'now', () => now);
+
+  const { bridge, emit } = await loadBridge(t);
+  emit(callbackUrl('stale'));
+
+  now += bridge.OAUTH_CALLBACK_TIMEOUT_MS + 1;
+  emit(callbackUrl('fresh'));
+
+  await assert.rejects(
+    bridge.waitForOAuthCallback('stale', 1),
+    /OAuth authorization timed out/,
+    'callbacks outside the timeout window should be pruned'
+  );
+
+  const callback = await bridge.waitForOAuthCallback('fresh', 1);
+  assert.equal(callback.state, 'fresh');
+  assert.equal(callback.code, 'fresh');
+});
+
+test('OAuth callback waiter resolves when a matching state arrives', async (t) => {
+  const { bridge, emit } = await loadBridge(t);
+  const pending = bridge.waitForOAuthCallback('matching-state', 100);
+
+  emit(callbackUrl('other-state'));
+  emit(callbackUrl('matching-state', 'matching-code'));
+
+  const callback = await pending;
+  assert.equal(callback.state, 'matching-state');
+  assert.equal(callback.code, 'matching-code');
+});
+
+test('OAuth callback bridge ignores malformed and non-OAuth URLs safely', async (t) => {
+  const { bridge, emit } = await loadBridge(t);
+  emit(callbackUrl('keep'));
+
+  for (let i = 0; i < bridge.OAUTH_CALLBACK_QUEUE_MAX_SIZE + 25; i++) {
+    emit(i % 2 === 0 ? `not a url ${i}` : `https://example.com/oauth/callback?state=ignored-${i}`);
+  }
+
+  const callback = await bridge.waitForOAuthCallback('keep', 1);
+  assert.equal(callback.state, 'keep');
+  assert.equal(callback.code, 'keep');
+
+  await assert.rejects(
+    bridge.waitForOAuthCallback('ignored-1', 1),
+    /OAuth authorization timed out/,
+    'non-OAuth URLs should not be retained as callbacks'
+  );
+});

--- a/scripts/test-raycast-cache-size-index.mjs
+++ b/scripts/test-raycast-cache-size-index.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+import { performance } from 'node:perf_hooks';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+const CACHE_SOURCE_FILE = 'src/renderer/src/raycast-api/index.tsx';
+const ENTRY_COUNT = 120;
+const ENTRY_SIZE = 1024;
+
+function extractCacheSource() {
+  const source = fs.readFileSync(CACHE_SOURCE_FILE, 'utf8');
+  const start = source.indexOf('export namespace Cache');
+  const end = source.indexOf('// =====================================================================\n// \u2500\u2500\u2500 AI', start);
+  assert.notEqual(start, -1, 'Cache namespace marker should exist');
+  assert.notEqual(end, -1, 'AI section marker should exist after Cache');
+  return source.slice(start, end);
+}
+
+const transpiledCache = ts.transpileModule(extractCacheSource(), {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+  },
+  fileName: CACHE_SOURCE_FILE,
+});
+
+function createInstrumentedLocalStorage() {
+  const data = new Map();
+  const stats = {
+    getItem: 0,
+    setItem: 0,
+    removeItem: 0,
+    key: 0,
+    length: 0,
+  };
+
+  return {
+    getItem(key) {
+      stats.getItem += 1;
+      const normalizedKey = String(key);
+      return data.has(normalizedKey) ? data.get(normalizedKey) : null;
+    },
+    setItem(key, value) {
+      stats.setItem += 1;
+      data.set(String(key), String(value));
+    },
+    removeItem(key) {
+      stats.removeItem += 1;
+      data.delete(String(key));
+    },
+    key(index) {
+      stats.key += 1;
+      return Array.from(data.keys())[index] ?? null;
+    },
+    get length() {
+      stats.length += 1;
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    resetStats() {
+      stats.getItem = 0;
+      stats.setItem = 0;
+      stats.removeItem = 0;
+      stats.key = 0;
+      stats.length = 0;
+    },
+    snapshotStats() {
+      return { ...stats };
+    },
+    rawValue(key) {
+      return data.get(String(key));
+    },
+  };
+}
+
+function loadCache(storage, sandboxConsole = console) {
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    console: sandboxConsole,
+    localStorage: storage,
+    JSON,
+    Map,
+    Set,
+  };
+
+  vm.runInNewContext(transpiledCache.outputText, sandbox, { filename: CACHE_SOURCE_FILE });
+  return module.exports.Cache;
+}
+
+function measure(storage, name, fn) {
+  storage.resetStats();
+  const startedAt = performance.now();
+  const result = fn();
+  const durationMs = performance.now() - startedAt;
+  return {
+    name,
+    durationMs: Number(durationMs.toFixed(3)),
+    ...storage.snapshotStats(),
+    ...result,
+  };
+}
+
+function payload(size = ENTRY_SIZE, char = 'x') {
+  return char.repeat(size);
+}
+
+function cacheStorageKey(namespace) {
+  return `sc-cache-${namespace}`;
+}
+
+function cacheItemStorageKey(namespace, key) {
+  return `${cacheStorageKey(namespace)}-item-${key}`;
+}
+
+function readMetadata(storage, namespace) {
+  return JSON.parse(storage.rawValue(cacheStorageKey(namespace)));
+}
+
+function runBenchmark() {
+  const setStorage = createInstrumentedLocalStorage();
+  const SetCache = loadCache(setStorage);
+  const setCache = new SetCache({ namespace: 'bench-set', capacity: ENTRY_COUNT * ENTRY_SIZE * 10 });
+  const setReport = measure(setStorage, 'set-fill', () => {
+    for (let index = 0; index < ENTRY_COUNT; index += 1) {
+      setCache.set(`key-${index}`, payload());
+    }
+    return { entries: ENTRY_COUNT };
+  });
+
+  const getReport = measure(setStorage, 'get-existing', () => {
+    for (let index = 0; index < ENTRY_COUNT; index += 1) {
+      assert.equal(setCache.get(`key-${index}`), payload());
+    }
+    return { entries: ENTRY_COUNT };
+  });
+
+  const evictionStorage = createInstrumentedLocalStorage();
+  const EvictionCache = loadCache(evictionStorage);
+  const seedCache = new EvictionCache({
+    namespace: 'bench-eviction',
+    capacity: ENTRY_COUNT * ENTRY_SIZE * 10,
+  });
+  for (let index = 0; index < ENTRY_COUNT; index += 1) {
+    seedCache.set(`key-${index}`, payload());
+  }
+
+  const evictingCache = new EvictionCache({
+    namespace: 'bench-eviction',
+    capacity: Math.floor(ENTRY_COUNT / 2) * ENTRY_SIZE,
+  });
+  const evictionReport = measure(evictionStorage, 'set-with-eviction', () => {
+    evictingCache.set('new-key', payload());
+    return { entries: ENTRY_COUNT, targetCapacityEntries: Math.floor(ENTRY_COUNT / 2) };
+  });
+
+  return [setReport, getReport, evictionReport];
+}
+
+function printBenchmarkReport(reports) {
+  console.log('Raycast Cache localStorage benchmark');
+  for (const report of reports) {
+    console.log(
+      [
+        `  ${report.name}`,
+        `entries=${report.entries}`,
+        `durationMs=${report.durationMs}`,
+        `getItem=${report.getItem}`,
+        `setItem=${report.setItem}`,
+        `removeItem=${report.removeItem}`,
+        `key=${report.key}`,
+        `length=${report.length}`,
+      ].join(' ')
+    );
+  }
+}
+
+test('Cache stores, removes, clears, and notifies subscribers', () => {
+  const storage = createInstrumentedLocalStorage();
+  const Cache = loadCache(storage);
+  const cache = new Cache({ namespace: 'behavior', capacity: 4096 });
+  const notifications = [];
+  cache.subscribe((key, data) => notifications.push([key, data]));
+
+  cache.set('alpha', 'one');
+  assert.equal(cache.get('alpha'), 'one');
+  assert.equal(cache.has('alpha'), true);
+  assert.equal(cache.remove('alpha'), true);
+  assert.equal(cache.remove('alpha'), false);
+  assert.equal(cache.has('alpha'), false);
+
+  cache.set('beta', 'two');
+  cache.set('gamma', 'three');
+  assert.equal(cache.isEmpty, false);
+  cache.clear();
+  assert.equal(cache.isEmpty, true);
+  assert.equal(cache.has('beta'), false);
+  assert.equal(cache.has('gamma'), false);
+  assert.deepEqual(notifications, [
+    ['alpha', 'one'],
+    ['alpha', undefined],
+    ['beta', 'two'],
+    ['gamma', 'three'],
+    [undefined, undefined],
+  ]);
+});
+
+test('Cache eviction honors least-recently-used ordering', () => {
+  const storage = createInstrumentedLocalStorage();
+  const Cache = loadCache(storage);
+  const cache = new Cache({ namespace: 'lru', capacity: 9 });
+
+  cache.set('a', '111');
+  cache.set('b', '222');
+  cache.set('c', '333');
+  assert.equal(cache.get('a'), '111');
+  cache.set('d', '444');
+
+  assert.equal(cache.has('a'), true);
+  assert.equal(cache.has('b'), false);
+  assert.equal(cache.has('c'), true);
+  assert.equal(cache.has('d'), true);
+});
+
+test('Cache migrates legacy LRU metadata into size metadata', () => {
+  const storage = createInstrumentedLocalStorage();
+  storage.setItem(cacheStorageKey('legacy'), JSON.stringify({ lruOrder: ['alpha', 'beta'] }));
+  storage.setItem(cacheItemStorageKey('legacy', 'alpha'), '111');
+  storage.setItem(cacheItemStorageKey('legacy', 'beta'), '2222');
+  storage.resetStats();
+
+  const Cache = loadCache(storage);
+  const cache = new Cache({ namespace: 'legacy', capacity: 4096 });
+  const metadata = readMetadata(storage, 'legacy');
+
+  assert.deepEqual(metadata.lruOrder, ['alpha', 'beta']);
+  assert.deepEqual(metadata.sizeByKey, { alpha: 3, beta: 4 });
+  assert.equal(metadata.totalSize, 7);
+  assert.equal(cache.get('alpha'), '111');
+  assert.equal(cache.get('beta'), '2222');
+});
+
+test('Cache recovers corrupt metadata by scanning cache item keys', () => {
+  const storage = createInstrumentedLocalStorage();
+  storage.setItem(cacheStorageKey('corrupt'), '{not valid json');
+  storage.setItem(cacheItemStorageKey('corrupt', 'alpha'), 'aaa');
+  storage.setItem(cacheItemStorageKey('corrupt', 'beta'), 'bbbb');
+  storage.resetStats();
+
+  const errors = [];
+  const Cache = loadCache(storage, {
+    ...console,
+    error: (...args) => errors.push(args),
+  });
+  const cache = new Cache({ namespace: 'corrupt', capacity: 4096 });
+  const metadata = readMetadata(storage, 'corrupt');
+
+  assert.equal(errors.length, 1);
+  assert.deepEqual(metadata.lruOrder, ['alpha', 'beta']);
+  assert.deepEqual(metadata.sizeByKey, { alpha: 3, beta: 4 });
+  assert.equal(metadata.totalSize, 7);
+  assert.equal(cache.get('alpha'), 'aaa');
+  assert.equal(cache.get('beta'), 'bbbb');
+});
+
+test('Cache recovers malformed LRU metadata by scanning cache item keys', () => {
+  const storage = createInstrumentedLocalStorage();
+  storage.setItem(cacheStorageKey('malformed'), JSON.stringify({ lruOrder: [42], sizeByKey: {} }));
+  storage.setItem(cacheItemStorageKey('malformed', 'alpha'), 'aaa');
+  storage.resetStats();
+
+  const Cache = loadCache(storage);
+  const cache = new Cache({ namespace: 'malformed', capacity: 4096 });
+  const metadata = readMetadata(storage, 'malformed');
+
+  assert.deepEqual(metadata.lruOrder, ['alpha']);
+  assert.deepEqual(metadata.sizeByKey, { alpha: 3 });
+  assert.equal(metadata.totalSize, 3);
+  assert.equal(cache.get('alpha'), 'aaa');
+});
+
+test('Cache repairs stale size metadata for individual key operations', () => {
+  const storage = createInstrumentedLocalStorage();
+  storage.setItem(cacheStorageKey('stale'), JSON.stringify({
+    version: 2,
+    lruOrder: ['missing', 'external'],
+    sizeByKey: { missing: 10, external: 1 },
+    totalSize: 11,
+  }));
+  storage.setItem(cacheItemStorageKey('stale', 'external'), 'actual');
+
+  const Cache = loadCache(storage);
+  const cache = new Cache({ namespace: 'stale', capacity: 4096 });
+
+  assert.equal(cache.has('missing'), false);
+  assert.equal(cache.has('external'), true);
+  assert.equal(cache.remove('external'), true);
+  assert.equal(cache.has('external'), false);
+
+  const metadata = readMetadata(storage, 'stale');
+  assert.deepEqual(metadata.lruOrder, []);
+  assert.deepEqual(metadata.sizeByKey, {});
+  assert.equal(metadata.totalSize, 0);
+});
+
+test('Cache benchmark reports localStorage reads for set, get, and eviction', () => {
+  const reports = runBenchmark();
+  printBenchmarkReport(reports);
+
+  const byName = Object.fromEntries(reports.map((report) => [report.name, report]));
+  assert.equal(byName['set-fill'].getItem, 0);
+  assert.equal(byName['get-existing'].getItem, ENTRY_COUNT);
+  assert.equal(byName['set-with-eviction'].getItem, 0);
+  assert.ok(byName['set-with-eviction'].removeItem > 0, 'eviction scenario should remove LRU entries');
+});

--- a/scripts/test-with-cache-expiry.mjs
+++ b/scripts/test-with-cache-expiry.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+function loadPlatformRuntimeWithObservedMaps() {
+  const filePath = path.resolve('src/renderer/src/raycast-api/platform-runtime.ts');
+  const source = fs.readFileSync(filePath, 'utf8');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    },
+    fileName: filePath,
+  });
+
+  const observedMaps = [];
+  class ObservableMap extends Map {
+    constructor(...args) {
+      super(...args);
+      observedMaps.push(this);
+    }
+  }
+
+  const module = { exports: {} };
+  const sandbox = {
+    module,
+    exports: module.exports,
+    require,
+    console,
+    Date,
+    Error,
+    JSON,
+    Map: ObservableMap,
+    Promise,
+    window: {},
+  };
+
+  vm.runInNewContext(transpiled.outputText, sandbox, { filename: filePath });
+  return { exports: module.exports, observedMaps };
+}
+
+test('withCache sweeps expired unique keys when maxAge is configured', async () => {
+  const originalNow = Date.now;
+  const uniqueKeyCount = 1_000;
+  let now = 1_000;
+  let calls = 0;
+
+  Date.now = () => now;
+  try {
+    const { exports, observedMaps } = loadPlatformRuntimeWithObservedMaps();
+    const cached = exports.withCache(async (key) => {
+      calls += 1;
+      return `value:${key}:${calls}`;
+    }, { maxAge: 10 });
+
+    for (let index = 0; index < uniqueKeyCount; index += 1) {
+      await cached(`expired-${index}`);
+      now += 11;
+    }
+
+    await cached('latest');
+
+    const retainedSize = observedMaps[0]?.size;
+    console.log(`[withCache metric] retained entries after unique expired inserts: ${retainedSize}`);
+    assert.equal(retainedSize, 1);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test('withCache recomputes and replaces an expired hit', async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  let calls = 0;
+
+  Date.now = () => now;
+  try {
+    const { exports, observedMaps } = loadPlatformRuntimeWithObservedMaps();
+    const cached = exports.withCache(async (key) => {
+      calls += 1;
+      return { key, calls };
+    }, { maxAge: 10 });
+
+    assert.deepEqual(await cached('same-key'), { key: 'same-key', calls: 1 });
+    now += 11;
+    assert.deepEqual(await cached('same-key'), { key: 'same-key', calls: 2 });
+    assert.equal(observedMaps[0]?.size, 1);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test('withCache retains non-expiring entries until clearCache is called', async () => {
+  const { exports, observedMaps } = loadPlatformRuntimeWithObservedMaps();
+  let calls = 0;
+  const cached = exports.withCache(async (key) => {
+    calls += 1;
+    return `value:${key}:${calls}`;
+  });
+
+  assert.equal(await cached('a'), 'value:a:1');
+  assert.equal(await cached('b'), 'value:b:2');
+  assert.equal(await cached('a'), 'value:a:1');
+  assert.equal(observedMaps[0]?.size, 2);
+  assert.equal(calls, 2);
+
+  cached.clearCache();
+  assert.equal(observedMaps[0]?.size, 0);
+});

--- a/src/main/exec-command.ts
+++ b/src/main/exec-command.ts
@@ -1,0 +1,157 @@
+import * as fs from 'fs';
+import { execFileSync as defaultExecFileSync, spawn as defaultSpawn } from 'child_process';
+
+export type ExecCommandOptions = {
+  shell?: boolean | string;
+  input?: string;
+  env?: Record<string, string>;
+  cwd?: string;
+};
+
+export type ExecCommandResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+type ExecCommandProcess = {
+  stdout?: {
+    on(event: 'data', listener: (data: Buffer) => void): void;
+  };
+  stderr?: {
+    on(event: 'data', listener: (data: Buffer) => void): void;
+  };
+  stdin?: {
+    write(input: string): void;
+    end(): void;
+  };
+  on(event: 'close', listener: (code: number | null) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+  kill(): unknown;
+};
+
+type ExecFileSyncLike = (
+  file: string,
+  args?: readonly string[],
+  options?: Record<string, unknown>
+) => string | Buffer;
+
+type ExecCommandDependencies = {
+  spawn?: (command: string, args: string[], options: Record<string, unknown>) => ExecCommandProcess;
+  execFileSync?: ExecFileSyncLike;
+  existsSync?: (path: fs.PathLike) => boolean;
+  env?: NodeJS.ProcessEnv;
+  cwd?: () => string;
+  setTimeout?: typeof setTimeout;
+  clearTimeout?: typeof clearTimeout;
+};
+
+const EXEC_COMMAND_TIMEOUT_MS = 300000;
+
+function resolveExecutablePath(input: string, dependencies: Required<Pick<ExecCommandDependencies, 'execFileSync' | 'existsSync'>>): string {
+  if (!input || typeof input !== 'string') return input;
+  if (!input.includes('/') && !input.includes('\\')) return input;
+  if (!input.startsWith('/')) return input;
+  if (dependencies.existsSync(input)) return input;
+  try {
+    const base = input.split('/').filter(Boolean).pop() || '';
+    if (!base) return input;
+    const lookup = String(
+      dependencies.execFileSync(
+        '/bin/zsh',
+        ['-lc', `command -v -- ${JSON.stringify(base)} 2>/dev/null || true`],
+        { encoding: 'utf-8' }
+      )
+    ).trim();
+    if (lookup && dependencies.existsSync(lookup)) return lookup;
+  } catch {}
+  return input;
+}
+
+export function runExecCommand(
+  command: string,
+  args: string[],
+  options?: ExecCommandOptions,
+  dependencies: ExecCommandDependencies = {}
+): Promise<ExecCommandResult> {
+  const spawn = dependencies.spawn ?? defaultSpawn;
+  const execFileSync = dependencies.execFileSync ?? defaultExecFileSync;
+  const existsSync = dependencies.existsSync ?? fs.existsSync.bind(fs);
+  const env = dependencies.env ?? process.env;
+  const cwd = dependencies.cwd ?? process.cwd.bind(process);
+  const scheduleTimeout = dependencies.setTimeout ?? setTimeout;
+  const cancelTimeout = dependencies.clearTimeout ?? clearTimeout;
+
+  return new Promise((resolve) => {
+    try {
+      const normalizedCommand = resolveExecutablePath(command, { execFileSync, existsSync });
+      // Augment PATH so extensions can find brew, npm, nvm, etc. even when
+      // the app is launched from the Dock (where macOS strips the login PATH).
+      const extraPaths = [
+        '/opt/homebrew/bin', '/opt/homebrew/sbin',
+        '/usr/local/bin', '/usr/local/sbin',
+        '/usr/bin', '/usr/sbin', '/bin', '/sbin',
+      ];
+      const currentPath = (options?.env?.PATH ?? env.PATH ?? '');
+      const augmentedPath = [
+        ...extraPaths,
+        ...currentPath.split(':').filter(Boolean),
+      ].filter((v, i, a) => a.indexOf(v) === i).join(':');
+      const spawnOptions: Record<string, unknown> = {
+        shell: options?.shell ?? false,
+        env: { ...env, ...options?.env, PATH: augmentedPath },
+        cwd: options?.cwd || cwd(),
+      };
+
+      const proc = options?.shell
+        ? spawn([normalizedCommand, ...args].join(' '), [], { ...spawnOptions, shell: true })
+        : spawn(normalizedCommand, args, spawnOptions);
+
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+
+      const finish = (result: ExecCommandResult) => {
+        if (settled) return;
+        settled = true;
+        if (timeout) {
+          cancelTimeout(timeout);
+          timeout = null;
+        }
+        resolve(result);
+      };
+
+      proc.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      if (options?.input && proc.stdin) {
+        proc.stdin.write(options.input);
+        proc.stdin.end();
+      }
+
+      proc.on('close', (code: number | null) => {
+        finish({ stdout, stderr, exitCode: code ?? 0 });
+      });
+
+      proc.on('error', (err: Error) => {
+        finish({ stdout, stderr: err.message, exitCode: 1 });
+      });
+
+      // Timeout after 5 minutes - allows long-running commands (brew install, npm install, etc.)
+      timeout = scheduleTimeout(() => {
+        try {
+          proc.kill();
+        } catch {}
+        finish({ stdout, stderr: stderr || 'Command timed out', exitCode: 124 });
+      }, EXEC_COMMAND_TIMEOUT_MS);
+    } catch (e: any) {
+      resolve({ stdout: '', stderr: e?.message || 'Failed to execute command', exitCode: 1 });
+    }
+  });
+}

--- a/src/main/extension-registry.ts
+++ b/src/main/extension-registry.ts
@@ -36,6 +36,13 @@ import { installDepsWithBun } from './bun-manager';
 
 const execAsync = promisify(exec);
 
+function invalidateExtensionRunnerCaches(): void {
+  try {
+    const runner = require('./extension-runner');
+    runner.invalidateExtensionRunnerCaches?.();
+  } catch {}
+}
+
 function shellQuoteSingle(value: string): string {
   return `'${String(value || '').replace(/'/g, `'\\''`)}'`;
 }
@@ -1137,6 +1144,7 @@ async function installExtensionFromBundle(
 
     // Copy to extensions directory
     fs.cpSync(srcDir, installPath, { recursive: true });
+    invalidateExtensionRunnerCaches();
 
     // Cleanup backup
     if (backupPath && fs.existsSync(backupPath)) {
@@ -1244,6 +1252,7 @@ async function installExtensionViaAPI(name: string): Promise<boolean> {
       const { buildAllCommands } = require('./extension-runner');
       const builtCount = await buildAllCommands(name);
       console.log(`  Build: ${Date.now() - t1}ms. Extension "${name}" installed (${builtCount} commands) in ${Date.now() - t0}ms total`);
+      invalidateExtensionRunnerCaches();
     }
 
     // Cleanup backup
@@ -1355,6 +1364,7 @@ async function installExtensionViaGit(name: string): Promise<boolean> {
     const { buildAllCommands } = require('./extension-runner');
     const builtCount = await buildAllCommands(name);
     console.log(`Extension "${name}" installed (${builtCount} commands) at ${installPath}`);
+    invalidateExtensionRunnerCaches();
     if (backupPath && fs.existsSync(backupPath)) {
       fs.rmSync(backupPath, { recursive: true, force: true });
     }
@@ -1535,6 +1545,7 @@ export async function uninstallExtension(name: string): Promise<boolean> {
 
   try {
     fs.rmSync(installPath, { recursive: true, force: true });
+    invalidateExtensionRunnerCaches();
     console.log(`Extension "${name}" uninstalled.`);
 
     // Report uninstall to backend (fire-and-forget)

--- a/src/main/extension-runner.ts
+++ b/src/main/extension-runner.ts
@@ -111,6 +111,43 @@ interface InstalledExtensionSource {
   sourceRoot: string;
 }
 
+interface FsPathSignature {
+  exists: boolean;
+  isFile: boolean;
+  isDirectory: boolean;
+  size: number;
+  mtimeMs: number;
+}
+
+interface InstalledExtensionSourceSignature {
+  extName: string;
+  extPath: string;
+  sourceRoot: string;
+  extPathSignature: FsPathSignature;
+  packageJsonSignature: FsPathSignature;
+}
+
+interface InstalledExtensionsSnapshot {
+  roots: string[];
+  rootSignatures: FsPathSignature[];
+  sources: InstalledExtensionSource[];
+  sourceSignatures: InstalledExtensionSourceSignature[];
+}
+
+interface CachedManifest {
+  signature: FsPathSignature;
+  value: any;
+}
+
+interface CachedTextFile {
+  signature: FsPathSignature;
+  value: string;
+}
+
+let _installedExtensionsSnapshot: InstalledExtensionsSnapshot | null = null;
+const _extensionManifestCache = new Map<string, CachedManifest>();
+const _extensionBundleCodeCache = new Map<string, CachedTextFile>();
+
 function getManagedExtensionsDir(): string {
   const dir = path.join(app.getPath('userData'), 'extensions');
   if (!fs.existsSync(dir)) {
@@ -144,6 +181,91 @@ function normalizeExtensionName(name: string): string {
   return raw.replace(/^@/, '').replace(/[\\/]/g, '-');
 }
 
+function getPathSignature(filePath: string): FsPathSignature {
+  try {
+    const stat = fs.statSync(filePath);
+    return {
+      exists: true,
+      isFile: stat.isFile(),
+      isDirectory: stat.isDirectory(),
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+    };
+  } catch {
+    return {
+      exists: false,
+      isFile: false,
+      isDirectory: false,
+      size: -1,
+      mtimeMs: -1,
+    };
+  }
+}
+
+function samePathSignature(a: FsPathSignature, b: FsPathSignature): boolean {
+  return (
+    a.exists === b.exists &&
+    a.isFile === b.isFile &&
+    a.isDirectory === b.isDirectory &&
+    a.size === b.size &&
+    a.mtimeMs === b.mtimeMs
+  );
+}
+
+function sameRootSnapshot(
+  roots: string[],
+  rootSignatures: FsPathSignature[],
+  snapshot: InstalledExtensionsSnapshot
+): boolean {
+  if (roots.length !== snapshot.roots.length) return false;
+  if (rootSignatures.length !== snapshot.rootSignatures.length) return false;
+  for (let i = 0; i < roots.length; i++) {
+    if (roots[i] !== snapshot.roots[i]) return false;
+    if (!samePathSignature(rootSignatures[i], snapshot.rootSignatures[i])) return false;
+  }
+  return true;
+}
+
+function getInstalledExtensionSourceSignature(source: InstalledExtensionSource): InstalledExtensionSourceSignature {
+  return {
+    extName: source.extName,
+    extPath: source.extPath,
+    sourceRoot: source.sourceRoot,
+    extPathSignature: getPathSignature(source.extPath),
+    packageJsonSignature: getPathSignature(path.join(source.extPath, 'package.json')),
+  };
+}
+
+function sameInstalledExtensionSourceSignature(
+  a: InstalledExtensionSourceSignature,
+  b: InstalledExtensionSourceSignature
+): boolean {
+  return (
+    a.extName === b.extName &&
+    a.extPath === b.extPath &&
+    a.sourceRoot === b.sourceRoot &&
+    samePathSignature(a.extPathSignature, b.extPathSignature) &&
+    samePathSignature(a.packageJsonSignature, b.packageJsonSignature)
+  );
+}
+
+function getInstalledExtensionSourceSignatures(
+  sources: InstalledExtensionSource[]
+): InstalledExtensionSourceSignature[] {
+  return sources.map((source) => getInstalledExtensionSourceSignature(source));
+}
+
+function sameInstalledExtensionSourceSignatures(
+  a: InstalledExtensionSourceSignature[],
+  b: InstalledExtensionSourceSignature[]
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (!sameInstalledExtensionSourceSignature(a[i], b[i])) return false;
+  }
+  return true;
+}
+
 function getConfiguredExtensionRoots(): string[] {
   const settingsPaths = Array.isArray(loadSettings().customExtensionFolders)
     ? loadSettings().customExtensionFolders
@@ -162,7 +284,7 @@ function getConfiguredExtensionRoots(): string[] {
   return [...unique];
 }
 
-function collectInstalledExtensions(): InstalledExtensionSource[] {
+function scanInstalledExtensions(roots: string[]): InstalledExtensionSource[] {
   const results: InstalledExtensionSource[] = [];
   const seen = new Set<string>();
 
@@ -183,7 +305,7 @@ function collectInstalledExtensions(): InstalledExtensionSource[] {
     results.push({ extName, extPath, sourceRoot });
   };
 
-  for (const sourceRoot of getConfiguredExtensionRoots()) {
+  for (const sourceRoot of roots) {
     if (!fs.existsSync(sourceRoot)) continue;
 
     const sourceRootPkg = path.join(sourceRoot, 'package.json');
@@ -206,6 +328,27 @@ function collectInstalledExtensions(): InstalledExtensionSource[] {
   return results;
 }
 
+function collectInstalledExtensions(): InstalledExtensionSource[] {
+  const roots = getConfiguredExtensionRoots();
+  const rootSignatures = roots.map((root) => getPathSignature(root));
+
+  if (_installedExtensionsSnapshot && sameRootSnapshot(roots, rootSignatures, _installedExtensionsSnapshot)) {
+    const currentSourceSignatures = getInstalledExtensionSourceSignatures(_installedExtensionsSnapshot.sources);
+    if (sameInstalledExtensionSourceSignatures(currentSourceSignatures, _installedExtensionsSnapshot.sourceSignatures)) {
+      return _installedExtensionsSnapshot.sources;
+    }
+  }
+
+  const sources = scanInstalledExtensions(roots);
+  _installedExtensionsSnapshot = {
+    roots,
+    rootSignatures,
+    sources,
+    sourceSignatures: getInstalledExtensionSourceSignatures(sources),
+  };
+  return sources;
+}
+
 function resolveInstalledExtensionPath(extName: string): string | null {
   const normalized = normalizeExtensionName(extName);
   if (!normalized) return null;
@@ -213,11 +356,60 @@ function resolveInstalledExtensionPath(extName: string): string | null {
   return match?.extPath || null;
 }
 
+function readExtensionManifest(extPath: string): any | null {
+  const pkgPath = path.join(extPath, 'package.json');
+  const signature = getPathSignature(pkgPath);
+  if (!signature.exists || !signature.isFile) return null;
+
+  const cached = _extensionManifestCache.get(pkgPath);
+  if (cached && samePathSignature(cached.signature, signature)) {
+    return cached.value;
+  }
+
+  const value = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+  _extensionManifestCache.set(pkgPath, { signature, value });
+  return value;
+}
+
+function readExtensionBundleCode(outFile: string): string {
+  const signature = getPathSignature(outFile);
+  if (!signature.exists || !signature.isFile) return '';
+
+  const cached = _extensionBundleCodeCache.get(outFile);
+  if (cached && samePathSignature(cached.signature, signature)) {
+    return cached.value;
+  }
+
+  const value = fs.readFileSync(outFile, 'utf-8');
+  _extensionBundleCodeCache.set(outFile, { signature, value });
+  return value;
+}
+
+function invalidateExtensionStaticCacheForPath(extPath: string): void {
+  const normalizedExtPath = path.resolve(extPath);
+  _installedExtensionsSnapshot = null;
+  _extensionManifestCache.delete(path.join(normalizedExtPath, 'package.json'));
+
+  const buildDir = path.join(normalizedExtPath, '.sc-build') + path.sep;
+  for (const bundlePath of _extensionBundleCodeCache.keys()) {
+    if (bundlePath.startsWith(buildDir)) {
+      _extensionBundleCodeCache.delete(bundlePath);
+    }
+  }
+}
+
+export function invalidateExtensionRunnerCaches(): void {
+  _installedExtensionsSnapshot = null;
+  _extensionManifestCache.clear();
+  _extensionBundleCodeCache.clear();
+  _extensionIconCache.clear();
+}
+
 // ─── Icon extraction ────────────────────────────────────────────────
 
 // Session-level cache: absolute icon path → stable data URL string.
 // Prevents re-reading and re-encoding the same icon file on every getCommands() call.
-const _extensionIconCache = new Map<string, string>();
+const _extensionIconCache = new Map<string, { signature: FsPathSignature; value: string }>();
 
 function resizeIconWithSips(inputPath: string): Buffer | null {
   const tmp = path.join(os.tmpdir(), `sc-icon-${Date.now()}-${Math.random().toString(36).slice(2)}.png`);
@@ -241,10 +433,13 @@ function getExtensionIconDataUrl(
   ];
 
   for (const p of candidates) {
-    if (!fs.existsSync(p)) continue;
+    const signature = getPathSignature(p);
+    if (!signature.exists || !signature.isFile) continue;
 
     const cached = _extensionIconCache.get(p);
-    if (cached !== undefined) return cached;
+    if (cached !== undefined && samePathSignature(cached.signature, signature)) {
+      return cached.value;
+    }
 
     try {
       const ext = path.extname(p).toLowerCase();
@@ -260,7 +455,7 @@ function getExtensionIconDataUrl(
         result = `data:image/png;base64,${finalData.toString('base64')}`;
       }
 
-      _extensionIconCache.set(p, result);
+      _extensionIconCache.set(p, { signature, value: result });
       return result;
     } catch {}
   }
@@ -310,11 +505,11 @@ export function discoverInstalledExtensionCommands(): ExtensionCommandInfo[] {
   const results: ExtensionCommandInfo[] = [];
   for (const source of collectInstalledExtensions()) {
     const extPath = source.extPath;
-    const pkgPath = path.join(extPath, 'package.json');
     const extName = source.extName;
 
     try {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+      const pkg = readExtensionManifest(extPath);
+      if (!pkg) continue;
       if (!isManifestPlatformCompatible(pkg)) continue;
       const iconDataUrl = getExtensionIconDataUrl(
         extPath,
@@ -375,11 +570,11 @@ export function getInstalledExtensionsSettingsSchema(): InstalledExtensionSettin
   const results: InstalledExtensionSettingsSchema[] = [];
   for (const source of collectInstalledExtensions()) {
     const extPath = source.extPath;
-    const pkgPath = path.join(extPath, 'package.json');
     const extName = source.extName;
 
     try {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+      const pkg = readExtensionManifest(extPath);
+      if (!pkg) continue;
       if (!isManifestPlatformCompatible(pkg)) continue;
       const iconDataUrl = getExtensionIconDataUrl(extPath, pkg.icon || 'icon.png');
       const ownerRaw = pkg.owner || pkg.author || '';
@@ -660,11 +855,14 @@ export async function buildAllCommands(extName: string, extPathOverride?: string
     return 0;
   }
 
+  invalidateExtensionStaticCacheForPath(extPath);
+
   let commands: any[];
   let requiresNodeModules = false;
   let manifestExternal: string[] = [];
   try {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    const pkg = readExtensionManifest(extPath);
+    if (!pkg) return 0;
     if (!isManifestPlatformCompatible(pkg)) {
       console.warn(`Skipping build for incompatible extension ${extName}`);
       return 0;
@@ -954,11 +1152,14 @@ export async function buildSingleCommand(extName: string, cmdName: string): Prom
     return false;
   }
 
+  invalidateExtensionStaticCacheForPath(extPath);
+
   let cmd: any;
   let requiresNodeModules = false;
   let manifestExternal: string[] = [];
   try {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    const pkg = readExtensionManifest(extPath);
+    if (!pkg) return false;
     if (!isManifestPlatformCompatible(pkg)) {
       console.error(`buildSingleCommand: platform not compatible for ${extName}`);
       return false;
@@ -1172,8 +1373,7 @@ export async function getExtensionBundle(
     if (!fs.existsSync(outFile)) {
       let entryMissing = false;
       try {
-        const pkgPath = path.join(extPath, 'package.json');
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+        const pkg = readExtensionManifest(extPath);
         const cmd = (Array.isArray(pkg?.commands) ? pkg.commands : []).find((c: any) => c?.name === cmdName);
         if (cmd && !resolveEntryFile(extPath, cmd)) entryMissing = true;
       } catch {}
@@ -1203,8 +1403,7 @@ export async function getExtensionBundle(
     if (!fs.existsSync(outFile)) {
       let diagnostic = '';
       try {
-        const pkgPath = path.join(extPath, 'package.json');
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+        const pkg = readExtensionManifest(extPath);
         const commands = Array.isArray(pkg?.commands) ? pkg.commands : [];
         const cmd = commands.find((c: any) => c?.name === cmdName);
         const nodeModulesExists = fs.existsSync(path.join(extPath, 'node_modules'));
@@ -1230,7 +1429,7 @@ export async function getExtensionBundle(
     }
   }
 
-  const code = fs.readFileSync(outFile, 'utf-8');
+  const code = readExtensionBundleCode(outFile);
   if (!code) {
     const msg = `Pre-built bundle is empty: ${outFile}`;
     console.error(msg);
@@ -1266,8 +1465,8 @@ export async function getExtensionBundle(
   }> = [];
 
   try {
-    const pkgPath = path.join(extPath, 'package.json');
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    const pkg = readExtensionManifest(extPath);
+    if (!pkg) return null;
     if (!isManifestPlatformCompatible(pkg)) {
       return null;
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -218,6 +218,7 @@ import {
   importRaycastConfigFromFile,
   previewRaycastConfigImport,
 } from './raycast-config-import';
+import { runExecCommand, type ExecCommandOptions } from './exec-command';
 
 import { initialize as initAptabase, trackEvent } from "@aptabase/electron/main";
 
@@ -15384,91 +15385,9 @@ app.whenReady().then(async () => {
       _event: any,
       command: string,
       args: string[],
-      options?: { shell?: boolean | string; input?: string; env?: Record<string, string>; cwd?: string }
+      options?: ExecCommandOptions
     ) => {
-      const { spawn, execFile } = require('child_process');
-      const fs = require('fs');
-
-      return new Promise((resolve) => {
-        try {
-          const resolveExecutablePath = (input: string): string => {
-            if (!input || typeof input !== 'string') return input;
-            if (!input.includes('/') && !input.includes('\\')) return input;
-            if (!input.startsWith('/')) return input;
-            if (fs.existsSync(input)) return input;
-            try {
-              const base = input.split('/').filter(Boolean).pop() || '';
-              if (!base) return input;
-              const lookup = execFileSync('/bin/zsh', ['-lc', `command -v -- ${JSON.stringify(base)} 2>/dev/null || true`], { encoding: 'utf-8' }).trim();
-              if (lookup && fs.existsSync(lookup)) return lookup;
-            } catch {}
-            return input;
-          };
-
-          const execFileSync = require('child_process').execFileSync;
-          const normalizedCommand = resolveExecutablePath(command);
-          // Augment PATH so extensions can find brew, npm, nvm, etc. even when
-          // the app is launched from the Dock (where macOS strips the login PATH).
-          const extraPaths = [
-            '/opt/homebrew/bin', '/opt/homebrew/sbin',
-            '/usr/local/bin', '/usr/local/sbin',
-            '/usr/bin', '/usr/sbin', '/bin', '/sbin',
-          ];
-          const currentPath = (options?.env?.PATH ?? process.env.PATH ?? '');
-          const augmentedPath = [
-            ...extraPaths,
-            ...currentPath.split(':').filter(Boolean),
-          ].filter((v, i, a) => a.indexOf(v) === i).join(':');
-          const spawnOptions: any = {
-            shell: options?.shell ?? false,
-            env: { ...process.env, ...options?.env, PATH: augmentedPath },
-            cwd: options?.cwd || process.cwd(),
-          };
-
-          let proc: any;
-          if (options?.shell) {
-            // When shell is true, join command and args
-            const fullCommand = [normalizedCommand, ...args].join(' ');
-            proc = spawn(fullCommand, [], { ...spawnOptions, shell: true });
-          } else {
-            proc = spawn(normalizedCommand, args, spawnOptions);
-          }
-
-          let stdout = '';
-          let stderr = '';
-
-          proc.stdout?.on('data', (data: Buffer) => {
-            stdout += data.toString();
-          });
-
-          proc.stderr?.on('data', (data: Buffer) => {
-            stderr += data.toString();
-          });
-
-          if (options?.input && proc.stdin) {
-            proc.stdin.write(options.input);
-            proc.stdin.end();
-          }
-
-          proc.on('close', (code: number | null) => {
-            resolve({ stdout, stderr, exitCode: code ?? 0 });
-          });
-
-          proc.on('error', (err: Error) => {
-            resolve({ stdout, stderr: err.message, exitCode: 1 });
-          });
-
-          // Timeout after 5 minutes — allows long-running commands (brew install, npm install, etc.)
-          setTimeout(() => {
-            try {
-              proc.kill();
-            } catch {}
-            resolve({ stdout, stderr: stderr || 'Command timed out', exitCode: 124 });
-          }, 300000);
-        } catch (e: any) {
-          resolve({ stdout: '', stderr: e?.message || 'Failed to execute command', exitCode: 1 });
-        }
-      });
+      return runExecCommand(command, args, options);
     }
   );
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -111,6 +111,7 @@ import {
   MAX_INLINE_QUICK_LINK_ARGUMENTS,
   getQuickLinkIdFromCommandId,
 } from './utils/launcher-misc';
+import { enqueueBackgroundNoViewRun } from './utils/background-no-view-runs';
 import {
   WEB_SEARCH_ROOT_BANG_PREFIX,
   buildBangSearchUrl,
@@ -310,8 +311,9 @@ const App: React.FC = () => {
     launchType: 'userInitiated' | 'background' = 'userInitiated',
     reportStatus = false
   ) => {
-    const runId = `${bundle.extensionName || bundle.extName}/${bundle.commandName || bundle.cmdName}/${Date.now()}`;
-    setBackgroundNoViewRuns((prev) => [...prev, { runId, bundle, launchType, reportStatus }]);
+    setBackgroundNoViewRuns((prev) =>
+      enqueueBackgroundNoViewRun(prev, bundle, launchType, reportStatus).runs
+    );
   }, [setBackgroundNoViewRuns]);
 
   const onExitAiMode = useCallback(() => {

--- a/src/renderer/src/ExtensionView.tsx
+++ b/src/renderer/src/ExtensionView.tsx
@@ -16,6 +16,7 @@ import { ArrowLeft, AlertTriangle } from 'lucide-react';
 import * as RaycastAPI from './raycast-api';
 import { NavigationContext, setExtensionContext, setGlobalNavigation, ExtensionContextType, ExtensionInfoReactContext } from './raycast-api';
 import { withExtensionContext } from './raycast-api/context-scope-runtime';
+import { getCompiledExtensionWrapper } from './utils/extension-wrapper-cache';
 
 // Also import @raycast/utils stubs from our shim
 import * as RaycastUtils from './raycast-api';
@@ -529,6 +530,203 @@ function fsStatResult(
 
 const commandPathCache = new Map<string, string | null>();
 
+type SyncCommandResult = { stdout: string; stderr: string; exitCode: number };
+type RealFsStatPayload = {
+  exists: boolean;
+  isDirectory: boolean;
+  isFile: boolean;
+  size: number;
+  mode?: number;
+  uid?: number;
+  gid?: number;
+  dev?: number;
+  ino?: number;
+  nlink?: number;
+  atimeMs?: number;
+  mtimeMs?: number;
+  ctimeMs?: number;
+  birthtimeMs?: number;
+};
+
+let realNodeFsModule: any | undefined;
+let realNodeChildProcessModule: any | undefined;
+
+function getRealNodeRequire(): ((id: string) => any) | null {
+  if (!USE_REAL_NODE_BUILTINS) return null;
+  if (typeof _realNodeRequire === 'function') return _realNodeRequire;
+  if (typeof window !== 'undefined' && typeof (window as any).__scNodeRequire === 'function') {
+    return (window as any).__scNodeRequire;
+  }
+  return null;
+}
+
+function getRealNodeBuiltin(name: string): any | null {
+  const realRequire = getRealNodeRequire();
+  if (!realRequire) return null;
+  try {
+    return realRequire(name);
+  } catch {
+    return null;
+  }
+}
+
+function getRealNodeFsModule(): any | null {
+  if (realNodeFsModule !== undefined) return realNodeFsModule;
+  const mod = getRealNodeBuiltin('fs');
+  if (mod) realNodeFsModule = mod;
+  return mod || null;
+}
+
+function getRealNodeChildProcessModule(): any | null {
+  if (realNodeChildProcessModule !== undefined) return realNodeChildProcessModule;
+  const mod = getRealNodeBuiltin('child_process');
+  if (mod) realNodeChildProcessModule = mod;
+  return mod || null;
+}
+
+function formatSyncOutput(value: any): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return BufferPolyfill.from(toUint8Array(value)).toString();
+  } catch {
+    return String(value ?? '');
+  }
+}
+
+function buildSyncCommandEnv(options?: { env?: Record<string, string> }): Record<string, string> {
+  const baseEnv = { ...((_realNodeProcess?.env || {}) as Record<string, string>) };
+  const extraPaths = [
+    '/opt/homebrew/bin', '/opt/homebrew/sbin',
+    '/usr/local/bin', '/usr/local/sbin',
+    '/usr/bin', '/usr/sbin', '/bin', '/sbin',
+  ];
+  const currentPath = (options?.env?.PATH ?? baseEnv.PATH ?? '');
+  const augmentedPath = [
+    ...extraPaths,
+    ...String(currentPath).split(':').filter(Boolean),
+  ].filter((value, index, all) => all.indexOf(value) === index).join(':');
+  return {
+    ...baseEnv,
+    ...(options?.env || {}),
+    PATH: augmentedPath,
+  };
+}
+
+function runNodeCommandSync(
+  command: string,
+  args: string[],
+  options?: { shell?: boolean | string; input?: string; env?: Record<string, string>; cwd?: string }
+): SyncCommandResult | null {
+  const childProcess = getRealNodeChildProcessModule();
+  if (!childProcess || typeof childProcess.spawnSync !== 'function') return null;
+  try {
+    const spawnOptions: any = {
+      shell: options?.shell ?? false,
+      env: buildSyncCommandEnv(options),
+      cwd: options?.cwd || _realNodeProcess?.cwd?.() || undefined,
+      input: options?.input,
+      encoding: 'utf-8',
+      timeout: 60_000,
+    };
+    const result = options?.shell
+      ? childProcess.spawnSync([command, ...(args || [])].join(' '), [], { ...spawnOptions, shell: true })
+      : childProcess.spawnSync(command, args || [], spawnOptions);
+    return {
+      stdout: formatSyncOutput(result?.stdout),
+      stderr: formatSyncOutput(result?.stderr || result?.error?.message),
+      exitCode: typeof result?.status === 'number' ? result.status : result?.error ? 1 : 0,
+    };
+  } catch (error: any) {
+    return {
+      stdout: '',
+      stderr: error?.message || 'Failed to execute command',
+      exitCode: 1,
+    };
+  }
+}
+
+function runExtensionCommandSync(
+  command: string,
+  args: string[],
+  options?: { shell?: boolean | string; input?: string; env?: Record<string, string>; cwd?: string }
+): SyncCommandResult {
+  const nodeResult = runNodeCommandSync(command, args, options);
+  if (nodeResult) return nodeResult;
+  try {
+    return (window as any).electron?.execCommandSync?.(command, args, options) || { stdout: '', stderr: '', exitCode: 0 };
+  } catch (error: any) {
+    return { stdout: '', stderr: error?.message || 'Failed to execute command', exitCode: 1 };
+  }
+}
+
+function realFileExistsSync(path: string): boolean {
+  const fs = getRealNodeFsModule();
+  if (fs && typeof fs.existsSync === 'function') {
+    try {
+      return Boolean(fs.existsSync(path));
+    } catch {
+      return false;
+    }
+  }
+  try {
+    return (window as any).electron?.fileExistsSync?.(path) ?? false;
+  } catch {
+    return false;
+  }
+}
+
+function readRealFileSyncText(path: string): { data: string | null; error: string | null } {
+  const fs = getRealNodeFsModule();
+  if (fs && typeof fs.readFileSync === 'function') {
+    try {
+      return { data: String(fs.readFileSync(path, 'utf-8')), error: null };
+    } catch (error: any) {
+      return { data: null, error: error?.message || String(error) };
+    }
+  }
+  try {
+    return (window as any).electron?.readFileSync?.(path) || { data: null, error: 'readFileSync unavailable' };
+  } catch (error: any) {
+    return { data: null, error: error?.message || String(error) };
+  }
+}
+
+function toRealFsStatPayload(stat: any): RealFsStatPayload {
+  return {
+    exists: true,
+    isDirectory: typeof stat?.isDirectory === 'function' ? stat.isDirectory() : Boolean(stat?.isDirectory),
+    isFile: typeof stat?.isFile === 'function' ? stat.isFile() : Boolean(stat?.isFile),
+    size: Number(stat?.size) || 0,
+    mode: Number(stat?.mode) || undefined,
+    uid: Number(stat?.uid) || undefined,
+    gid: Number(stat?.gid) || undefined,
+    dev: Number(stat?.dev) || undefined,
+    ino: Number(stat?.ino) || undefined,
+    nlink: Number(stat?.nlink) || undefined,
+    atimeMs: Number(stat?.atimeMs) || undefined,
+    mtimeMs: Number(stat?.mtimeMs) || undefined,
+    ctimeMs: Number(stat?.ctimeMs) || undefined,
+    birthtimeMs: Number(stat?.birthtimeMs) || undefined,
+  };
+}
+
+function realStatSync(path: string): RealFsStatPayload {
+  const fs = getRealNodeFsModule();
+  if (fs && typeof fs.statSync === 'function') {
+    try {
+      return toRealFsStatPayload(fs.statSync(path));
+    } catch {
+      return { exists: false, isDirectory: false, isFile: false, size: 0 };
+    }
+  }
+  try {
+    return (window as any).electron?.statSync?.(path) || { exists: false, isDirectory: false, isFile: false, size: 0 };
+  } catch {
+    return { exists: false, isDirectory: false, isFile: false, size: 0 };
+  }
+}
+
 function isBareCommandPath(p: string): boolean {
   if (!p) return false;
   if (p.includes('/') || p.includes('\\')) return false;
@@ -540,7 +738,7 @@ function resolveCommandOnPath(command: string): string | null {
   if (!isBareCommandPath(command)) return null;
   if (commandPathCache.has(command)) return commandPathCache.get(command) || null;
   try {
-    const result = (window as any).electron?.execCommandSync?.(
+    const result = runExtensionCommandSync(
       '/bin/zsh',
       ['-lc', `command -v -- ${JSON.stringify(command)} 2>/dev/null || true`],
       {}
@@ -553,7 +751,7 @@ function resolveCommandOnPath(command: string): string | null {
     const commonDirs = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin'];
     for (const dir of commonDirs) {
       const candidate = `${dir}/${command}`;
-      if ((window as any).electron?.fileExistsSync?.(candidate)) {
+      if (realFileExistsSync(candidate)) {
         commandPathCache.set(command, candidate);
         return candidate;
       }
@@ -572,7 +770,7 @@ function resolveExecutablePath(input: any): string {
 
   if (raw.startsWith('/')) {
     try {
-      const exists = (window as any).electron?.fileExistsSync?.(raw);
+      const exists = realFileExistsSync(raw);
       if (exists) return raw;
       const base = raw.split('/').filter(Boolean).pop() || '';
       if (base) {
@@ -705,8 +903,16 @@ function collectVirtualDirectoryEntries(dirPath: string): Map<string, FsEntryKin
 }
 
 function getRealDirectoryEntriesSync(dirPath: string): string[] {
+  const fs = getRealNodeFsModule();
+  if (fs && typeof fs.readdirSync === 'function') {
+    try {
+      return fs.readdirSync(dirPath).map((entry: any) => String(entry || '')).filter((entry: string) => entry.length > 0);
+    } catch {
+      return [];
+    }
+  }
   try {
-    const result = (window as any).electron?.execCommandSync?.('/bin/ls', ['-A1', dirPath], {});
+    const result = runExtensionCommandSync('/bin/ls', ['-A1', dirPath], {});
     if (!result || result.exitCode !== 0) return [];
     return String(result.stdout || '')
       .split(/\r?\n/)
@@ -729,7 +935,7 @@ async function getRealDirectoryEntriesAsync(dirPath: string): Promise<string[]> 
 
 function getEntryKindFromRealStat(path: string): FsEntryKind {
   try {
-    const stat = (window as any).electron?.statSync?.(path);
+    const stat = realStatSync(path);
     if (!stat?.exists) return 'unknown';
     if (stat.isDirectory) return 'directory';
     if (stat.isFile) return 'file';
@@ -773,7 +979,7 @@ function combineDirectoryEntries(
 }
 
 function assertReadableDirectory(path: string, hasEntries: boolean): void {
-  const stat = (window as any).electron?.statSync?.(path);
+  const stat = realStatSync(path);
   if (stat?.exists && !stat.isDirectory) {
     throw createFsError('ENOTDIR', 'scandir', path);
   }
@@ -819,7 +1025,7 @@ const fsStub: Record<string, any> = {
     if (getStoredText(path) !== null) return true;
     // Fall back to real file system via sync IPC
     try {
-      return (window as any).electron?.fileExistsSync?.(path) ?? false;
+      return realFileExistsSync(path);
     } catch {
       return false;
     }
@@ -834,7 +1040,7 @@ const fsStub: Record<string, any> = {
     }
     // Fall back to real file system via sync IPC (for reading extension assets etc.)
     try {
-      const result = (window as any).electron?.readFileSync?.(path);
+      const result = readRealFileSyncText(path);
       if (result && result.data !== null) {
         if (opts?.encoding || typeof opts === 'string') return result.data;
         return BufferPolyfill.from(result.data);
@@ -876,7 +1082,7 @@ const fsStub: Record<string, any> = {
     const content = getStoredText(path);
     if (content !== null) return fsStatResult(true, false, content.length);
     try {
-      const result = (window as any).electron?.statSync?.(path);
+      const result = realStatSync(path);
       if (result?.exists) return fsStatResult(true, result.isDirectory, Number(result.size) || 0, result);
     } catch {}
     return fsStatResult(false);
@@ -886,7 +1092,7 @@ const fsStub: Record<string, any> = {
     const content = getStoredText(path);
     if (content !== null) return fsStatResult(true, false, content.length);
     try {
-      const result = (window as any).electron?.statSync?.(path);
+      const result = realStatSync(path);
       if (result?.exists) return fsStatResult(true, result.isDirectory, Number(result.size) || 0, result);
     } catch {}
     return fsStatResult(false);
@@ -915,7 +1121,7 @@ const fsStub: Record<string, any> = {
     const path = resolveFsLookupPath(p);
     if (getStoredText(path) !== null) return;
     try {
-      if ((window as any).electron?.fileExistsSync?.(path)) return;
+      if (realFileExistsSync(path)) return;
     } catch {}
     const err: any = new Error(`ENOENT: no such file or directory, access '${path}'`);
     err.code = 'ENOENT';
@@ -1007,7 +1213,7 @@ const fsStub: Record<string, any> = {
         cb(null, content);
       } else {
         // Fall back to real file system
-        const exists = Boolean((window as any).electron?.fileExistsSync?.(path));
+        const exists = realFileExistsSync(path);
         ((window as any).electron?.readFile?.(path) as Promise<string>)
           ?.then((data: string) => {
             if (exists) {
@@ -1049,7 +1255,7 @@ const fsStub: Record<string, any> = {
       if (getStoredText(path) !== null) cb(null);
       else {
         try {
-          if ((window as any).electron?.fileExistsSync?.(path)) { cb(null); return; }
+          if (realFileExistsSync(path)) { cb(null); return; }
         } catch {}
         const err: any = new Error(`ENOENT: no such file or directory, access '${path}'`);
         err.code = 'ENOENT';
@@ -1067,7 +1273,7 @@ const fsStub: Record<string, any> = {
       return;
     }
     try {
-      const result = (window as any).electron?.statSync?.(path);
+      const result = realStatSync(path);
       if (result?.exists) {
         cb(null, fsStatResult(true, result.isDirectory, Number(result.size) || 0, result));
         return;
@@ -1085,7 +1291,7 @@ const fsStub: Record<string, any> = {
       return;
     }
     try {
-      const result = (window as any).electron?.statSync?.(path);
+      const result = realStatSync(path);
       if (result?.exists) {
         cb(null, fsStatResult(true, result.isDirectory, Number(result.size) || 0, result));
         return;
@@ -1131,7 +1337,7 @@ const fsStub: Record<string, any> = {
       }
       // Fall back to real file system
       try {
-        const exists = Boolean((window as any).electron?.fileExistsSync?.(path));
+        const exists = realFileExistsSync(path);
         const data = await (window as any).electron?.readFile?.(path);
         if (exists) {
           if (opts?.encoding || typeof opts === 'string') return data;
@@ -1167,7 +1373,7 @@ const fsStub: Record<string, any> = {
       const content = getStoredText(path);
       if (content !== null) return fsStatResult(true, false, content.length);
       try {
-        const result = (window as any).electron?.statSync?.(path);
+        const result = realStatSync(path);
         if (result?.exists) return fsStatResult(true, result.isDirectory, Number(result.size) || 0, result);
       } catch {}
       throw createFsError('ENOENT', 'stat', path);
@@ -1177,7 +1383,7 @@ const fsStub: Record<string, any> = {
       const content = getStoredText(path);
       if (content !== null) return fsStatResult(true, false, content.length);
       try {
-        const result = (window as any).electron?.statSync?.(path);
+        const result = realStatSync(path);
         if (result?.exists) return fsStatResult(true, result.isDirectory, Number(result.size) || 0, result);
       } catch {}
       throw createFsError('ENOENT', 'lstat', path);
@@ -1187,7 +1393,7 @@ const fsStub: Record<string, any> = {
       const path = resolveFsLookupPath(p);
       if (getStoredText(path) !== null) return;
       try {
-        if ((window as any).electron?.fileExistsSync?.(path)) return;
+        if (realFileExistsSync(path)) return;
       } catch {}
       const err: any = new Error(`ENOENT: no such file or directory, access '${path}'`);
       err.code = 'ENOENT';
@@ -1874,7 +2080,7 @@ const childProcessStub = {
   },
   execSync: (command: string) => {
     const normalizedCommand = rewriteShellCommandForMissingBinary(command);
-    const result = (window as any).electron?.execCommandSync?.(
+    const result = runExtensionCommandSync(
       '/bin/zsh',
       ['-lc', normalizedCommand],
       { shell: false }
@@ -1982,11 +2188,11 @@ const childProcessStub = {
       options = args[1];
     }
 
-    const result = (window as any).electron?.execCommandSync?.(
+    const result = runExtensionCommandSync(
       file,
       execArgs,
       { shell: false, env: options?.env, cwd: options?.cwd, input: options?.input }
-    ) || { stdout: '', stderr: '', exitCode: 0 };
+    );
 
     if (result.exitCode !== 0) {
       const stderrOrMsg = String(result?.stderr || '');
@@ -2203,11 +2409,11 @@ const childProcessStub = {
   },
   spawnSync: (command: string, spawnArgs?: string[], options?: any) => {
     const resolvedCommand = resolveExecutablePath(command);
-    const result = (window as any).electron?.execCommandSync?.(
+    const result = runExtensionCommandSync(
       resolvedCommand,
       Array.isArray(spawnArgs) ? spawnArgs : [],
       { shell: options?.shell ?? false, env: options?.env, cwd: options?.cwd, input: options?.input }
-    ) || { stdout: '', stderr: '', exitCode: 0 };
+    );
 
     const stdoutBuf = BufferPolyfill.from(result.stdout || '');
     const stderrBuf = BufferPolyfill.from(result.stderr || '');
@@ -3037,6 +3243,11 @@ function isNodeBuiltinRequest(name: string): boolean {
   return false;
 }
 
+function shouldUseSuperCmdBuiltinFacade(name: string): boolean {
+  const normalized = name.startsWith('node:') ? name.slice(5) : name;
+  return normalized === 'fs' || normalized === 'fs/promises' || normalized === 'child_process';
+}
+
 // Capture real Node globals once, then remove them from globalThis so
 // extensions can't reach around fakeRequire. Runs at module load, before
 // any extension code executes.
@@ -3571,7 +3782,8 @@ end tell`.trim();
 function loadExtensionExport(
   code: string,
   extensionPath?: string,
-  timerRegistry?: TimerRegistry
+  timerRegistry?: TimerRegistry,
+  extensionIdentity = extensionPath || 'unknown-extension'
 ): Function | null {
   const patchSchemeDynamicImports = (sourceCode: string): string => {
     // Extension bundles may emit dynamic imports for native Raycast bridges
@@ -3747,6 +3959,10 @@ function loadExtensionExport(
       // Prefer real Node (via the preload bridge) when the hosting window
       // has Node enabled. Falls back to the stub if the module isn't a
       // recognised built-in, or if real require throws.
+      if (shouldUseSuperCmdBuiltinFacade(name)) {
+        const facade = nodeBuiltinStubs[name] || nodeBuiltinStubs[`node:${name}`];
+        if (facade) return facade;
+      }
       const realModule = tryRealNodeRequire(name);
       if (realModule !== undefined) {
         return realModule;
@@ -3962,28 +4178,12 @@ function loadExtensionExport(
     // anyway because requests are routed through the main process). Code
     // that genuinely needs navigator can still reach it via
     // `globalThis.navigator` or `window.navigator`.
-    const fn = new Function(
-      'exports',
-      'require',
-      'module',
-      '__filename',
-      '__dirname',
-      'process',
-      'Buffer',
-      'global',
-      'globalThis',
-      'setImmediate',
-      'clearImmediate',
-      'setInterval',
-      'clearInterval',
-      'setTimeout',
-      'clearTimeout',
-      'requestAnimationFrame',
-      'cancelAnimationFrame',
-      'navigator',
-      '__scDynamicImport',
-      executableCode
-    );
+    const { wrapper: fn, cacheHit } = getCompiledExtensionWrapper({
+      extensionIdentity,
+      code,
+      executableCode,
+    });
+    console.debug(`[loadExtensionExport] Wrapper cache ${cacheHit ? 'hit' : 'miss'} for ${extensionIdentity}`);
 
     fn(
       moduleExports,
@@ -4239,6 +4439,11 @@ const ExtensionView: React.FC<ExtensionViewProps> = ({
     mode,
   ]);
 
+  const extensionWrapperIdentity = useMemo(
+    () => [owner, extensionName, commandName, extensionPath].map((part) => String(part || '')).join('\0'),
+    [owner, extensionName, commandName, extensionPath]
+  );
+
   // Set extension context before loading (so getPreferenceValues etc. work)
   useEffect(() => {
     setExtensionContext(extensionCtx);
@@ -4266,9 +4471,9 @@ const ExtensionView: React.FC<ExtensionViewProps> = ({
     // Load under the extension's scoped context so other async extension work
     // cannot leak a different context into this bundle.
     return withExtensionContext(extensionCtx, () =>
-      loadExtensionExport(code, extensionPath, timerRegistryRef.current)
+      loadExtensionExport(code, extensionPath, timerRegistryRef.current, extensionWrapperIdentity)
     );
-  }, [code, buildError, extensionCtx, extensionPath]);
+  }, [code, buildError, extensionCtx, extensionPath, extensionWrapperIdentity]);
 
   // Is this a no-view command? Trust the mode from package.json.
   // NOTE: 'menu-bar' commands ARE React components (they use hooks),

--- a/src/renderer/src/ExtensionView.tsx
+++ b/src/renderer/src/ExtensionView.tsx
@@ -1098,9 +1098,30 @@ const fsStub: Record<string, any> = {
     return fsStatResult(false);
   },
   realpathSync: (p: string) => resolveFsLookupPath(p),
-  unlinkSync: (p: string) => { removeStoredText(resolveFsLookupPath(p)); },
-  rmdirSync: noop,
-  rmSync: (p: string) => { removeStoredText(resolveFsLookupPath(p)); },
+  unlinkSync: (p: string) => {
+    const path = resolveFsLookupPath(p);
+    const hadVirtual = getStoredText(path) !== null;
+    removeStoredText(path);
+    if (!hadVirtual) {
+      const fs = getRealNodeFsModule();
+      if (fs && typeof fs.unlinkSync === 'function') fs.unlinkSync(path);
+    }
+  },
+  rmdirSync: (p: string, ...args: any[]) => {
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.rmdirSync === 'function') {
+      return fs.rmdirSync(resolveFsLookupPath(p), ...args);
+    }
+  },
+  rmSync: (p: string, ...args: any[]) => {
+    const path = resolveFsLookupPath(p);
+    const hadVirtual = getStoredText(path) !== null;
+    removeStoredText(path);
+    if (!hadVirtual) {
+      const fs = getRealNodeFsModule();
+      if (fs && typeof fs.rmSync === 'function') return fs.rmSync(path, ...args);
+    }
+  },
   renameSync: (oldPath: string, newPath: string) => {
     const src = resolveFsLookupPath(oldPath);
     const dest = resolveFsLookupPath(newPath);
@@ -1108,15 +1129,28 @@ const fsStub: Record<string, any> = {
     if (content !== null) {
       setStoredText(dest, content);
       removeStoredText(src);
+      return;
     }
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.renameSync === 'function') fs.renameSync(src, dest);
   },
   copyFileSync: (src: string, dest: string) => {
     const source = resolveFsLookupPath(src);
     const destination = resolveFsLookupPath(dest);
     const content = getStoredText(source);
-    if (content !== null) setStoredText(destination, content);
+    if (content !== null) {
+      setStoredText(destination, content);
+      return;
+    }
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.copyFileSync === 'function') fs.copyFileSync(source, destination);
   },
-  chmodSync: noop,
+  chmodSync: (p: string, mode: string | number) => {
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.chmodSync === 'function') {
+      fs.chmodSync(resolveFsLookupPath(p), mode);
+    }
+  },
   accessSync: (p: any) => {
     const path = resolveFsLookupPath(p);
     if (getStoredText(path) !== null) return;
@@ -1127,14 +1161,35 @@ const fsStub: Record<string, any> = {
     err.code = 'ENOENT';
     throw err;
   },
-  openSync: () => 0,
-  closeSync: noop,
-  readSync: () => 0,
-  writeSync: () => 0,
-  createReadStream: (p: any) => {
+  openSync: (p: any, ...args: any[]) => {
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.openSync === 'function') {
+      return fs.openSync(resolveFsLookupPath(p), ...args);
+    }
+    return 0;
+  },
+  closeSync: (fd: number) => {
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.closeSync === 'function') fs.closeSync(fd);
+  },
+  readSync: (...args: any[]) => {
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.readSync === 'function') return fs.readSync(...args);
+    return 0;
+  },
+  writeSync: (...args: any[]) => {
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.writeSync === 'function') return fs.writeSync(...args);
+    return 0;
+  },
+  createReadStream: (p: any, ...args: any[]) => {
     const path = resolveFsLookupPath(p);
-    const s: any = new (nodeBuiltinStubs?.stream?.Readable || class {})();
     const content = getStoredText(path);
+    const fs = getRealNodeFsModule();
+    if (content == null && fs && typeof fs.createReadStream === 'function') {
+      return fs.createReadStream(path, ...args);
+    }
+    const s: any = new (nodeBuiltinStubs?.stream?.Readable || class {})();
     setTimeout(() => {
       if (content != null) {
         const bytes = toUint8Array(content);
@@ -1145,8 +1200,12 @@ const fsStub: Record<string, any> = {
     }, 0);
     return s;
   },
-  createWriteStream: (p: any) => {
+  createWriteStream: (p: any, ...args: any[]) => {
     const filePath = resolveFsLookupPath(p);
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.createWriteStream === 'function') {
+      return fs.createWriteStream(filePath, ...args);
+    }
     const s: any = new WritableStub();
     const chunks: Uint8Array[] = [];
     const defer = (fn: () => void) => {
@@ -1323,9 +1382,25 @@ const fsStub: Record<string, any> = {
     fsStub.renameSync(oldPath, newPath);
     if (typeof cb === 'function') cb(null);
   },
-  watch: () => ({ close: noop, on: noop }),
-  watchFile: noop,
-  unwatchFile: noop,
+  watch: (p: string, ...args: any[]) => {
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.watch === 'function') {
+      return fs.watch(resolveFsLookupPath(p), ...args);
+    }
+    return { close: noop, on: noop };
+  },
+  watchFile: (p: string, ...args: any[]) => {
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.watchFile === 'function') {
+      return fs.watchFile(resolveFsLookupPath(p), ...args);
+    }
+  },
+  unwatchFile: (p: string, ...args: any[]) => {
+    const fs = getRealNodeFsModule();
+    if (fs && typeof fs.unwatchFile === 'function') {
+      return fs.unwatchFile(resolveFsLookupPath(p), ...args);
+    }
+  },
   constants: { F_OK: 0, R_OK: 4, W_OK: 2, X_OK: 1 },
   promises: {
     readFile: async (p: string, opts?: any) => {
@@ -1418,7 +1493,13 @@ const fsStub: Record<string, any> = {
         throw new Error(result.stderr || `chmod failed with exit code ${result.exitCode}`);
       }
     },
-    open: noopAsync,
+    open: async (p: string, ...args: any[]) => {
+      const fs = getRealNodeFsModule();
+      if (fs?.promises && typeof fs.promises.open === 'function') {
+        return fs.promises.open(resolveFsLookupPath(p), ...args);
+      }
+      return noopAsync();
+    },
   },
 };
 
@@ -2439,7 +2520,13 @@ const childProcessStub = {
       error: undefined,
     };
   },
-  fork: () => createStubChildProcess(),
+  fork: (...args: any[]) => {
+    const childProcess = getRealNodeChildProcessModule();
+    if (childProcess && typeof childProcess.fork === 'function') {
+      return childProcess.fork(...args);
+    }
+    return createStubChildProcess();
+  },
 };
 
 // ── timers stubs ────────────────────────────────────────────────
@@ -3248,6 +3335,59 @@ function shouldUseSuperCmdBuiltinFacade(name: string): boolean {
   return normalized === 'fs' || normalized === 'fs/promises' || normalized === 'child_process';
 }
 
+const superCmdBuiltinFacadeCache = new Map<string, any>();
+
+function getSuperCmdBuiltinFacade(name: string): any | undefined {
+  if (!shouldUseSuperCmdBuiltinFacade(name)) return undefined;
+  const normalized = name.startsWith('node:') ? name.slice(5) : name;
+  const facade = nodeBuiltinStubs[normalized] || nodeBuiltinStubs[name] || nodeBuiltinStubs[`node:${normalized}`];
+  if (!facade) return undefined;
+
+  const realModule = getRealNodeBuiltin(name) || getRealNodeBuiltin(normalized);
+  if (!realModule || typeof realModule !== 'object') return facade;
+
+  const cacheKey = normalized;
+  const cached = superCmdBuiltinFacadeCache.get(cacheKey);
+  if (cached?.realModule === realModule && cached?.facade === facade) {
+    return cached.proxy;
+  }
+
+  const proxy = new Proxy(facade, {
+    get(target, prop, receiver) {
+      if (prop === Symbol.toStringTag && prop in realModule) return realModule[prop as any];
+      if (Reflect.has(target, prop)) {
+        const value = Reflect.get(target, prop, receiver);
+        const realValue = realModule[prop as any];
+        if (
+          prop === 'constants' &&
+          value &&
+          realValue &&
+          typeof value === 'object' &&
+          typeof realValue === 'object'
+        ) {
+          return { ...realValue, ...value };
+        }
+        return value;
+      }
+      return realModule[prop as any];
+    },
+    has(target, prop) {
+      return Reflect.has(target, prop) || prop in realModule;
+    },
+    ownKeys(target) {
+      return Array.from(new Set([...Reflect.ownKeys(realModule), ...Reflect.ownKeys(target)]));
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      const targetDescriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+      if (targetDescriptor) return targetDescriptor;
+      const realDescriptor = Reflect.getOwnPropertyDescriptor(realModule, prop);
+      return realDescriptor ? { ...realDescriptor, configurable: true } : undefined;
+    },
+  });
+  superCmdBuiltinFacadeCache.set(cacheKey, { facade, realModule, proxy });
+  return proxy;
+}
+
 // Capture real Node globals once, then remove them from globalThis so
 // extensions can't reach around fakeRequire. Runs at module load, before
 // any extension code executes.
@@ -3960,7 +4100,7 @@ function loadExtensionExport(
       // has Node enabled. Falls back to the stub if the module isn't a
       // recognised built-in, or if real require throws.
       if (shouldUseSuperCmdBuiltinFacade(name)) {
-        const facade = nodeBuiltinStubs[name] || nodeBuiltinStubs[`node:${name}`];
+        const facade = getSuperCmdBuiltinFacade(name);
         if (facade) return facade;
       }
       const realModule = tryRealNodeRequire(name);
@@ -4183,7 +4323,9 @@ function loadExtensionExport(
       code,
       executableCode,
     });
-    console.debug(`[loadExtensionExport] Wrapper cache ${cacheHit ? 'hit' : 'miss'} for ${extensionIdentity}`);
+    if ((globalThis as any).__SUPERCMD_DEBUG_EXTENSION_WRAPPER_CACHE) {
+      console.debug(`[loadExtensionExport] Wrapper cache ${cacheHit ? 'hit' : 'miss'} for ${extensionIdentity}`);
+    }
 
     fn(
       moduleExports,

--- a/src/renderer/src/components/HiddenExtensionRunners.tsx
+++ b/src/renderer/src/components/HiddenExtensionRunners.tsx
@@ -1,7 +1,8 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo } from 'react';
 import ExtensionView from '../ExtensionView';
 import type { BackgroundNoViewRun, MenuBarEntry } from '../hooks/useMenuBarExtensions';
 import { NOOP_ON_CLOSE } from '../utils/launcher-misc';
+import { removeBackgroundNoViewRun } from '../utils/background-no-view-runs';
 
 type HiddenExtensionRunnersProps = {
   menuBarExtensions: MenuBarEntry[];
@@ -9,11 +10,55 @@ type HiddenExtensionRunnersProps = {
   setBackgroundNoViewRuns: React.Dispatch<React.SetStateAction<BackgroundNoViewRun[]>>;
 };
 
+type BackgroundNoViewRunnerProps = {
+  run: BackgroundNoViewRun;
+  onRunFinished: (runId: string) => void;
+};
+
+const BackgroundNoViewRunner: React.FC<BackgroundNoViewRunnerProps> = ({ run, onRunFinished }) => {
+  const closeRun = useCallback(() => {
+    onRunFinished(run.runId);
+  }, [onRunFinished, run.runId]);
+
+  return (
+    <ExtensionView
+      code={run.bundle.code}
+      title={run.bundle.title}
+      mode="no-view"
+      extensionName={(run.bundle as any).extensionName || run.bundle.extName}
+      extensionDisplayName={(run.bundle as any).extensionDisplayName}
+      extensionIconDataUrl={(run.bundle as any).extensionIconDataUrl}
+      commandName={(run.bundle as any).commandName || run.bundle.cmdName}
+      assetsPath={(run.bundle as any).assetsPath}
+      supportPath={(run.bundle as any).supportPath}
+      owner={(run.bundle as any).owner}
+      preferences={(run.bundle as any).preferences}
+      preferenceDefinitions={(run.bundle as any).preferenceDefinitions}
+      launchArguments={(run.bundle as any).launchArguments}
+      launchContext={(run.bundle as any).launchContext}
+      fallbackText={(run.bundle as any).fallbackText}
+      launchType={run.launchType}
+      reportStatus={run.reportStatus}
+      onClose={closeRun}
+    />
+  );
+};
+
 const HiddenExtensionRunners: React.FC<HiddenExtensionRunnersProps> = ({
   menuBarExtensions,
   backgroundNoViewRuns,
   setBackgroundNoViewRuns,
 }) => {
+  const onBackgroundNoViewRunFinished = useCallback((runId: string) => {
+    setBackgroundNoViewRuns((prev) => removeBackgroundNoViewRun(prev, runId));
+  }, [setBackgroundNoViewRuns]);
+
+  useEffect(() => {
+    return () => {
+      setBackgroundNoViewRuns((prev) => (prev.length === 0 ? prev : []));
+    };
+  }, [setBackgroundNoViewRuns]);
+
   const menuBarRunner = useMemo(() => {
     if (menuBarExtensions.length === 0) return null;
     return (
@@ -49,33 +94,15 @@ const HiddenExtensionRunners: React.FC<HiddenExtensionRunnersProps> = ({
     return (
       <div style={{ display: 'none', position: 'absolute', width: 0, height: 0, overflow: 'hidden', pointerEvents: 'none' }}>
         {backgroundNoViewRuns.map((run) => (
-          <ExtensionView
+          <BackgroundNoViewRunner
             key={`bg-no-view-${run.runId}`}
-            code={run.bundle.code}
-            title={run.bundle.title}
-            mode="no-view"
-            extensionName={(run.bundle as any).extensionName || run.bundle.extName}
-            extensionDisplayName={(run.bundle as any).extensionDisplayName}
-            extensionIconDataUrl={(run.bundle as any).extensionIconDataUrl}
-            commandName={(run.bundle as any).commandName || run.bundle.cmdName}
-            assetsPath={(run.bundle as any).assetsPath}
-            supportPath={(run.bundle as any).supportPath}
-            owner={(run.bundle as any).owner}
-            preferences={(run.bundle as any).preferences}
-            preferenceDefinitions={(run.bundle as any).preferenceDefinitions}
-            launchArguments={(run.bundle as any).launchArguments}
-            launchContext={(run.bundle as any).launchContext}
-            fallbackText={(run.bundle as any).fallbackText}
-            launchType={run.launchType}
-            reportStatus={run.reportStatus}
-            onClose={() => {
-              setBackgroundNoViewRuns((prev) => prev.filter((item) => item.runId !== run.runId));
-            }}
+            run={run}
+            onRunFinished={onBackgroundNoViewRunFinished}
           />
         ))}
       </div>
     );
-  }, [backgroundNoViewRuns, setBackgroundNoViewRuns]);
+  }, [backgroundNoViewRuns, onBackgroundNoViewRunFinished]);
 
   return (
     <>

--- a/src/renderer/src/hooks/backgroundRefreshTimers.ts
+++ b/src/renderer/src/hooks/backgroundRefreshTimers.ts
@@ -1,0 +1,136 @@
+import type { CommandInfo } from '../../types/electron';
+
+export type BackgroundRefreshTimerKind = 'extension' | 'inline-script';
+
+export interface BackgroundRefreshTimerDescriptor {
+  key: string;
+  kind: BackgroundRefreshTimerKind;
+  command: CommandInfo;
+  intervalMs: number;
+  extensionCommand?: { extName: string; cmdName: string };
+}
+
+export interface BackgroundRefreshTimerEntry<TTimerId> {
+  timerId: TTimerId;
+}
+
+export interface BackgroundRefreshTimerReconcileResult {
+  created: number;
+  retained: number;
+  cleared: number;
+}
+
+export interface BackgroundRefreshTimerReconcileOptions<TTimerId> {
+  timers: Map<string, BackgroundRefreshTimerEntry<TTimerId>>;
+  descriptors: BackgroundRefreshTimerDescriptor[];
+  createTimer: (descriptor: BackgroundRefreshTimerDescriptor) => TTimerId;
+  clearTimer: (timerId: TTimerId) => void;
+}
+
+export function parseExtensionCommandPath(pathValue: string): { extName: string; cmdName: string } | null {
+  const rawPath = String(pathValue || '').trim();
+  const separatorIndex = rawPath.indexOf('/');
+  if (separatorIndex <= 0 || separatorIndex >= rawPath.length - 1) return null;
+
+  const extName = rawPath.slice(0, separatorIndex).trim();
+  const cmdName = rawPath.slice(separatorIndex + 1).trim();
+  if (!extName || !cmdName) return null;
+
+  return { extName, cmdName };
+}
+
+export function getBackgroundRefreshTimerKey(cmd: CommandInfo): string | null {
+  if (cmd.category === 'extension' && typeof cmd.interval === 'string' && cmd.path) {
+    const identity = parseExtensionCommandPath(cmd.path);
+    if (!identity) return null;
+
+    return [
+      'extension',
+      cmd.id,
+      `${identity.extName}/${identity.cmdName}`,
+      cmd.path.trim(),
+      cmd.mode || '',
+      cmd.interval,
+    ].join('\u0000');
+  }
+
+  if (cmd.category === 'script' && cmd.mode === 'inline' && typeof cmd.interval === 'string') {
+    return ['inline-script', cmd.id, (cmd.path || '').trim(), cmd.mode, cmd.interval].join('\u0000');
+  }
+
+  return null;
+}
+
+export function getBackgroundRefreshTimerDescriptors(
+  commands: CommandInfo[],
+  parseIntervalToMs: (interval: string) => number | null
+): BackgroundRefreshTimerDescriptor[] {
+  const descriptors: BackgroundRefreshTimerDescriptor[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const cmd of commands) {
+    const key = getBackgroundRefreshTimerKey(cmd);
+    if (!key || seenKeys.has(key) || typeof cmd.interval !== 'string') continue;
+
+    const intervalMs = parseIntervalToMs(cmd.interval);
+    if (!intervalMs) continue;
+
+    descriptors.push({
+      key,
+      kind: cmd.category === 'extension' ? 'extension' : 'inline-script',
+      command: cmd,
+      intervalMs,
+      extensionCommand: cmd.category === 'extension' ? parseExtensionCommandPath(cmd.path || '') || undefined : undefined,
+    });
+    seenKeys.add(key);
+  }
+
+  return descriptors;
+}
+
+export function reconcileBackgroundRefreshTimers<TTimerId>({
+  timers,
+  descriptors,
+  createTimer,
+  clearTimer,
+}: BackgroundRefreshTimerReconcileOptions<TTimerId>): BackgroundRefreshTimerReconcileResult {
+  const nextKeys = new Set(descriptors.map((descriptor) => descriptor.key));
+  let created = 0;
+  let retained = 0;
+  let cleared = 0;
+
+  for (const [key, entry] of Array.from(timers.entries())) {
+    if (!nextKeys.has(key)) {
+      clearTimer(entry.timerId);
+      timers.delete(key);
+      cleared += 1;
+    }
+  }
+
+  for (const descriptor of descriptors) {
+    if (timers.has(descriptor.key)) {
+      retained += 1;
+      continue;
+    }
+
+    timers.set(descriptor.key, { timerId: createTimer(descriptor) });
+    created += 1;
+  }
+
+  return { created, retained, cleared };
+}
+
+export function clearBackgroundRefreshTimers<TTimerId>(
+  timers: Map<string, BackgroundRefreshTimerEntry<TTimerId>>,
+  clearTimer: (timerId: TTimerId) => void
+): number {
+  let cleared = 0;
+
+  for (const entry of timers.values()) {
+    clearTimer(entry.timerId);
+    cleared += 1;
+  }
+
+  timers.clear();
+  return cleared;
+}

--- a/src/renderer/src/hooks/useBackgroundRefresh.ts
+++ b/src/renderer/src/hooks/useBackgroundRefresh.ts
@@ -7,13 +7,21 @@
  * - Inline script commands (category: "script", mode: "inline"): runs the script and
  *   calls fetchCommands() to refresh the subtitle shown in the launcher
  *
- * All timers are cleared and re-registered whenever the `commands` list changes.
- * This ensures newly installed or removed commands are handled correctly.
+ * Timers are keyed by stable command identity, path, mode, and interval so
+ * unchanged background commands keep their existing intervals across command
+ * list refreshes. Removed commands are cleared, and changed commands restart.
  */
 
-import { useRef, useEffect } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 import type { CommandInfo } from '../../types/electron';
 import { parseIntervalToMs } from '../utils/command-helpers';
+import {
+  clearBackgroundRefreshTimers,
+  getBackgroundRefreshTimerDescriptors,
+  reconcileBackgroundRefreshTimers,
+  type BackgroundRefreshTimerEntry,
+  type BackgroundRefreshTimerDescriptor,
+} from './backgroundRefreshTimers';
 import {
   readJsonObject,
   getScriptCmdArgsKey,
@@ -36,41 +44,20 @@ export interface UseBackgroundRefreshOptions {
 }
 
 export function useBackgroundRefresh({ commands, fetchCommands, isMenuBarCommandActive }: UseBackgroundRefreshOptions): void {
-  const intervalTimerIdsRef = useRef<number[]>([]);
+  const intervalTimersRef = useRef<Map<string, BackgroundRefreshTimerEntry<number>>>(new Map());
+  const fetchCommandsRef = useRef(fetchCommands);
+  fetchCommandsRef.current = fetchCommands;
+
   const isMenuBarCommandActiveRef = useRef(isMenuBarCommandActive);
   isMenuBarCommandActiveRef.current = isMenuBarCommandActive;
 
-  const parseExtensionCommandPath = (pathValue: string): { extName: string; cmdName: string } | null => {
-    const rawPath = String(pathValue || '').trim();
-    const separatorIndex = rawPath.indexOf('/');
-    if (separatorIndex <= 0 || separatorIndex >= rawPath.length - 1) return null;
+  const createTimer = useCallback((descriptor: BackgroundRefreshTimerDescriptor): number => {
+    const cmd = descriptor.command;
 
-    const extName = rawPath.slice(0, separatorIndex).trim();
-    const cmdName = rawPath.slice(separatorIndex + 1).trim();
-    if (!extName || !cmdName) return null;
+    if (descriptor.kind === 'extension') {
+      const { extName, cmdName } = descriptor.extensionCommand!;
 
-    return { extName, cmdName };
-  };
-
-  useEffect(() => {
-    for (const timerId of intervalTimerIdsRef.current) {
-      window.clearInterval(timerId);
-    }
-    intervalTimerIdsRef.current = [];
-
-    const extensionCommands = commands.filter(
-      (cmd) => cmd.category === 'extension' && typeof cmd.interval === 'string' && cmd.path
-    );
-
-    for (const cmd of extensionCommands) {
-      const ms = parseIntervalToMs(cmd.interval);
-      if (!ms) continue;
-
-      const identity = parseExtensionCommandPath(cmd.path || '');
-      if (!identity) continue;
-      const { extName, cmdName } = identity;
-
-      const timerId = window.setInterval(async () => {
+      return window.setInterval(async () => {
         try {
           const result = await window.electron.runExtension(extName, cmdName);
           if (!result || !result.code) return;
@@ -110,47 +97,41 @@ export function useBackgroundRefresh({ commands, fetchCommands, isMenuBarCommand
         } catch (error) {
           console.error('[BackgroundRefresh] Failed to run command:', cmd.id, error);
         }
-      }, ms);
-
-      intervalTimerIdsRef.current.push(timerId);
+      }, descriptor.intervalMs);
     }
 
-    const inlineScriptCommands = commands.filter(
-      (cmd) =>
-        cmd.category === 'script' &&
-        cmd.mode === 'inline' &&
-        typeof cmd.interval === 'string'
-    );
-    for (const cmd of inlineScriptCommands) {
-      const ms = parseIntervalToMs(cmd.interval);
-      if (!ms) continue;
-
-      const timerId = window.setInterval(async () => {
-        try {
-          const storedArgs = readJsonObject(getScriptCmdArgsKey(cmd.id));
-          const missingArgs = getMissingRequiredScriptArguments(cmd, storedArgs);
-          if (missingArgs.length > 0) return;
-          const result = await window.electron.runScriptCommand({
-            commandId: cmd.id,
-            arguments: storedArgs,
-            background: true,
-          });
-          if (result?.mode === 'inline') {
-            await fetchCommands();
-          }
-        } catch (error) {
-          console.error('[BackgroundRefresh] Failed to run script command:', cmd.id, error);
+    return window.setInterval(async () => {
+      try {
+        const storedArgs = readJsonObject(getScriptCmdArgsKey(cmd.id));
+        const missingArgs = getMissingRequiredScriptArguments(cmd, storedArgs);
+        if (missingArgs.length > 0) return;
+        const result = await window.electron.runScriptCommand({
+          commandId: cmd.id,
+          arguments: storedArgs,
+          background: true,
+        });
+        if (result?.mode === 'inline') {
+          await fetchCommandsRef.current();
         }
-      }, ms);
-
-      intervalTimerIdsRef.current.push(timerId);
-    }
-
-    return () => {
-      for (const timerId of intervalTimerIdsRef.current) {
-        window.clearInterval(timerId);
+      } catch (error) {
+        console.error('[BackgroundRefresh] Failed to run script command:', cmd.id, error);
       }
-      intervalTimerIdsRef.current = [];
+    }, descriptor.intervalMs);
+  }, []);
+
+  useEffect(() => {
+    const descriptors = getBackgroundRefreshTimerDescriptors(commands, parseIntervalToMs);
+    reconcileBackgroundRefreshTimers({
+      timers: intervalTimersRef.current,
+      descriptors,
+      createTimer,
+      clearTimer: (timerId) => window.clearInterval(timerId),
+    });
+  }, [commands, createTimer]);
+
+  useEffect(() => {
+    return () => {
+      clearBackgroundRefreshTimers(intervalTimersRef.current, (timerId) => window.clearInterval(timerId));
     };
-  }, [commands, fetchCommands]);
+  }, []);
 }

--- a/src/renderer/src/hooks/useLauncherCommandExecution.ts
+++ b/src/renderer/src/hooks/useLauncherCommandExecution.ts
@@ -3,6 +3,7 @@ import type React from 'react';
 import type { CommandInfo, ExtensionBundle, QuickLinkDynamicField } from '../../types/electron';
 import { LAST_EXT_KEY } from '../utils/constants';
 import {
+  flushCommandArgumentSettingsSync,
   getCmdArgsKey,
   getScriptCmdArgsKey,
   hydrateExtensionBundlePreferences,
@@ -266,10 +267,13 @@ export function useLauncherCommandExecution(
         };
 
         if (Object.keys(inlineArguments).length > 0 && command.mode === 'no-view') {
+          const commandArgsKey = getCmdArgsKey(extName, cmdName);
           writeJsonObject(
-            getCmdArgsKey(extName, cmdName),
-            { ...((hydratedWithInlineArguments as any).launchArguments || {}) }
+            commandArgsKey,
+            { ...((hydratedWithInlineArguments as any).launchArguments || {}) },
+            { commandArgumentSettingsSync: 'debounced' }
           );
+          await flushCommandArgumentSettingsSync(commandArgsKey);
         }
 
         if (shouldOpenCommandSetup(hydratedWithInlineArguments)) {

--- a/src/renderer/src/hooks/useLauncherInlineArguments.ts
+++ b/src/renderer/src/hooks/useLauncherInlineArguments.ts
@@ -272,7 +272,11 @@ export function useLauncherInlineArguments({
           [argumentName]: value,
         };
         if (extensionIdentity && command.mode === 'no-view') {
-          writeJsonObject(getCmdArgsKey(extensionIdentity.extName, extensionIdentity.cmdName), nextCommandValues);
+          writeJsonObject(
+            getCmdArgsKey(extensionIdentity.extName, extensionIdentity.cmdName),
+            nextCommandValues,
+            { commandArgumentSettingsSync: 'debounced' }
+          );
         }
         return {
           ...prev,

--- a/src/renderer/src/hooks/useMenuBarExtensions.ts
+++ b/src/renderer/src/hooks/useMenuBarExtensions.ts
@@ -19,18 +19,14 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react';
 import type { ExtensionBundle } from '../../types/electron';
+import type { ExtensionStorageChangedDetail } from '../raycast-api/storage-events';
+import type { BackgroundNoViewRun } from '../utils/background-no-view-runs';
+
+export type { BackgroundNoViewRun } from '../utils/background-no-view-runs';
 
 export interface MenuBarEntry {
   key: string;
   bundle: ExtensionBundle;
-}
-
-export interface BackgroundNoViewRun {
-  runId: string;
-  bundle: ExtensionBundle;
-  launchType: 'userInitiated' | 'background';
-  /** When true, execution status is mirrored to the system status-bar badge. */
-  reportStatus?: boolean;
 }
 
 export interface UseMenuBarExtensionsReturn {
@@ -46,7 +42,13 @@ export interface UseMenuBarExtensionsReturn {
   hideMenuBarExtension: (bundle: Partial<ExtensionBundle>) => void;
   hideMenuBarExtensionsForExtension: (extensionName: string) => void;
   upsertMenuBarExtension: (bundle: ExtensionBundle, options?: { remount?: boolean }) => void;
-  remountMenuBarExtensionsForExtension: (extensionName: string) => void;
+  remountMenuBarExtensionsForExtension: (
+    extensionName: string,
+    options?: {
+      sourceCommandName?: string;
+      sourceCommandMode?: string;
+    }
+  ) => void;
 }
 
 export function useMenuBarExtensions(): UseMenuBarExtensionsReturn {
@@ -133,25 +135,35 @@ export function useMenuBarExtensions(): UseMenuBarExtensionsReturn {
     });
   }, [getMenuBarIdentity]);
 
-  const remountMenuBarExtensionsForExtension = useCallback((extensionName: string) => {
+  const remountMenuBarExtensionsForExtension = useCallback((
+    extensionName: string,
+    options?: {
+      sourceCommandName?: string;
+      sourceCommandMode?: string;
+    }
+  ) => {
     const normalized = (extensionName || '').trim();
     if (!normalized) return;
     const now = Date.now();
     const lastTs = menuBarRemountTimestampsRef.current[normalized] || 0;
     if (now - lastTs < 200) return;
-    menuBarRemountTimestampsRef.current[normalized] = now;
+    const sourceCommandName = (options?.sourceCommandName || '').trim();
+    const sourceCommandMode = (options?.sourceCommandMode || '').trim();
+    const skipSourceCommand = sourceCommandMode === 'menu-bar' && Boolean(sourceCommandName);
     setMenuBarExtensions((prev) => {
       let changed = false;
       const next = prev.map((entry) => {
         const entryExt = (entry.bundle.extName || entry.bundle.extensionName || '').trim();
         if (!entryExt || entryExt !== normalized) return entry;
+        const cmdName = (entry.bundle.cmdName || entry.bundle.commandName || '').trim();
+        if (skipSourceCommand && cmdName === sourceCommandName) return entry;
         changed = true;
-        const cmdName = entry.bundle.cmdName || entry.bundle.commandName || '';
         return {
           key: `${normalized}:${cmdName}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
           bundle: entry.bundle,
         };
       });
+      if (changed) menuBarRemountTimestampsRef.current[normalized] = now;
       return changed ? next : prev;
     });
   }, []);
@@ -163,10 +175,13 @@ export function useMenuBarExtensions(): UseMenuBarExtensionsReturn {
   // This matches Raycast behavior where menu-bar commands observe state changes quickly.
   useEffect(() => {
     const onStorageChanged = (event: Event) => {
-      const custom = event as CustomEvent<{ extensionName?: string }>;
+      const custom = event as CustomEvent<Partial<ExtensionStorageChangedDetail>>;
       const extensionName = (custom.detail?.extensionName || '').trim();
       if (!extensionName) return;
-      remountMenuBarExtensionsForExtension(extensionName);
+      remountMenuBarExtensionsForExtension(extensionName, {
+        sourceCommandName: custom.detail?.commandName,
+        sourceCommandMode: custom.detail?.commandMode,
+      });
     };
     window.addEventListener('sc-extension-storage-changed', onStorageChanged as EventListener);
     return () => {

--- a/src/renderer/src/hooks/useMenuBarExtensions.ts
+++ b/src/renderer/src/hooks/useMenuBarExtensions.ts
@@ -144,12 +144,20 @@ export function useMenuBarExtensions(): UseMenuBarExtensionsReturn {
   ) => {
     const normalized = (extensionName || '').trim();
     if (!normalized) return;
-    const now = Date.now();
-    const lastTs = menuBarRemountTimestampsRef.current[normalized] || 0;
-    if (now - lastTs < 200) return;
     const sourceCommandName = (options?.sourceCommandName || '').trim();
     const sourceCommandMode = (options?.sourceCommandMode || '').trim();
     const skipSourceCommand = sourceCommandMode === 'menu-bar' && Boolean(sourceCommandName);
+    const hasRemountTarget = menuBarExtensions.some((entry) => {
+      const entryExt = (entry.bundle.extName || entry.bundle.extensionName || '').trim();
+      if (!entryExt || entryExt !== normalized) return false;
+      const cmdName = (entry.bundle.cmdName || entry.bundle.commandName || '').trim();
+      return !(skipSourceCommand && cmdName === sourceCommandName);
+    });
+    if (!hasRemountTarget) return;
+    const now = Date.now();
+    const lastTs = menuBarRemountTimestampsRef.current[normalized] || 0;
+    if (now - lastTs < 200) return;
+    menuBarRemountTimestampsRef.current[normalized] = now;
     setMenuBarExtensions((prev) => {
       let changed = false;
       const next = prev.map((entry) => {
@@ -163,10 +171,9 @@ export function useMenuBarExtensions(): UseMenuBarExtensionsReturn {
           bundle: entry.bundle,
         };
       });
-      if (changed) menuBarRemountTimestampsRef.current[normalized] = now;
       return changed ? next : prev;
     });
-  }, []);
+  }, [menuBarExtensions]);
 
   // Note: no auto-mount on app startup. Menu-bar extensions are per-session — the
   // user must explicitly run each command from the launcher to mount it.

--- a/src/renderer/src/raycast-api/hooks/use-cached-promise.ts
+++ b/src/renderer/src/raycast-api/hooks/use-cached-promise.ts
@@ -47,13 +47,8 @@ export function useCachedPromise<T>(
   const [isPaginated, setIsPaginated] = useState(false);
 
   const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const abortableRefRef = useRef<React.MutableRefObject<AbortController | null | undefined> | undefined>(undefined);
   const fnRef = useRef(fn);
   const argsRef = useRef(args || []);
   const optionsRef = useRef(options);
@@ -63,30 +58,68 @@ export function useCachedPromise<T>(
   optionsRef.current = options;
   runtimeCtxRef.current = snapshotExtensionContext();
 
+  const clearAbortController = useCallback((controller: AbortController) => {
+    const abortableRef = abortableRefRef.current;
+    if (abortableRef?.current === controller) {
+      abortableRef.current = null;
+    }
+    if (abortControllerRef.current === controller) {
+      abortControllerRef.current = null;
+      if (abortableRefRef.current === abortableRef) {
+        abortableRefRef.current = undefined;
+      }
+    }
+  }, []);
+
+  const abortCurrentRun = useCallback(() => {
+    const controller = abortControllerRef.current;
+    if (!controller) return;
+    controller.abort();
+    clearAbortController(controller);
+  }, [clearAbortController]);
+
+  const prepareAbortController = useCallback((abortable?: React.MutableRefObject<AbortController | null | undefined>) => {
+    abortCurrentRun();
+    if (!abortable) return null;
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    abortableRefRef.current = abortable;
+    abortable.current = controller;
+    return controller;
+  }, [abortCurrentRun]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      abortCurrentRun();
+    };
+  }, [abortCurrentRun]);
+
   const fetchPage = useCallback(async (pageNum: number, currentCursor?: string) => {
     const opts = optionsRef.current;
     if (opts?.execute === false || !mountedRef.current) return;
 
+    const runController = prepareAbortController(opts?.abortable);
+    const runCtx = runtimeCtxRef.current;
+    const isCurrentRun = () => !runController || abortControllerRef.current === runController;
+
     setIsLoading(true);
     setError(undefined);
 
-    if (opts?.abortable) {
-      const controller = new AbortController();
-      opts.abortable.current = controller;
-    }
-
-    withExtensionContext(runtimeCtxRef.current, () => {
+    withExtensionContext(runCtx, () => {
       opts?.onWillExecute?.(argsRef.current);
     });
 
     try {
-      const outerResult = withExtensionContext(runtimeCtxRef.current, () => fnRef.current(...argsRef.current));
+      const outerResult = withExtensionContext(runCtx, () => fnRef.current(...argsRef.current));
 
       if (typeof outerResult === 'function') {
         setIsPaginated(true);
         const paginationOptions = { page: pageNum, cursor: currentCursor, lastItem: undefined };
-        const innerResult = await withExtensionContext(runtimeCtxRef.current, () => outerResult(paginationOptions));
-        if (!mountedRef.current) return;
+        const innerResult = await withExtensionContext(runCtx, () => outerResult(paginationOptions));
+        if (!mountedRef.current || !isCurrentRun()) return;
 
         if (innerResult && typeof innerResult === 'object' && 'data' in innerResult) {
           const { data: pageData, hasMore: more, cursor: nextCursor } = innerResult;
@@ -96,14 +129,14 @@ export function useCachedPromise<T>(
           if (pageNum === 0) {
             setAccumulatedData(Array.isArray(pageData) ? pageData : []);
           } else {
-            setAccumulatedData((prev) => {
+            setAccumulatedData((prev: any) => {
               const prevArr = Array.isArray(prev) ? prev : [];
               const newArr = Array.isArray(pageData) ? pageData : [];
               return [...prevArr, ...newArr];
             });
           }
 
-          withExtensionContext(runtimeCtxRef.current, () => {
+          withExtensionContext(runCtx, () => {
             opts?.onData?.((innerResult as any).data);
           });
         } else {
@@ -112,7 +145,7 @@ export function useCachedPromise<T>(
         }
       } else {
         const result = await outerResult;
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || !isCurrentRun()) return;
 
         if (result && typeof result === 'object' && 'data' in result && 'hasMore' in result) {
           setIsPaginated(true);
@@ -123,35 +156,40 @@ export function useCachedPromise<T>(
           if (pageNum === 0) {
             setAccumulatedData(Array.isArray(pageData) ? pageData : []);
           } else {
-            setAccumulatedData((prev) => {
+            setAccumulatedData((prev: any) => {
               const prevArr = Array.isArray(prev) ? prev : [];
               const newArr = Array.isArray(pageData) ? pageData : [];
               return [...prevArr, ...newArr];
             });
           }
 
-          withExtensionContext(runtimeCtxRef.current, () => {
+          withExtensionContext(runCtx, () => {
             opts?.onData?.(pageData as T);
           });
         } else {
           setAccumulatedData(result as any);
           setHasMore(false);
-          withExtensionContext(runtimeCtxRef.current, () => {
+          withExtensionContext(runCtx, () => {
             opts?.onData?.(result as T);
           });
         }
       }
     } catch (err) {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || !isCurrentRun()) return;
       const e = err instanceof Error ? err : new Error(String(err));
       setError(e);
-      withExtensionContext(runtimeCtxRef.current, () => {
+      withExtensionContext(runCtx, () => {
         opts?.onError?.(e);
       });
     } finally {
-      if (mountedRef.current) setIsLoading(false);
+      if (mountedRef.current && isCurrentRun()) {
+        setIsLoading(false);
+      }
+      if (runController) {
+        clearAbortController(runController);
+      }
     }
-  }, []);
+  }, [prepareAbortController, clearAbortController]);
 
   const argsKey = JSON.stringify(args || []);
   useEffect(() => {

--- a/src/renderer/src/raycast-api/hooks/use-local-storage.ts
+++ b/src/renderer/src/raycast-api/hooks/use-local-storage.ts
@@ -5,6 +5,7 @@
 
 import { useCallback, useState } from 'react';
 import { emitExtensionStorageChanged } from '../storage-events';
+import { getCurrentScopedExtensionContext } from '../context-scope-runtime';
 import { getScopedLocalStorageKeys, readScopedJsonState } from './storage-scope';
 
 export function useLocalStorage<T>(
@@ -17,6 +18,10 @@ export function useLocalStorage<T>(
   isLoading: boolean;
 } {
   const { scopedKey, legacyKeys } = getScopedLocalStorageKeys(key);
+  const currentContext = getCurrentScopedExtensionContext();
+  const storageEventExtensionName = currentContext.extensionName;
+  const storageEventCommandName = currentContext.commandName;
+  const storageEventCommandMode = currentContext.commandMode;
   const [value, setValueState] = useState<T | undefined>(() => {
     return readScopedJsonState(scopedKey, legacyKeys, initialValue);
   });
@@ -29,8 +34,12 @@ export function useLocalStorage<T>(
     } catch {
       // best-effort
     }
-    emitExtensionStorageChanged();
-  }, [scopedKey]);
+    emitExtensionStorageChanged({
+      extensionName: storageEventExtensionName,
+      commandName: storageEventCommandName,
+      commandMode: storageEventCommandMode,
+    });
+  }, [scopedKey, storageEventCommandMode, storageEventCommandName, storageEventExtensionName]);
 
   const removeValue = useCallback(async () => {
     setValueState(undefined);
@@ -42,8 +51,12 @@ export function useLocalStorage<T>(
     } catch {
       // best-effort
     }
-    emitExtensionStorageChanged();
-  }, [legacyKeys, scopedKey]);
+    emitExtensionStorageChanged({
+      extensionName: storageEventExtensionName,
+      commandName: storageEventCommandName,
+      commandMode: storageEventCommandMode,
+    });
+  }, [legacyKeys, scopedKey, storageEventCommandMode, storageEventCommandName, storageEventExtensionName]);
 
   return { value, setValue, removeValue, isLoading };
 }

--- a/src/renderer/src/raycast-api/hooks/use-promise.ts
+++ b/src/renderer/src/raycast-api/hooks/use-promise.ts
@@ -49,51 +49,98 @@ export function usePromise<T>(
   const [error, setError] = useState<Error | undefined>(undefined);
 
   const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const abortableRefRef = useRef<React.MutableRefObject<AbortController | null | undefined> | undefined>(undefined);
 
   const stableArgs = useStableArgs(args || []);
 
   const fnRef = useRef(fn);
   const argsRef = useRef(stableArgs);
+  const optionsRef = useRef(options);
   const runtimeCtxRef = useRef<ExtensionContextSnapshot>(snapshotExtensionContext());
   fnRef.current = fn;
   argsRef.current = stableArgs;
+  optionsRef.current = options;
   runtimeCtxRef.current = snapshotExtensionContext();
 
+  const clearAbortController = useCallback((controller: AbortController) => {
+    const abortableRef = abortableRefRef.current;
+    if (abortableRef?.current === controller) {
+      abortableRef.current = null;
+    }
+    if (abortControllerRef.current === controller) {
+      abortControllerRef.current = null;
+      if (abortableRefRef.current === abortableRef) {
+        abortableRefRef.current = undefined;
+      }
+    }
+  }, []);
+
+  const abortCurrentRun = useCallback(() => {
+    const controller = abortControllerRef.current;
+    if (!controller) return;
+    controller.abort();
+    clearAbortController(controller);
+  }, [clearAbortController]);
+
+  const prepareAbortController = useCallback((abortable?: React.MutableRefObject<AbortController | null | undefined>) => {
+    abortCurrentRun();
+    if (!abortable) return null;
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    abortableRefRef.current = abortable;
+    abortable.current = controller;
+    return controller;
+  }, [abortCurrentRun]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      abortCurrentRun();
+    };
+  }, [abortCurrentRun]);
+
   const execute = useCallback(() => {
-    if (options?.execute === false || !mountedRef.current) return;
+    const opts = optionsRef.current;
+    if (opts?.execute === false || !mountedRef.current) return;
+
+    const runController = prepareAbortController(opts?.abortable);
+    const runCtx = runtimeCtxRef.current;
+    const isCurrentRun = () => !runController || abortControllerRef.current === runController;
 
     setIsLoading(true);
     setError(undefined);
-    withExtensionContext(runtimeCtxRef.current, () => {
-      options?.onWillExecute?.(argsRef.current);
+    withExtensionContext(runCtx, () => {
+      opts?.onWillExecute?.(argsRef.current);
     });
 
     Promise.resolve()
-      .then(() => withExtensionContext(runtimeCtxRef.current, () => fnRef.current(...argsRef.current)))
+      .then(() => withExtensionContext(runCtx, () => fnRef.current(...argsRef.current)))
       .then((result) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || !isCurrentRun()) return;
         setData(result);
         setIsLoading(false);
-        withExtensionContext(runtimeCtxRef.current, () => {
-          options?.onData?.(result);
+        withExtensionContext(runCtx, () => {
+          opts?.onData?.(result);
         });
       })
       .catch((err) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || !isCurrentRun()) return;
         const e = err instanceof Error ? err : new Error(String(err));
         setError(e);
         setIsLoading(false);
-        withExtensionContext(runtimeCtxRef.current, () => {
-          options?.onError?.(e);
+        withExtensionContext(runCtx, () => {
+          opts?.onError?.(e);
         });
+      })
+      .finally(() => {
+        if (runController) {
+          clearAbortController(runController);
+        }
       });
-  }, [options?.execute]);
+  }, [options?.execute, prepareAbortController, clearAbortController]);
 
   useEffect(() => {
     execute();

--- a/src/renderer/src/raycast-api/index.tsx
+++ b/src/renderer/src/raycast-api/index.tsx
@@ -1387,11 +1387,22 @@ export namespace Cache {
   export type Subscription = () => void;
 }
 
+const CACHE_METADATA_VERSION = 2;
+
+interface CacheStorageMetadata {
+  version?: number;
+  lruOrder?: unknown;
+  sizeByKey?: unknown;
+  totalSize?: unknown;
+}
+
 export class Cache {
   private storageKey: string;
   private capacity: number;
   private subscribers: Set<Cache.Subscriber> = new Set();
   private lruOrder: string[] = []; // Track access order for LRU
+  private sizeByKey: Map<string, number> = new Map();
+  private totalSize = 0;
 
   constructor(options: Cache.Options = {}) {
     this.capacity = options.capacity ?? 10 * 1024 * 1024; // 10MB default
@@ -1403,21 +1414,146 @@ export class Cache {
   }
 
   private loadFromStorage(): void {
+    let metadata: CacheStorageMetadata | null = null;
+    let hadStoredMetadata = false;
+
     try {
       const stored = localStorage.getItem(this.storageKey);
+      hadStoredMetadata = stored !== null;
       if (stored) {
-        const parsed = JSON.parse(stored);
-        this.lruOrder = parsed.lruOrder || [];
+        metadata = JSON.parse(stored);
       }
     } catch (e) {
       console.error('Failed to load cache from storage:', e);
+      this.recoverFromStorage(undefined, true);
+      return;
+    }
+
+    if (!metadata || typeof metadata !== 'object') {
+      this.recoverFromStorage(undefined, hadStoredMetadata);
+      return;
+    }
+
+    const lruOrder = this.parseLruOrder(metadata.lruOrder);
+    if (!lruOrder) {
+      this.recoverFromStorage(undefined, true);
+      return;
+    }
+
+    const storedSizes = this.parseStoredSizes(metadata.sizeByKey);
+    if (!storedSizes) {
+      this.recoverFromStorage(lruOrder, true);
+      return;
+    }
+
+    let totalSize = 0;
+    const nextSizes = new Map<string, number>();
+    let hasAllSizes = true;
+
+    for (const key of lruOrder) {
+      const size = storedSizes.get(key);
+      if (size === undefined) {
+        hasAllSizes = false;
+        break;
+      }
+      nextSizes.set(key, size);
+      totalSize += size;
+    }
+
+    if (!hasAllSizes) {
+      this.recoverFromStorage(lruOrder, true);
+      return;
+    }
+
+    this.lruOrder = lruOrder;
+    this.sizeByKey = nextSizes;
+    this.totalSize = totalSize;
+
+    if (
+      metadata.version !== CACHE_METADATA_VERSION ||
+      metadata.totalSize !== totalSize ||
+      storedSizes.size !== lruOrder.length
+    ) {
+      this.saveToStorage();
+    }
+  }
+
+  private parseLruOrder(value: unknown): string[] | null {
+    if (!Array.isArray(value)) return null;
+
+    const seen = new Set<string>();
+    const order: string[] = [];
+    for (const key of value) {
+      if (typeof key !== 'string') return null;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      order.push(key);
+    }
+    return order;
+  }
+
+  private parseStoredSizes(value: unknown): Map<string, number> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+
+    const sizes = new Map<string, number>();
+    for (const [key, size] of Object.entries(value as Record<string, unknown>)) {
+      if (typeof size !== 'number' || !Number.isFinite(size) || size < 0) return null;
+      sizes.set(key, size);
+    }
+    return sizes;
+  }
+
+  private recoverFromStorage(preferredOrder?: string[], shouldSave = false): void {
+    this.lruOrder = [];
+    this.sizeByKey.clear();
+    this.totalSize = 0;
+
+    const recovered = new Set<string>();
+    const recoverKey = (key: string): void => {
+      if (recovered.has(key)) return;
+      recovered.add(key);
+
+      const value = localStorage.getItem(this.getItemKey(key));
+      if (value === null) return;
+
+      this.lruOrder.push(key);
+      this.sizeByKey.set(key, value.length);
+      this.totalSize += value.length;
+    };
+
+    if (preferredOrder) {
+      for (const key of preferredOrder) recoverKey(key);
+    } else {
+      const itemPrefix = this.getItemPrefix();
+      const storageKeys: string[] = [];
+      for (let index = 0; index < localStorage.length; index += 1) {
+        const storageKey = localStorage.key(index);
+        if (storageKey?.startsWith(itemPrefix)) storageKeys.push(storageKey);
+      }
+
+      for (const storageKey of storageKeys) {
+        recoverKey(storageKey.slice(itemPrefix.length));
+      }
+    }
+
+    if (shouldSave || this.lruOrder.length > 0) {
+      this.saveToStorage();
     }
   }
 
   private saveToStorage(): void {
     try {
+      const sizeByKey: Record<string, number> = {};
+      for (const key of this.lruOrder) {
+        const size = this.sizeByKey.get(key);
+        if (size !== undefined) sizeByKey[key] = size;
+      }
+
       const data = {
+        version: CACHE_METADATA_VERSION,
         lruOrder: this.lruOrder,
+        sizeByKey,
+        totalSize: this.totalSize,
       };
       localStorage.setItem(this.storageKey, JSON.stringify(data));
     } catch (e) {
@@ -1425,19 +1561,16 @@ export class Cache {
     }
   }
 
+  private getItemPrefix(): string {
+    return `${this.storageKey}-item-`;
+  }
+
   private getItemKey(key: string): string {
-    return `${this.storageKey}-item-${key}`;
+    return `${this.getItemPrefix()}${key}`;
   }
 
   private getCurrentSize(): number {
-    let total = 0;
-    for (const key of this.lruOrder) {
-      const value = localStorage.getItem(this.getItemKey(key));
-      if (value) {
-        total += value.length;
-      }
-    }
-    return total;
+    return this.totalSize;
   }
 
   private evictLRU(): void {
@@ -1445,6 +1578,9 @@ export class Cache {
     const oldestKey = this.lruOrder.shift();
     if (oldestKey) {
       localStorage.removeItem(this.getItemKey(oldestKey));
+      const size = this.sizeByKey.get(oldestKey) ?? 0;
+      this.sizeByKey.delete(oldestKey);
+      this.totalSize = Math.max(0, this.totalSize - size);
     }
   }
 
@@ -1456,6 +1592,29 @@ export class Cache {
     }
     // Add to end (most recently used)
     this.lruOrder.push(key);
+  }
+
+  private removeTrackedKey(key: string): boolean {
+    const index = this.lruOrder.indexOf(key);
+    const trackedSize = this.sizeByKey.get(key);
+    const existed = index !== -1 || trackedSize !== undefined;
+
+    if (index !== -1) {
+      this.lruOrder.splice(index, 1);
+    }
+    if (trackedSize !== undefined) {
+      this.sizeByKey.delete(key);
+      this.totalSize = Math.max(0, this.totalSize - trackedSize);
+    }
+
+    return existed;
+  }
+
+  private trackItem(key: string, dataSize: number): void {
+    this.removeTrackedKey(key);
+    this.sizeByKey.set(key, dataSize);
+    this.totalSize += dataSize;
+    this.updateLRU(key);
   }
 
   private notifySubscribers(key: string | undefined, data: string | undefined): void {
@@ -1471,9 +1630,17 @@ export class Cache {
   get(key: string): string | undefined {
     const value = localStorage.getItem(this.getItemKey(key));
     if (value !== null) {
+      if (this.sizeByKey.get(key) !== value.length) {
+        this.removeTrackedKey(key);
+        this.sizeByKey.set(key, value.length);
+        this.totalSize += value.length;
+      }
       this.updateLRU(key);
       this.saveToStorage();
       return value;
+    }
+    if (this.removeTrackedKey(key)) {
+      this.saveToStorage();
     }
     return undefined;
   }
@@ -1483,15 +1650,14 @@ export class Cache {
     const dataSize = data.length;
 
     // Check if adding this item would exceed capacity
-    let currentSize = this.getCurrentSize();
-    while (currentSize + dataSize > this.capacity && this.lruOrder.length > 0) {
+    this.removeTrackedKey(key);
+    while (this.getCurrentSize() + dataSize > this.capacity && this.lruOrder.length > 0) {
       this.evictLRU();
-      currentSize = this.getCurrentSize();
     }
 
     // Store the item
     localStorage.setItem(itemKey, data);
-    this.updateLRU(key);
+    this.trackItem(key, dataSize);
     this.saveToStorage();
 
     // Notify subscribers
@@ -1500,14 +1666,11 @@ export class Cache {
 
   remove(key: string): boolean {
     const itemKey = this.getItemKey(key);
-    const existed = localStorage.getItem(itemKey) !== null;
+    const existedInStorage = localStorage.getItem(itemKey) !== null;
+    const existed = this.removeTrackedKey(key) || existedInStorage;
 
     if (existed) {
       localStorage.removeItem(itemKey);
-      const index = this.lruOrder.indexOf(key);
-      if (index !== -1) {
-        this.lruOrder.splice(index, 1);
-      }
       this.saveToStorage();
       this.notifySubscribers(key, undefined);
     }
@@ -1516,7 +1679,22 @@ export class Cache {
   }
 
   has(key: string): boolean {
-    return localStorage.getItem(this.getItemKey(key)) !== null;
+    const value = localStorage.getItem(this.getItemKey(key));
+    if (value !== null) {
+      if (this.sizeByKey.get(key) !== value.length) {
+        this.removeTrackedKey(key);
+        this.sizeByKey.set(key, value.length);
+        this.totalSize += value.length;
+        this.updateLRU(key);
+        this.saveToStorage();
+      }
+      return true;
+    }
+
+    if (this.removeTrackedKey(key)) {
+      this.saveToStorage();
+    }
+    return false;
   }
 
   get isEmpty(): boolean {
@@ -1531,6 +1709,8 @@ export class Cache {
       localStorage.removeItem(this.getItemKey(key));
     }
     this.lruOrder = [];
+    this.sizeByKey.clear();
+    this.totalSize = 0;
     this.saveToStorage();
 
     // Notify subscribers

--- a/src/renderer/src/raycast-api/menubar-runtime-parent.tsx
+++ b/src/renderer/src/raycast-api/menubar-runtime-parent.tsx
@@ -6,6 +6,11 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { getMenuBarRuntimeDeps } from './menubar-runtime-config';
 import {
+  createMenuBarVisiblePayloadHashCache,
+  shouldSendMenuBarVisiblePayload,
+  type SerializedMenuBarVisiblePayload,
+} from './menubar-runtime-payload-cache';
+import {
   type MBItemRegistration,
   type MBRegistryAPI,
   MBRegistryContext,
@@ -31,6 +36,7 @@ export function MenuBarExtraComponent({ children, icon, title, tooltip, isLoadin
   const registryRef = useRef(new Map<string, MBItemRegistration>());
   const [registryVersion, setRegistryVersion] = useState(0);
   const pendingRef = useRef(false);
+  const visiblePayloadHashCacheRef = useRef(createMenuBarVisiblePayloadHashCache());
 
   resetMenuBarOrderCounters();
 
@@ -160,7 +166,7 @@ export function MenuBarExtraComponent({ children, icon, title, tooltip, isLoadin
 
       if (cancelled) return;
       setMenuBarActions(extId, actions as unknown as Map<string, () => void>);
-      (window as any).electron?.updateMenuBar?.({
+      const payload: SerializedMenuBarVisiblePayload = {
         extId,
         iconPath: trayIconPayload.iconPath,
         iconDataUrl: trayIconPayload.iconDataUrl,
@@ -171,7 +177,13 @@ export function MenuBarExtraComponent({ children, icon, title, tooltip, isLoadin
         title: title || '',
         tooltip: tooltip || '',
         items: dividedSerialized,
-      });
+      };
+
+      if (!shouldSendMenuBarVisiblePayload(visiblePayloadHashCacheRef.current, payload)) {
+        return;
+      }
+
+      (window as any).electron?.updateMenuBar?.(payload);
     };
 
     syncMenuBar().catch((error) => {

--- a/src/renderer/src/raycast-api/menubar-runtime-payload-cache.ts
+++ b/src/renderer/src/raycast-api/menubar-runtime-payload-cache.ts
@@ -1,0 +1,39 @@
+/**
+ * raycast-api/menubar-runtime-payload-cache.ts
+ * Purpose: Detect unchanged MenuBarExtra payloads before crossing IPC.
+ */
+
+export type SerializedMenuBarVisiblePayload = {
+  extId: string;
+  iconPath?: string;
+  iconDataUrl?: string;
+  iconEmoji?: string;
+  iconTemplate?: boolean;
+  iconBitmapScale?: number;
+  fallbackIconDataUrl: string;
+  title: string;
+  tooltip: string;
+  items: any[];
+};
+
+export type MenuBarVisiblePayloadHashCache = {
+  current: string | null;
+};
+
+export function createMenuBarVisiblePayloadHashCache(): MenuBarVisiblePayloadHashCache {
+  return { current: null };
+}
+
+export function hashMenuBarVisiblePayload(payload: SerializedMenuBarVisiblePayload): string {
+  return JSON.stringify(payload);
+}
+
+export function shouldSendMenuBarVisiblePayload(
+  cache: MenuBarVisiblePayloadHashCache,
+  payload: SerializedMenuBarVisiblePayload,
+): boolean {
+  const nextHash = hashMenuBarVisiblePayload(payload);
+  if (cache.current === nextHash) return false;
+  cache.current = nextHash;
+  return true;
+}

--- a/src/renderer/src/raycast-api/oauth/oauth-bridge.ts
+++ b/src/renderer/src/raycast-api/oauth/oauth-bridge.ts
@@ -7,10 +7,28 @@ import { getOAuthRuntimeDeps } from './runtime-config';
 
 const OAUTH_TOKEN_KEY_PREFIX = 'sc-oauth-token:';
 const OAUTH_CLIENT_ID_OVERRIDE_PREFIX = 'sc-oauth-client-id:';
-const OAUTH_CALLBACK_TIMEOUT_MS = 3 * 60 * 1000;
+export const OAUTH_CALLBACK_TIMEOUT_MS = 3 * 60 * 1000;
+export const OAUTH_CALLBACK_QUEUE_MAX_SIZE = 256;
 
-const oauthCallbackWaiters = new Set<(url: string) => void>();
-const oauthCallbackQueue: string[] = [];
+export type OAuthCallbackResult = {
+  code?: string;
+  accessToken?: string;
+  tokenType?: string;
+  provider?: string;
+  state?: string;
+  error?: string;
+  errorDescription?: string;
+};
+
+type QueuedOAuthCallback = {
+  parsed: OAuthCallbackResult;
+  receivedAt: number;
+};
+
+type OAuthCallbackWaiter = (callback: OAuthCallbackResult) => boolean;
+
+const oauthCallbackWaiters = new Set<OAuthCallbackWaiter>();
+const oauthCallbackQueue: QueuedOAuthCallback[] = [];
 let oauthCallbackBridgeInitialized = false;
 
 export function oauthTokenKey(providerId: string): string {
@@ -27,15 +45,46 @@ export function ensureOAuthCallbackBridge() {
 
   try {
     (window as any).electron?.onOAuthCallback?.((url: string) => {
-      if (!url) return;
-      oauthCallbackQueue.push(url);
-      for (const waiter of Array.from(oauthCallbackWaiters)) {
-        waiter(url);
-      }
+      enqueueOAuthCallback(url);
     });
   } catch {
     // best-effort
   }
+}
+
+function pruneOAuthCallbackQueue(now = Date.now()) {
+  const expiresBefore = now - OAUTH_CALLBACK_TIMEOUT_MS;
+
+  let writeIndex = 0;
+  for (const callback of oauthCallbackQueue) {
+    if (callback.receivedAt >= expiresBefore) {
+      oauthCallbackQueue[writeIndex++] = callback;
+    }
+  }
+  oauthCallbackQueue.length = writeIndex;
+
+  if (oauthCallbackQueue.length > OAUTH_CALLBACK_QUEUE_MAX_SIZE) {
+    oauthCallbackQueue.splice(0, oauthCallbackQueue.length - OAUTH_CALLBACK_QUEUE_MAX_SIZE);
+  }
+}
+
+function enqueueOAuthCallback(rawUrl: string) {
+  if (!rawUrl) return;
+
+  const parsed = parseOAuthCallbackUrl(rawUrl);
+  if (!parsed) return;
+
+  const now = Date.now();
+  pruneOAuthCallbackQueue(now);
+
+  let handled = false;
+  for (const waiter of Array.from(oauthCallbackWaiters)) {
+    handled = waiter(parsed) || handled;
+  }
+  if (handled) return;
+
+  oauthCallbackQueue.push({ parsed, receivedAt: now });
+  pruneOAuthCallbackQueue(now);
 }
 
 function toBase64Url(bytes: Uint8Array): string {
@@ -95,15 +144,7 @@ export async function buildAuthorizationRequest(params: {
   };
 }
 
-export function parseOAuthCallbackUrl(rawUrl: string): {
-  code?: string;
-  accessToken?: string;
-  tokenType?: string;
-  provider?: string;
-  state?: string;
-  error?: string;
-  errorDescription?: string;
-} | null {
+export function parseOAuthCallbackUrl(rawUrl: string): OAuthCallbackResult | null {
   try {
     const parsed = new URL(rawUrl);
     if (parsed.protocol !== 'supercmd:') return null;
@@ -133,20 +174,21 @@ export function parseOAuthCallbackUrl(rawUrl: string): {
 export async function waitForOAuthCallback(
   state: string,
   timeoutMs = OAUTH_CALLBACK_TIMEOUT_MS
-): Promise<{ code?: string; accessToken?: string; tokenType?: string; provider?: string; error?: string; errorDescription?: string }> {
+): Promise<OAuthCallbackResult> {
   ensureOAuthCallbackBridge();
 
-  const stateMatches = (parsed: ReturnType<typeof parseOAuthCallbackUrl>) => {
+  const stateMatches = (parsed: OAuthCallbackResult) => {
     if (!parsed) return false;
     if (!state) return true;
     return parsed.state === state;
   };
 
+  pruneOAuthCallbackQueue();
   for (let i = 0; i < oauthCallbackQueue.length; i++) {
-    const parsed = parseOAuthCallbackUrl(oauthCallbackQueue[i]);
+    const parsed = oauthCallbackQueue[i].parsed;
     if (stateMatches(parsed)) {
       oauthCallbackQueue.splice(i, 1);
-      return parsed!;
+      return parsed;
     }
   }
 
@@ -156,12 +198,12 @@ export async function waitForOAuthCallback(
       reject(new Error('OAuth authorization timed out'));
     }, timeoutMs);
 
-    const handler = (rawUrl: string) => {
-      const parsed = parseOAuthCallbackUrl(rawUrl);
-      if (!stateMatches(parsed)) return;
+    const handler: OAuthCallbackWaiter = (parsed) => {
+      if (!stateMatches(parsed)) return false;
       clearTimeout(timer);
       oauthCallbackWaiters.delete(handler);
-      resolve(parsed!);
+      resolve(parsed);
+      return true;
     };
 
     oauthCallbackWaiters.add(handler);

--- a/src/renderer/src/raycast-api/platform-runtime.ts
+++ b/src/renderer/src/raycast-api/platform-runtime.ts
@@ -144,18 +144,34 @@ export function withCache<Fn extends (...args: any[]) => Promise<any>>(
   const wrapped = (async (...args: any[]) => {
     const key = JSON.stringify(args);
     const cached = cacheStore.get(key);
+    const maxAge = options?.maxAge;
 
     if (cached) {
-      const isExpired = options?.maxAge != null && (Date.now() - cached.timestamp) > options.maxAge;
-      const isValid = options?.validate ? options.validate(cached.data) : true;
+      const isExpired = maxAge != null && (Date.now() - cached.timestamp) > maxAge;
 
-      if (!isExpired && isValid) {
-        return cached.data;
+      if (isExpired) {
+        cacheStore.delete(key);
+      } else {
+        const isValid = options?.validate ? options.validate(cached.data) : true;
+
+        if (isValid) {
+          return cached.data;
+        }
       }
     }
 
     const result = await fn(...args);
-    cacheStore.set(key, { data: result, timestamp: Date.now() });
+    const timestamp = Date.now();
+
+    if (maxAge != null) {
+      for (const [cacheKey, entry] of cacheStore) {
+        if ((timestamp - entry.timestamp) > maxAge) {
+          cacheStore.delete(cacheKey);
+        }
+      }
+    }
+
+    cacheStore.set(key, { data: result, timestamp });
     return result;
   }) as Fn & { clearCache: () => void };
 
@@ -165,4 +181,3 @@ export function withCache<Fn extends (...args: any[]) => Promise<any>>(
 
   return wrapped;
 }
-

--- a/src/renderer/src/raycast-api/storage-events.ts
+++ b/src/renderer/src/raycast-api/storage-events.ts
@@ -3,7 +3,17 @@
  * Purpose: Shared extension storage change event bridge.
  */
 
-type ExtensionCtx = { extensionName?: string };
+export type ExtensionStorageChangedDetail = {
+  extensionName: string;
+  commandName?: string;
+  commandMode?: string;
+};
+
+type ExtensionCtx = {
+  extensionName?: string;
+  commandName?: string;
+  commandMode?: string;
+};
 
 let getExtensionContextRef: () => ExtensionCtx = () => ({ extensionName: '' });
 
@@ -11,14 +21,21 @@ export function configureStorageEvents(deps: { getExtensionContext: () => Extens
   getExtensionContextRef = deps.getExtensionContext;
 }
 
-export function emitExtensionStorageChanged(): void {
+export function emitExtensionStorageChanged(origin?: Partial<ExtensionStorageChangedDetail>): void {
   try {
-    const extensionName = (getExtensionContextRef().extensionName || '').trim();
+    const context = getExtensionContextRef();
+    const extensionName = (origin?.extensionName || context.extensionName || '').trim();
     if (!extensionName) return;
+
+    const commandName = (origin?.commandName || context.commandName || '').trim();
+    const commandMode = (origin?.commandMode || context.commandMode || '').trim();
+    const detail: ExtensionStorageChangedDetail = { extensionName };
+    if (commandName) detail.commandName = commandName;
+    if (commandMode) detail.commandMode = commandMode;
 
     window.dispatchEvent(
       new CustomEvent('sc-extension-storage-changed', {
-        detail: { extensionName },
+        detail,
       })
     );
   } catch {

--- a/src/renderer/src/utils/background-no-view-runs.ts
+++ b/src/renderer/src/utils/background-no-view-runs.ts
@@ -1,0 +1,67 @@
+import type { ExtensionBundle } from '../../types/electron';
+
+export type BackgroundNoViewLaunchType = 'userInitiated' | 'background';
+
+export interface BackgroundNoViewRun {
+  runId: string;
+  bundle: ExtensionBundle;
+  launchType: BackgroundNoViewLaunchType;
+  /** When true, execution status is mirrored to the system status-bar badge. */
+  reportStatus?: boolean;
+}
+
+export interface BackgroundNoViewQueueResult {
+  runs: BackgroundNoViewRun[];
+  enqueued: boolean;
+}
+
+export function getBackgroundNoViewRunIdentity(bundle: Partial<ExtensionBundle>): string | null {
+  const extName = String(bundle.extName || bundle.extensionName || '').trim();
+  const cmdName = String(bundle.cmdName || bundle.commandName || '').trim();
+  if (!extName || !cmdName) return null;
+  return `${extName}/${cmdName}`;
+}
+
+export function enqueueBackgroundNoViewRun(
+  prev: BackgroundNoViewRun[],
+  bundle: ExtensionBundle,
+  launchType: BackgroundNoViewLaunchType = 'userInitiated',
+  reportStatus = false,
+  now: () => number = Date.now
+): BackgroundNoViewQueueResult {
+  const identity = getBackgroundNoViewRunIdentity(bundle);
+  if (
+    launchType === 'background' &&
+    identity &&
+    prev.some((run) => getBackgroundNoViewRunIdentity(run.bundle) === identity)
+  ) {
+    return { runs: prev, enqueued: false };
+  }
+
+  const runIdPrefix =
+    identity ||
+    `${String(bundle.extName || bundle.extensionName || '').trim()}/${String(
+      bundle.cmdName || bundle.commandName || ''
+    ).trim()}`;
+
+  return {
+    runs: [
+      ...prev,
+      {
+        runId: `${runIdPrefix}/${now()}`,
+        bundle,
+        launchType,
+        reportStatus,
+      },
+    ],
+    enqueued: true,
+  };
+}
+
+export function removeBackgroundNoViewRun(
+  prev: BackgroundNoViewRun[],
+  runId: string
+): BackgroundNoViewRun[] {
+  const next = prev.filter((run) => run.runId !== runId);
+  return next.length === prev.length ? prev : next;
+}

--- a/src/renderer/src/utils/extension-preferences.ts
+++ b/src/renderer/src/utils/extension-preferences.ts
@@ -41,17 +41,120 @@ function writeLocalJsonObject(key: string, value: Record<string, any>) {
   localStorage.setItem(key, JSON.stringify(value));
 }
 
-export function writeJsonObject(key: string, value: Record<string, any>) {
+export const COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS = 250;
+
+type CommandArgumentSettingsSyncMode = 'immediate' | 'debounced';
+
+type WriteJsonObjectOptions = {
+  commandArgumentSettingsSync?: CommandArgumentSettingsSyncMode;
+};
+
+type TimerHandle = number | ReturnType<typeof setTimeout>;
+
+type PendingCommandArgumentSettingsSync = {
+  extName: string;
+  cmdName: string;
+  values: Record<string, any>;
+  timer: TimerHandle | null;
+};
+
+const pendingCommandArgumentSettingsSyncs = new Map<string, PendingCommandArgumentSettingsSync>();
+
+function parseCommandArgumentsStorageKey(key: string): { extName: string; cmdName: string } | null {
+  if (!key.startsWith(CMD_ARGS_KEY_PREFIX)) return null;
+  const slug = key.slice(CMD_ARGS_KEY_PREFIX.length);
+  const slash = slug.indexOf('/');
+  if (slash <= 0) return null;
+  const extName = slug.slice(0, slash);
+  const cmdName = slug.slice(slash + 1);
+  if (!extName || !cmdName) return null;
+  return { extName, cmdName };
+}
+
+function cloneStoragePayload(value: Record<string, any>): Record<string, any> {
+  return { ...value };
+}
+
+function setCommandArgumentSettingsSyncTimer(callback: () => void): TimerHandle {
+  if (typeof window !== 'undefined' && typeof window.setTimeout === 'function') {
+    return window.setTimeout(callback, COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS);
+  }
+  return setTimeout(callback, COMMAND_ARGUMENT_SETTINGS_SYNC_DEBOUNCE_MS);
+}
+
+function clearCommandArgumentSettingsSyncTimer(timer: TimerHandle): void {
+  if (typeof window !== 'undefined' && typeof window.clearTimeout === 'function') {
+    window.clearTimeout(timer as number);
+    return;
+  }
+  clearTimeout(timer as ReturnType<typeof setTimeout>);
+}
+
+async function saveCommandArgumentsToSettings(
+  extName: string,
+  cmdName: string,
+  values: Record<string, any>
+): Promise<void> {
+  try {
+    const electron = typeof window !== 'undefined' ? window.electron : undefined;
+    await electron?.saveExtensionCommandArguments?.({ extName, cmdName, values });
+  } catch {
+    // best-effort — sync failure must not break local persistence
+  }
+}
+
+function cancelPendingCommandArgumentSettingsSync(key: string): void {
+  const pending = pendingCommandArgumentSettingsSyncs.get(key);
+  if (!pending) return;
+  if (pending.timer !== null) {
+    clearCommandArgumentSettingsSyncTimer(pending.timer);
+  }
+  pendingCommandArgumentSettingsSyncs.delete(key);
+}
+
+function queueCommandArgumentSettingsSync(key: string, value: Record<string, any>): void {
+  const parsed = parseCommandArgumentsStorageKey(key);
+  if (!parsed) return;
+  cancelPendingCommandArgumentSettingsSync(key);
+  const pending: PendingCommandArgumentSettingsSync = {
+    ...parsed,
+    values: cloneStoragePayload(value),
+    timer: null,
+  };
+  pending.timer = setCommandArgumentSettingsSyncTimer(() => {
+    void flushCommandArgumentSettingsSync(key);
+  });
+  pendingCommandArgumentSettingsSyncs.set(key, pending);
+}
+
+export async function flushCommandArgumentSettingsSync(key?: string): Promise<void> {
+  const keys = key ? [key] : Array.from(pendingCommandArgumentSettingsSyncs.keys());
+  await Promise.all(keys.map(async (pendingKey) => {
+    const pending = pendingCommandArgumentSettingsSyncs.get(pendingKey);
+    if (!pending) return;
+    if (pending.timer !== null) {
+      clearCommandArgumentSettingsSyncTimer(pending.timer);
+    }
+    pendingCommandArgumentSettingsSyncs.delete(pendingKey);
+    await saveCommandArgumentsToSettings(pending.extName, pending.cmdName, pending.values);
+  }));
+}
+
+export function writeJsonObject(key: string, value: Record<string, any>, options?: WriteJsonObjectOptions) {
   writeLocalJsonObject(key, value);
   // Mirror extension preferences and command arguments into the synced
   // settings.json so they propagate to other Macs. localStorage stays
   // the synchronous read cache; this is best-effort fire-and-forget.
   // Script-command args (sc-script-cmd-args:) and the hidden-menubar key
   // are intentionally not synced.
-  syncExtensionStorageKeyToSettings(key, value);
+  syncExtensionStorageKeyToSettings(key, value, options);
 }
 
-function syncExtensionStorageKeyToSettings(key: string, value: Record<string, any>): void {
+function syncExtensionStorageKeyToSettings(
+  key: string,
+  value: Record<string, any>,
+  options?: WriteJsonObjectOptions
+): void {
   try {
     if (key.startsWith(EXT_PREFS_KEY_PREFIX)) {
       const extName = key.slice(EXT_PREFS_KEY_PREFIX.length);
@@ -69,12 +172,14 @@ function syncExtensionStorageKeyToSettings(key: string, value: Record<string, an
       return;
     }
     if (key.startsWith(CMD_ARGS_KEY_PREFIX)) {
-      const slug = key.slice(CMD_ARGS_KEY_PREFIX.length);
-      const slash = slug.indexOf('/');
-      if (slash <= 0) return;
-      const extName = slug.slice(0, slash);
-      const cmdName = slug.slice(slash + 1);
-      void window.electron?.saveExtensionCommandArguments?.({ extName, cmdName, values: value });
+      const parsed = parseCommandArgumentsStorageKey(key);
+      if (!parsed) return;
+      if (options?.commandArgumentSettingsSync === 'debounced') {
+        queueCommandArgumentSettingsSync(key, value);
+        return;
+      }
+      cancelPendingCommandArgumentSettingsSync(key);
+      void saveCommandArgumentsToSettings(parsed.extName, parsed.cmdName, value);
       return;
     }
   } catch {

--- a/src/renderer/src/utils/extension-wrapper-cache.ts
+++ b/src/renderer/src/utils/extension-wrapper-cache.ts
@@ -1,0 +1,193 @@
+export type ExtensionWrapperFunction = (...args: any[]) => any;
+
+export const EXTENSION_WRAPPER_ARGUMENTS = [
+  'exports',
+  'require',
+  'module',
+  '__filename',
+  '__dirname',
+  'process',
+  'Buffer',
+  'global',
+  'globalThis',
+  'setImmediate',
+  'clearImmediate',
+  'setInterval',
+  'clearInterval',
+  'setTimeout',
+  'clearTimeout',
+  'requestAnimationFrame',
+  'cancelAnimationFrame',
+  'navigator',
+  '__scDynamicImport',
+] as const;
+
+const MAX_COMPILED_EXTENSION_WRAPPERS = 32;
+
+interface CacheEntry {
+  wrapper: ExtensionWrapperFunction;
+  codeLength: number;
+  codeHash: string;
+}
+
+interface CodeFingerprint {
+  code: string;
+  codeLength: number;
+  codeHash: string;
+}
+
+interface CacheStats {
+  entries: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+  wrapperCreationCount: number;
+  wrapperCreationMs: number;
+}
+
+const compiledWrapperCache = new Map<string, CacheEntry>();
+const codeFingerprintCache = new Map<string, CodeFingerprint>();
+const cacheStats: CacheStats = {
+  entries: 0,
+  hits: 0,
+  misses: 0,
+  evictions: 0,
+  wrapperCreationCount: 0,
+  wrapperCreationMs: 0,
+};
+
+function nowMs(): number {
+  return globalThis.performance?.now?.() ?? Date.now();
+}
+
+export function hashExtensionCodeForCache(code: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < code.length; i++) {
+    hash ^= code.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function createExtensionWrapperCacheKey(extensionIdentity: string, code: string): string {
+  const identity = extensionIdentity || 'unknown-extension';
+  return `${identity}\0${code.length}\0${hashExtensionCodeForCache(code)}`;
+}
+
+function createExtensionWrapperCacheKeyFromFingerprint(
+  extensionIdentity: string,
+  fingerprint: CodeFingerprint
+): string {
+  return `${extensionIdentity}\0${fingerprint.codeLength}\0${fingerprint.codeHash}`;
+}
+
+function getCodeFingerprint(extensionIdentity: string, code: string): CodeFingerprint {
+  const cached = codeFingerprintCache.get(extensionIdentity);
+  if (cached?.code === code) {
+    codeFingerprintCache.delete(extensionIdentity);
+    codeFingerprintCache.set(extensionIdentity, cached);
+    return cached;
+  }
+
+  const fingerprint = {
+    code,
+    codeLength: code.length,
+    codeHash: hashExtensionCodeForCache(code),
+  };
+  codeFingerprintCache.set(extensionIdentity, fingerprint);
+
+  if (codeFingerprintCache.size > MAX_COMPILED_EXTENSION_WRAPPERS) {
+    const oldestKey = codeFingerprintCache.keys().next().value;
+    if (oldestKey) codeFingerprintCache.delete(oldestKey);
+  }
+
+  return fingerprint;
+}
+
+export function getCompiledExtensionWrapper(options: {
+  extensionIdentity: string;
+  code: string;
+  executableCode?: string;
+}): {
+  wrapper: ExtensionWrapperFunction;
+  cacheHit: boolean;
+  cacheKey: string;
+  codeLength: number;
+  codeHash: string;
+  wrapperCreationMs: number;
+} {
+  const extensionIdentity = options.extensionIdentity || 'unknown-extension';
+  const executableCode = String(options.executableCode ?? options.code ?? '');
+  const sourceCode = executableCode;
+  const fingerprint = getCodeFingerprint(extensionIdentity, sourceCode);
+  const cacheKey = createExtensionWrapperCacheKeyFromFingerprint(extensionIdentity, fingerprint);
+  const cached = compiledWrapperCache.get(cacheKey);
+
+  if (cached) {
+    cacheStats.hits++;
+    compiledWrapperCache.delete(cacheKey);
+    compiledWrapperCache.set(cacheKey, cached);
+    return {
+      wrapper: cached.wrapper,
+      cacheHit: true,
+      cacheKey,
+      codeLength: cached.codeLength,
+      codeHash: cached.codeHash,
+      wrapperCreationMs: 0,
+    };
+  }
+
+  cacheStats.misses++;
+  const start = nowMs();
+  const wrapper = new Function(
+    ...EXTENSION_WRAPPER_ARGUMENTS,
+    executableCode
+  ) as ExtensionWrapperFunction;
+  const wrapperCreationMs = nowMs() - start;
+
+  cacheStats.wrapperCreationCount++;
+  cacheStats.wrapperCreationMs += wrapperCreationMs;
+
+  compiledWrapperCache.set(cacheKey, {
+    wrapper,
+    codeLength: fingerprint.codeLength,
+    codeHash: fingerprint.codeHash,
+  });
+
+  if (compiledWrapperCache.size > MAX_COMPILED_EXTENSION_WRAPPERS) {
+    const oldestKey = compiledWrapperCache.keys().next().value;
+    if (oldestKey) {
+      compiledWrapperCache.delete(oldestKey);
+      cacheStats.evictions++;
+    }
+  }
+
+  cacheStats.entries = compiledWrapperCache.size;
+
+  return {
+    wrapper,
+    cacheHit: false,
+    cacheKey,
+    codeLength: fingerprint.codeLength,
+    codeHash: fingerprint.codeHash,
+    wrapperCreationMs,
+  };
+}
+
+export function getCompiledExtensionWrapperCacheStats(): CacheStats {
+  return {
+    ...cacheStats,
+    entries: compiledWrapperCache.size,
+  };
+}
+
+export function clearCompiledExtensionWrapperCache(): void {
+  compiledWrapperCache.clear();
+  codeFingerprintCache.clear();
+  cacheStats.entries = 0;
+  cacheStats.hits = 0;
+  cacheStats.misses = 0;
+  cacheStats.evictions = 0;
+  cacheStats.wrapperCreationCount = 0;
+  cacheStats.wrapperCreationMs = 0;
+}


### PR DESCRIPTION
## What changed
- Consolidates runtime, background refresh, menu-bar, cache, OAuth, exec, and hook lifecycle performance fixes into one upstream PR.
- Adds bounded/incremental caches for `withCache`, Raycast `Cache`, extension wrapper compilation, extension bundle preparation, and menu-bar visible payload updates.
- Reduces long-running menu-bar churn by avoiding storage self-remounts, deduping background no-view runs, and retaining unchanged background refresh timers.
- Reduces extension runtime overhead by preferring in-process Node facades for sync `fs`/`child_process` paths and by clearing abortable promise and exec timeout handles.
- Caps unmatched OAuth callback retention and coalesces inline command argument settings writes.
- Adds focused regression and measurement scripts for the touched runtime paths.

## Why
Long-lived menu-bar sessions can accumulate work from repeated refresh timer recreation, unchanged tray payload IPC, storage-triggered remounts, background no-view overlap, cache growth, sync IPC, and callback queues. This PR combines the related fixes so the upstream review can evaluate the full lag-reduction path together.

## Compatibility impact
- Raycast-compatible behavior is preserved: external and sibling storage changes still refresh menu-bar commands, while a menu-bar command no longer remounts itself for its own local storage write.
- User-initiated no-view launches are still allowed to overlap; only background ticks for the same extension command are deduped while a run is in flight.
- Extension wrapper and bundle caches invalidate on code or file-stat changes, and install/uninstall/build paths clear runner caches.
- Legacy Raycast cache metadata is migrated or repaired, and per-key `has`/`remove` still reconcile stale localStorage entries.
- OAuth callback semantics remain state-based, with stale/unmatched callbacks pruned to avoid unbounded queue growth.

## How tested
- `node --test scripts/test-with-cache-expiry.mjs scripts/test-menubar-payload-cache.mjs scripts/test-extension-wrapper-cache.mjs scripts/test-extension-bundle-cache.mjs scripts/test-menubar-storage-remounts.mjs scripts/test-abortable-promise-hooks.mjs scripts/test-inline-args-write-coalesce.mjs scripts/test-extension-sync-facade.mjs scripts/test-raycast-cache-size-index.mjs scripts/test-background-no-view-dedupe.mjs scripts/test-background-refresh-timer-diff.mjs scripts/test-exec-command-timeout-cleanup.mjs scripts/test-oauth-callback-queue.mjs`
- `node scripts/measure-extension-wrapper-cache.mjs`
- `node scripts/measure-extension-bundle-cache.mjs`
- `pnpm exec tsc -p tsconfig.main.json --noEmit --pretty false`
- `pnpm test`
- `pnpm exec tsc -p tsconfig.renderer.json --noEmit --pretty false` fails on the standalone branch because of existing repo-wide renderer typing debt unrelated to this consolidation.

## Performance evidence
- Menu-bar equivalent visible payload registrations drop from 3 sends to 1 send.
- Background refresh unchanged updates drop from legacy `created=2 cleared=2` to keyed `created=0 retained=2 cleared=0`.
- Background no-view duplicate ticks drop from `queued=3` to `queued=1 skipped=2`.
- Extension wrapper compilation drops from 1000 wrapper creations to 1 cached wrapper creation in the focused harness.
- Raycast cache benchmark avoids full scans on set/eviction (`set-fill getItem=0`, `set-with-eviction getItem=0`).
- Extension sync facade Node path reports 0 sync IPC calls for real path ops in the focused harness.

## Stack validation
Applied this consolidation over `codex/consolidate-validation-checks` (`fix(validation): restore project checks`) and validated the combined stack:
- `pnpm exec tsc -p tsconfig.renderer.json --noEmit --pretty false`
- `pnpm test`

## Replaces
- #482
- #486
- #490
- #498
- #499
- #500
- #501
- #509
- #510
- #512
- #514
- #522
- #524
