### PR TITLE
perf(ai): cache local model status probes

### DIFF
--- a/scripts/test-local-model-status-probe-cache.mjs
+++ b/scripts/test-local-model-status-probe-cache.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { importTs } from './lib/ts-import.mjs';
+
+const {
+  createLocalAsrHelperStatusProbeCache,
+  isCacheableLocalAsrHelperStatus,
+} = await importTs(path.resolve('src/main/local-model-status-probe.ts'));
+
+function makeStatus(overrides = {}) {
+  return {
+    state: 'downloaded',
+    modelName: 'parakeet-tdt-0.6b-v3',
+    path: '/models/parakeet',
+    progress: 1,
+    ...overrides,
+  };
+}
+
+function spinForMs(durationMs) {
+  const end = performance.now() + durationMs;
+  while (performance.now() < end) {}
+}
+
+test('local ASR helper status cache reuses stable statuses within the TTL', () => {
+  let now = 1_000;
+  let probeCalls = 0;
+  const cache = createLocalAsrHelperStatusProbeCache({
+    ttlMs: 5_000,
+    now: () => now,
+    readStatus() {
+      probeCalls += 1;
+      return makeStatus({ path: `/models/parakeet-${probeCalls}` });
+    },
+  });
+
+  assert.equal(cache.getStatus().path, '/models/parakeet-1');
+  assert.equal(cache.getStatus().path, '/models/parakeet-1');
+  assert.equal(probeCalls, 1);
+
+  now += 5_001;
+  assert.equal(cache.getStatus().path, '/models/parakeet-2');
+  assert.equal(probeCalls, 2);
+});
+
+test('local ASR helper status cache bypasses cached stable status when force refreshing', () => {
+  let probeCalls = 0;
+  const cache = createLocalAsrHelperStatusProbeCache({
+    ttlMs: 5_000,
+    readStatus() {
+      probeCalls += 1;
+      return makeStatus({ path: `/models/qwen3-${probeCalls}` });
+    },
+  });
+
+  assert.equal(cache.getStatus().path, '/models/qwen3-1');
+  assert.equal(cache.getStatus({ forceRefresh: true }).path, '/models/qwen3-2');
+  assert.equal(cache.getStatus().path, '/models/qwen3-2');
+  assert.equal(probeCalls, 2);
+});
+
+test('local ASR helper status cache does not retain transient statuses', () => {
+  const statuses = [
+    makeStatus({ state: 'downloading', path: '', progress: 0.5 }),
+    makeStatus({ state: 'error', path: '', progress: 0, error: 'failed' }),
+    makeStatus({ state: 'not-downloaded', path: '', progress: 0 }),
+  ];
+  let probeCalls = 0;
+  const cache = createLocalAsrHelperStatusProbeCache({
+    ttlMs: 5_000,
+    readStatus() {
+      const status = statuses[Math.min(probeCalls, statuses.length - 1)];
+      probeCalls += 1;
+      return status;
+    },
+  });
+
+  assert.equal(cache.getStatus().state, 'downloading');
+  assert.equal(cache.getStatus().state, 'error');
+  assert.equal(cache.getStatus().state, 'not-downloaded');
+  assert.equal(cache.getStatus().state, 'not-downloaded');
+  assert.equal(probeCalls, 3);
+});
+
+test('local ASR helper status cache can remember a fresh post-download status', () => {
+  let probeCalls = 0;
+  const cache = createLocalAsrHelperStatusProbeCache({
+    ttlMs: 5_000,
+    readStatus() {
+      probeCalls += 1;
+      return makeStatus({ state: 'not-downloaded', path: '', progress: 0 });
+    },
+  });
+
+  assert.equal(cache.getStatus().state, 'not-downloaded');
+  cache.rememberStatus(makeStatus({ state: 'downloaded', path: '/models/fresh', progress: 1 }));
+
+  const status = cache.getStatus();
+  assert.equal(status.state, 'downloaded');
+  assert.equal(status.path, '/models/fresh');
+  assert.equal(probeCalls, 1);
+});
+
+test('local ASR helper status cache measurement avoids repeated fake sync probes', () => {
+  const iterations = 60;
+  const fakeProbeMs = 1.75;
+  let legacyProbeCalls = 0;
+  const legacyStart = performance.now();
+  for (let index = 0; index < iterations; index += 1) {
+    legacyProbeCalls += 1;
+    spinForMs(fakeProbeMs);
+  }
+  const legacyMs = performance.now() - legacyStart;
+
+  let cachedProbeCalls = 0;
+  const cache = createLocalAsrHelperStatusProbeCache({
+    ttlMs: 5_000,
+    readStatus() {
+      cachedProbeCalls += 1;
+      spinForMs(fakeProbeMs);
+      return makeStatus();
+    },
+  });
+
+  const cachedStart = performance.now();
+  for (let index = 0; index < iterations; index += 1) {
+    cache.getStatus();
+  }
+  const cachedMs = performance.now() - cachedStart;
+
+  console.log(
+    `[local-model-status probe-cache] iterations=${iterations} ` +
+    `legacyCalls=${legacyProbeCalls} legacyMs=${legacyMs.toFixed(3)} ` +
+    `cachedCalls=${cachedProbeCalls} cachedMs=${cachedMs.toFixed(3)} ` +
+    `avoidedCalls=${legacyProbeCalls - cachedProbeCalls}`
+  );
+
+  assert.equal(legacyProbeCalls, iterations);
+  assert.equal(cachedProbeCalls, 1);
+  assert.equal(isCacheableLocalAsrHelperStatus(makeStatus()), true);
+  assert.ok(cachedMs < legacyMs / 4);
+});

--- a/src/main/local-model-status-probe.ts
+++ b/src/main/local-model-status-probe.ts
@@ -1,0 +1,60 @@
+export const LOCAL_ASR_HELPER_STATUS_CACHE_TTL_MS = 5_000;
+
+export type LocalAsrHelperStatus = {
+  state: string;
+};
+
+export type LocalAsrHelperStatusProbeOptions = {
+  forceRefresh?: boolean;
+};
+
+export type LocalAsrHelperStatusProbeCache<TStatus extends LocalAsrHelperStatus> = {
+  getStatus: (options?: LocalAsrHelperStatusProbeOptions) => TStatus;
+  rememberStatus: (status: TStatus) => TStatus;
+  clear: () => void;
+};
+
+type CreateLocalAsrHelperStatusProbeCacheOptions<TStatus extends LocalAsrHelperStatus> = {
+  readStatus: () => TStatus;
+  ttlMs?: number;
+  now?: () => number;
+};
+
+export function isCacheableLocalAsrHelperStatus(status: LocalAsrHelperStatus | null | undefined): boolean {
+  return status?.state === 'downloaded' || status?.state === 'not-downloaded';
+}
+
+export function createLocalAsrHelperStatusProbeCache<TStatus extends LocalAsrHelperStatus>({
+  readStatus,
+  ttlMs = LOCAL_ASR_HELPER_STATUS_CACHE_TTL_MS,
+  now = Date.now,
+}: CreateLocalAsrHelperStatusProbeCacheOptions<TStatus>): LocalAsrHelperStatusProbeCache<TStatus> {
+  let cachedStatus: TStatus | null = null;
+  let cacheExpiresAt = 0;
+
+  function rememberStatus(status: TStatus): TStatus {
+    if (isCacheableLocalAsrHelperStatus(status)) {
+      cachedStatus = status;
+      cacheExpiresAt = now() + ttlMs;
+    } else {
+      cachedStatus = null;
+      cacheExpiresAt = 0;
+    }
+    return status;
+  }
+
+  return {
+    getStatus(options = {}) {
+      const currentTime = now();
+      if (!options.forceRefresh && cachedStatus && currentTime < cacheExpiresAt) {
+        return cachedStatus;
+      }
+      return rememberStatus(readStatus());
+    },
+    rememberStatus,
+    clear() {
+      cachedStatus = null;
+      cacheExpiresAt = 0;
+    },
+  };
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { fork, execFileSync, type ChildProcess } from 'child_process';
 import { getNativeBinaryPath, resolvePackagedUnpackedPath } from './native-binary';
+import { createLocalAsrHelperStatusProbeCache } from './local-model-status-probe';
 import { getAvailableCommands, executeCommand, invalidateCache, initCommandsCache, getInflightDiscovery, refreshCommandsNow } from './commands';
 import {
   loadSettings,
@@ -255,6 +256,7 @@ type ParakeetModelStatus = {
 };
 let parakeetModelStatus: ParakeetModelStatus | null = null;
 let parakeetModelEnsurePromise: Promise<string> | null = null;
+let parakeetModelStatusProbeCache: ReturnType<typeof createLocalAsrHelperStatusProbeCache<ParakeetModelStatus>> | null = null;
 
 // Persistent serve-mode process for fast transcription (models stay loaded in memory)
 let parakeetServerProcess: any = null; // ChildProcess
@@ -393,15 +395,7 @@ function getParakeetTranscriberBinaryPath(): string {
   return getNativeBinaryPath('parakeet-transcriber');
 }
 
-function getParakeetModelStatus(): ParakeetModelStatus {
-  if (parakeetModelStatus?.state === 'downloading') {
-    return { ...parakeetModelStatus };
-  }
-  if (parakeetModelStatus?.state === 'error') {
-    return { ...parakeetModelStatus };
-  }
-
-  // Ask the binary for the real status
+function readParakeetModelStatusFromHelper(): ParakeetModelStatus {
   const binaryPath = getParakeetTranscriberBinaryPath();
   try {
     if (!fs.existsSync(binaryPath)) {
@@ -446,9 +440,36 @@ function getParakeetModelStatus(): ParakeetModelStatus {
   return parakeetModelStatus;
 }
 
+function getParakeetModelStatusProbeCache(): ReturnType<typeof createLocalAsrHelperStatusProbeCache<ParakeetModelStatus>> {
+  if (!parakeetModelStatusProbeCache) {
+    parakeetModelStatusProbeCache = createLocalAsrHelperStatusProbeCache<ParakeetModelStatus>({
+      readStatus: readParakeetModelStatusFromHelper,
+    });
+  }
+  return parakeetModelStatusProbeCache;
+}
+
+function rememberParakeetModelStatus(status: ParakeetModelStatus): ParakeetModelStatus {
+  parakeetModelStatus = status;
+  getParakeetModelStatusProbeCache().rememberStatus(status);
+  return status;
+}
+
+function getParakeetModelStatus(options: { forceRefresh?: boolean } = {}): ParakeetModelStatus {
+  if (parakeetModelStatus?.state === 'downloading') {
+    return { ...parakeetModelStatus };
+  }
+  if (parakeetModelStatus?.state === 'error') {
+    return { ...parakeetModelStatus };
+  }
+
+  parakeetModelStatus = getParakeetModelStatusProbeCache().getStatus(options);
+  return parakeetModelStatus;
+}
+
 async function ensureParakeetModelDownloaded(): Promise<string> {
   // Check if already downloaded
-  const status = getParakeetModelStatus();
+  const status = getParakeetModelStatus({ forceRefresh: true });
   if (status.state === 'downloaded' && status.path) {
     return status.path;
   }
@@ -522,12 +543,12 @@ async function ensureParakeetModelDownloaded(): Promise<string> {
         });
       });
 
-      parakeetModelStatus = {
+      rememberParakeetModelStatus({
         state: 'downloaded',
         modelName: 'parakeet-tdt-0.6b-v3',
         path: modelPath,
         progress: 1,
-      };
+      });
       console.log(`[Parakeet] Models ready at ${modelPath}`);
       return modelPath;
     } catch (error) {
@@ -573,7 +594,7 @@ async function transcribeAudioWithParakeet(opts: {
   language?: string;
   mimeType?: string;
 }): Promise<string> {
-  const status = getParakeetModelStatus();
+  const status = getParakeetModelStatus({ forceRefresh: true });
   if (status.state === 'downloading') {
     throw new Error('Parakeet models are still downloading. Finish setup from onboarding or Settings -> AI -> SuperCmd Whisper.');
   }
@@ -611,6 +632,7 @@ type Qwen3ModelStatus = {
 };
 let qwen3ModelStatus: Qwen3ModelStatus | null = null;
 let qwen3ModelEnsurePromise: Promise<string> | null = null;
+let qwen3ModelStatusProbeCache: ReturnType<typeof createLocalAsrHelperStatusProbeCache<Qwen3ModelStatus>> | null = null;
 
 let qwen3ServerProcess: any = null;
 let qwen3ServerReady = false;
@@ -743,10 +765,7 @@ function sendQwen3Request(request: Record<string, any>): Promise<any> {
   });
 }
 
-function getQwen3ModelStatus(): Qwen3ModelStatus {
-  if (qwen3ModelStatus?.state === 'downloading') return { ...qwen3ModelStatus };
-  if (qwen3ModelStatus?.state === 'error') return { ...qwen3ModelStatus };
-
+function readQwen3ModelStatusFromHelper(): Qwen3ModelStatus {
   const binaryPath = getParakeetTranscriberBinaryPath();
   try {
     if (!fs.existsSync(binaryPath)) {
@@ -771,8 +790,31 @@ function getQwen3ModelStatus(): Qwen3ModelStatus {
   return qwen3ModelStatus;
 }
 
+function getQwen3ModelStatusProbeCache(): ReturnType<typeof createLocalAsrHelperStatusProbeCache<Qwen3ModelStatus>> {
+  if (!qwen3ModelStatusProbeCache) {
+    qwen3ModelStatusProbeCache = createLocalAsrHelperStatusProbeCache<Qwen3ModelStatus>({
+      readStatus: readQwen3ModelStatusFromHelper,
+    });
+  }
+  return qwen3ModelStatusProbeCache;
+}
+
+function rememberQwen3ModelStatus(status: Qwen3ModelStatus): Qwen3ModelStatus {
+  qwen3ModelStatus = status;
+  getQwen3ModelStatusProbeCache().rememberStatus(status);
+  return status;
+}
+
+function getQwen3ModelStatus(options: { forceRefresh?: boolean } = {}): Qwen3ModelStatus {
+  if (qwen3ModelStatus?.state === 'downloading') return { ...qwen3ModelStatus };
+  if (qwen3ModelStatus?.state === 'error') return { ...qwen3ModelStatus };
+
+  qwen3ModelStatus = getQwen3ModelStatusProbeCache().getStatus(options);
+  return qwen3ModelStatus;
+}
+
 async function ensureQwen3ModelDownloaded(): Promise<string> {
-  const status = getQwen3ModelStatus();
+  const status = getQwen3ModelStatus({ forceRefresh: true });
   if (status.state === 'downloaded' && status.path) return status.path;
   if (qwen3ModelEnsurePromise) return await qwen3ModelEnsurePromise;
 
@@ -816,7 +858,7 @@ async function ensureQwen3ModelDownloaded(): Promise<string> {
         });
       });
 
-      qwen3ModelStatus = { state: 'downloaded', modelName: 'qwen3-asr-0.6b', path: modelPath, progress: 1 };
+      rememberQwen3ModelStatus({ state: 'downloaded', modelName: 'qwen3-asr-0.6b', path: modelPath, progress: 1 });
       console.log(`[Qwen3] Models ready at ${modelPath}`);
       return modelPath;
     } catch (error) {
@@ -835,7 +877,7 @@ async function transcribeAudioWithQwen3(opts: {
   language?: string;
   mimeType?: string;
 }): Promise<string> {
-  const status = getQwen3ModelStatus();
+  const status = getQwen3ModelStatus({ forceRefresh: true });
   if (status.state === 'downloading') throw new Error('Qwen3 models are still downloading.');
   if (status.state !== 'downloaded') throw new Error('Qwen3 models have not been downloaded yet. Download them from Settings -> AI -> SuperCmd Whisper.');
 
@@ -17778,11 +17820,11 @@ if let tiff = image?.tiffRepresentation {
 
   ipcMain.handle('parakeet-download-model', async () => {
     await ensureParakeetModelDownloaded();
-    return getParakeetModelStatus();
+    return getParakeetModelStatus({ forceRefresh: true });
   });
 
   ipcMain.handle('parakeet-warmup', async () => {
-    const status = getParakeetModelStatus();
+    const status = getParakeetModelStatus({ forceRefresh: true });
     if (status.state !== 'downloaded') {
       return { ready: false, error: 'Models not downloaded' };
     }
@@ -17803,11 +17845,11 @@ if let tiff = image?.tiffRepresentation {
 
   ipcMain.handle('qwen3-download-model', async () => {
     await ensureQwen3ModelDownloaded();
-    return getQwen3ModelStatus();
+    return getQwen3ModelStatus({ forceRefresh: true });
   });
 
   ipcMain.handle('qwen3-warmup', async () => {
-    const status = getQwen3ModelStatus();
+    const status = getQwen3ModelStatus({ forceRefresh: true });
     if (status.state !== 'downloaded') {
       return { ready: false, error: 'Models not downloaded' };
     }


### PR DESCRIPTION
## What changed

- Cache stable Parakeet and Qwen3 local ASR helper status probe results for a short TTL so the AI Settings poll loop does not launch both helpers every second.
- Keep `downloading` and `error` behavior compatible, and force-refresh download, warmup, and transcription action paths so explicit flows still read fresh helper state.
- Add focused cache tests with an injected fake slow probe.

## Why

- The AI Settings poll loop was launching both local ASR helpers every second even when helper status was stable.
- Audit baseline: 60 synchronous trivial helper launches averaged 1.763 ms each, so the two helper polls cost about 3.526 ms of main-process blocking per second when fast.

## Compatibility impact

- `downloading` and `error` behavior remains compatible.
- Download, warmup, and transcription action paths force-refresh helper state so explicit flows still read fresh helper state.
- Draft until the integration stack lands. This clean PR branch contains only the status-probe caching fix, and depends on PRs #530-#535 plus `codex/perf-consolidated-integration-stack` for the broader wave-2 integration context.

## How tested

- `node scripts/test-local-model-status-probe-cache.mjs`
- `./node_modules/.bin/tsc -p tsconfig.main.json`
- On the integration worker branch: `node scripts/test-ai-model-status-polling.mjs`
- On the integration worker branch: `pnpm run build:main`
- LSP diagnostics for touched TypeScript files passed on the integration worker branch; `src/main/local-model-status-probe.ts` is clean on this branch. `origin/main` currently reports unrelated main-process LSP diagnostics for missing/import-mismatched files outside this change.

## Performance evidence

- New fake-probe test on the clean PR branch: `iterations=60 legacyCalls=60 legacyMs=105.099 cachedCalls=1 cachedMs=1.813 avoidedCalls=59`.
- Same test on the integration worker branch before the clean cherry-pick: `iterations=60 legacyCalls=60 legacyMs=105.153 cachedCalls=1 cachedMs=1.816 avoidedCalls=59`.

## Stack validation

- This clean PR branch contains only the status-probe caching fix.
- Depends on PRs #530-#535 plus `codex/perf-consolidated-integration-stack` for the broader wave-2 integration context.