### PR TITLE
perf(menubar): cache native images

### DIFF
--- a/scripts/test-menubar-native-image-cache.mjs
+++ b/scripts/test-menubar-native-image-cache.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  createCachedMenuBarNativeImage,
+  createMenuBarNativeImageCache,
+} = await import(pathToFileURL(path.join(root, 'src/main/menubar-native-image-cache.ts')).href);
+
+function makeCounters() {
+  return {
+    createFromBuffer: 0,
+    createFromDataURL: 0,
+    createFromPath: 0,
+    readFileSync: 0,
+    resize: 0,
+    setTemplateImage: 0,
+    statSync: 0,
+  };
+}
+
+class MockNativeImage {
+  constructor(counters, source, width = 32, height = 32, empty = false) {
+    this.counters = counters;
+    this.source = source;
+    this.width = width;
+    this.height = height;
+    this.empty = empty;
+    this.template = undefined;
+  }
+
+  isEmpty() {
+    return this.empty;
+  }
+
+  getSize() {
+    return { width: this.width, height: this.height };
+  }
+
+  resize(options) {
+    this.counters.resize += 1;
+    const resized = new MockNativeImage(
+      this.counters,
+      `${this.source}:resized:${options.width}x${options.height}`,
+      options.width,
+      options.height,
+      this.empty,
+    );
+    resized.resizeQuality = options.quality;
+    return resized;
+  }
+
+  setTemplateImage(isTemplate) {
+    this.counters.setTemplateImage += 1;
+    this.template = isTemplate;
+  }
+}
+
+function makeNativeImage(counters) {
+  return {
+    createFromBuffer(_buffer, options = {}) {
+      counters.createFromBuffer += 1;
+      const logicalSize = options.scaleFactor && options.scaleFactor > 1 ? 18 : 36;
+      return new MockNativeImage(counters, `buffer:${options.scaleFactor || 1}`, logicalSize, logicalSize);
+    },
+    createFromDataURL(dataUrl) {
+      counters.createFromDataURL += 1;
+      const empty = dataUrl.includes('empty-native-path-svg');
+      return new MockNativeImage(counters, `data:${dataUrl.slice(0, 40)}`, 32, 32, empty);
+    },
+    createFromPath(pathValue) {
+      counters.createFromPath += 1;
+      const empty = /\.svg$/i.test(pathValue);
+      return new MockNativeImage(counters, `path:${pathValue}`, 32, 32, empty);
+    },
+  };
+}
+
+function makeFs(counters, files) {
+  return {
+    statSync(pathValue) {
+      counters.statSync += 1;
+      const file = files.get(pathValue);
+      if (!file) throw new Error(`ENOENT: ${pathValue}`);
+      return {
+        size: file.size,
+        mtimeMs: file.mtimeMs,
+        isFile: () => true,
+      };
+    },
+    readFileSync(pathValue, encoding) {
+      assert.equal(encoding, 'utf8');
+      counters.readFileSync += 1;
+      const file = files.get(pathValue);
+      if (!file) throw new Error(`ENOENT: ${pathValue}`);
+      return file.body;
+    },
+  };
+}
+
+function pngDataUrl(name) {
+  return `data:image/png;base64,${Buffer.from(`png:${name}`).toString('base64')}`;
+}
+
+function svgDataUrl(name) {
+  return `data:image/svg+xml;base64,${Buffer.from(`<svg>${name}</svg>`).toString('base64')}`;
+}
+
+function createIconResolver({ counters, files, sharedCache }) {
+  const nativeImage = makeNativeImage(counters);
+  const fs = makeFs(counters, files);
+
+  return (icon) => createCachedMenuBarNativeImage({
+    cache: sharedCache || createMenuBarNativeImageCache(512),
+    nativeImage,
+    fs,
+    pathValue: icon.pathValue,
+    dataUrlValue: icon.dataUrlValue,
+    bitmapScale: icon.bitmapScale,
+    size: icon.size,
+    template: icon.template,
+    resizeQuality: icon.resizeQuality,
+  });
+}
+
+function makeMetricFiles() {
+  const files = new Map();
+  for (let i = 0; i < 8; i += 1) {
+    files.set(`/icons/path-${i}.png`, { size: 100 + i, mtimeMs: 1000 + i, body: `png-${i}` });
+  }
+  for (let i = 0; i < 4; i += 1) {
+    files.set(`/icons/submenu-${i}.svg`, {
+      size: 200 + i,
+      mtimeMs: 2000 + i,
+      body: `<svg>empty-native-path-svg-${i}</svg>`,
+    });
+  }
+  return files;
+}
+
+function makeMetricIcons() {
+  const icons = [
+    {
+      dataUrlValue: pngDataUrl('tray'),
+      bitmapScale: 2,
+      size: 18,
+      template: true,
+      resizeQuality: 'best',
+    },
+  ];
+
+  for (let i = 0; i < 16; i += 1) {
+    icons.push({ dataUrlValue: svgDataUrl(`item-${i}`), size: 16, template: true });
+  }
+  for (let i = 0; i < 8; i += 1) {
+    icons.push({ dataUrlValue: pngDataUrl(`item-${i}`), bitmapScale: 2, size: 16, template: false });
+  }
+  for (let i = 0; i < 8; i += 1) {
+    icons.push({ pathValue: `/icons/path-${i}.png`, size: 16, template: false });
+  }
+  for (let i = 0; i < 4; i += 1) {
+    icons.push({ pathValue: `/icons/submenu-${i}.svg`, size: 16, template: false });
+  }
+  return icons;
+}
+
+function workCount(counters) {
+  return counters.createFromBuffer +
+    counters.createFromDataURL +
+    counters.createFromPath +
+    counters.readFileSync +
+    counters.resize;
+}
+
+function runRepeatedPayloadMetric({ updates, useSharedCache }) {
+  const counters = makeCounters();
+  const files = makeMetricFiles();
+  const sharedCache = useSharedCache ? createMenuBarNativeImageCache(512) : null;
+  const resolveIcon = createIconResolver({ counters, files, sharedCache });
+  const icons = makeMetricIcons();
+
+  for (let update = 0; update < updates; update += 1) {
+    for (const icon of icons) {
+      const image = resolveIcon(icon);
+      assert.ok(image, 'metric icon should resolve');
+    }
+  }
+
+  return counters;
+}
+
+test('MenuBarExtra native image cache', async (t) => {
+  await t.test('reuses data URL decode and resize work for repeated menu item icons', () => {
+    const counters = makeCounters();
+    const resolveIcon = createIconResolver({
+      counters,
+      files: new Map(),
+      sharedCache: createMenuBarNativeImageCache(),
+    });
+
+    const first = resolveIcon({ dataUrlValue: svgDataUrl('shared'), size: 16, template: true });
+    const second = resolveIcon({ dataUrlValue: svgDataUrl('shared'), size: 16, template: true });
+
+    assert.equal(first, second, 'same source, size, scale, and template state should reuse the image');
+    assert.equal(counters.createFromDataURL, 1, 'data URL is decoded once');
+    assert.equal(counters.resize, 1, 'image is resized once');
+    assert.equal(counters.setTemplateImage, 1, 'template state is applied once to the cached image');
+  });
+
+  await t.test('keeps template image states isolated in the cache key', () => {
+    const counters = makeCounters();
+    const resolveIcon = createIconResolver({
+      counters,
+      files: new Map(),
+      sharedCache: createMenuBarNativeImageCache(),
+    });
+    const dataUrlValue = svgDataUrl('template-split');
+
+    const templated = resolveIcon({ dataUrlValue, size: 16, template: true });
+    const original = resolveIcon({ dataUrlValue, size: 16, template: false });
+
+    assert.notEqual(templated, original, 'template and non-template requests must not share a NativeImage object');
+    assert.equal(templated.template, true);
+    assert.equal(original.template, false);
+    assert.equal(counters.createFromDataURL, 2, 'different template states decode separately');
+  });
+
+  await t.test('preserves retina data URL handling without repeat buffer decode', () => {
+    const counters = makeCounters();
+    const resolveIcon = createIconResolver({
+      counters,
+      files: new Map(),
+      sharedCache: createMenuBarNativeImageCache(),
+    });
+    const dataUrlValue = pngDataUrl('retina-tray');
+
+    const first = resolveIcon({ dataUrlValue, bitmapScale: 2, size: 18, template: true, resizeQuality: 'best' });
+    const second = resolveIcon({ dataUrlValue, bitmapScale: 2, size: 18, template: true, resizeQuality: 'best' });
+
+    assert.equal(first, second);
+    assert.equal(counters.createFromBuffer, 1, 'retina PNG data URL uses createFromBuffer once');
+    assert.equal(counters.createFromDataURL, 0, 'successful buffer decode does not fall back to createFromDataURL');
+    assert.equal(counters.resize, 0, 'logical-size retina reps are not resized');
+  });
+
+  await t.test('reuses stable path icons and refreshes when file identity changes', () => {
+    const counters = makeCounters();
+    const files = new Map([
+      ['/icons/stable.png', { size: 64, mtimeMs: 10, body: 'png' }],
+    ]);
+    const resolveIcon = createIconResolver({
+      counters,
+      files,
+      sharedCache: createMenuBarNativeImageCache(),
+    });
+
+    const first = resolveIcon({ pathValue: '/icons/stable.png', size: 16, template: false });
+    const second = resolveIcon({ pathValue: '/icons/stable.png', size: 16, template: false });
+    files.set('/icons/stable.png', { size: 65, mtimeMs: 11, body: 'png-new' });
+    const third = resolveIcon({ pathValue: '/icons/stable.png', size: 16, template: false });
+
+    assert.equal(first, second, 'stable file identity should reuse decoded image');
+    assert.notEqual(first, third, 'changed file identity should refresh decoded image');
+    assert.equal(counters.createFromPath, 2);
+    assert.equal(counters.resize, 2);
+    assert.equal(counters.statSync, 3, 'path identity is checked each call so changed assets refresh');
+  });
+
+  await t.test('caches SVG fallback reads for stable path icons', () => {
+    const counters = makeCounters();
+    const files = new Map([
+      ['/icons/vector.svg', { size: 42, mtimeMs: 100, body: '<svg>empty-native-path-svg</svg>' }],
+    ]);
+    const resolveIcon = createIconResolver({
+      counters,
+      files,
+      sharedCache: createMenuBarNativeImageCache(),
+    });
+
+    const first = resolveIcon({ pathValue: '/icons/vector.svg', size: 16, template: false });
+    const second = resolveIcon({ pathValue: '/icons/vector.svg', size: 16, template: false });
+
+    assert.equal(first, second);
+    assert.equal(counters.createFromPath, 1, 'native SVG path decode attempted once');
+    assert.equal(counters.readFileSync, 1, 'SVG fallback body is read once');
+    assert.equal(counters.createFromDataURL, 1, 'SVG fallback data URL is decoded once');
+  });
+
+  await t.test('measures repeated accepted payload decode and resize savings', () => {
+    const updates = 20;
+    const before = runRepeatedPayloadMetric({ updates, useSharedCache: false });
+    const after = runRepeatedPayloadMetric({ updates, useSharedCache: true });
+    const beforeWork = workCount(before);
+    const afterWork = workCount(after);
+
+    t.diagnostic(
+      `repeated payload (${updates} updates, 1 tray icon, 36 item/submenu icons): ` +
+      `before=${beforeWork} native decode/read/resize operations, after=${afterWork}`,
+    );
+    t.diagnostic(`before=${JSON.stringify(before)} after=${JSON.stringify(after)}`);
+
+    assert.equal(beforeWork, 1620);
+    assert.equal(afterWork, 81);
+    assert.ok(afterWork < beforeWork / 10, 'cached path should eliminate repeated native image work');
+  });
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -218,6 +218,10 @@ import {
   importRaycastConfigFromFile,
   previewRaycastConfigImport,
 } from './raycast-config-import';
+import {
+  createCachedMenuBarNativeImage,
+  createMenuBarNativeImageCache,
+} from './menubar-native-image-cache';
 
 import { initialize as initAptabase, trackEvent } from "@aptabase/electron/main";
 
@@ -7369,6 +7373,7 @@ app.on('open-url', (event: any, url: string) => {
 // ─── Menu Bar (Tray) Management ─────────────────────────────────────
 
 const menuBarTrays = new Map<string, InstanceType<typeof Tray>>();
+const menuBarNativeImageCache = createMenuBarNativeImageCache();
 let appTray: InstanceType<typeof Tray> | null = null;
 
 function buildDefaultMacTrayTemplateIcon(): any | null {
@@ -19090,93 +19095,44 @@ if let tiff = image?.tiffRepresentation {
 
     let tray = menuBarTrays.get(extId);
 
-    const createNativeImageFromMenuIcon = (
-      payload: { pathValue?: string; dataUrlValue?: string; bitmapScale?: number },
-      size: number,
-    ) => {
-      try {
-        const fs = require('fs');
-        let image: any;
-        const dataUrlValue = String(payload?.dataUrlValue || '').trim();
-        const pathValue = String(payload?.pathValue || '').trim();
-        const requestedScale = Number(payload?.bitmapScale);
-        const bitmapScale = Number.isFinite(requestedScale) && requestedScale >= 1 ? requestedScale : 1;
-
-        if (dataUrlValue.startsWith('data:')) {
-          // For raster PNG data URLs that the renderer pre-rasterized at higher
-          // DPR (bitmapScale > 1), reconstruct via createFromBuffer with the
-          // matching scaleFactor so the Tray treats it as a retina rep instead
-          // of stretching a low-res bitmap.
-          const isRasterPng = dataUrlValue.startsWith('data:image/png');
-          if (isRasterPng && bitmapScale > 1) {
-            const commaIdx = dataUrlValue.indexOf(',');
-            const base64Body = commaIdx >= 0 ? dataUrlValue.slice(commaIdx + 1) : '';
-            const buf = base64Body ? Buffer.from(base64Body, 'base64') : null;
-            if (buf && buf.length > 0) {
-              image = nativeImage.createFromBuffer(buf, { scaleFactor: bitmapScale });
-            }
-          }
-          if (!image || image.isEmpty?.()) {
-            image = nativeImage.createFromDataURL(dataUrlValue);
-          }
-        } else {
-          if (!pathValue || !fs.existsSync(pathValue)) return null;
-          image = nativeImage.createFromPath(pathValue);
-          if ((!image || image.isEmpty()) && /\.svg$/i.test(pathValue)) {
-            const svg = fs.readFileSync(pathValue, 'utf8');
-            const svgDataUrl = `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
-            image = nativeImage.createFromDataURL(svgDataUrl);
-          }
-        }
-        if (!image || image.isEmpty()) return null;
-
-        // When the source already carries a retina backing (scaleFactor > 1),
-        // resizing to logical px would discard the @2x rep — keep it intact.
-        const currentSize = image.getSize?.() || { width: 0, height: 0 };
-        if (bitmapScale > 1 && currentSize.width === size && currentSize.height === size) {
-          return image;
-        }
-        return image.resize({ width: size, height: size, quality: 'best' });
-      } catch {
-        return null;
-      }
-    };
-
     let lastResolvedTrayIconOk = false;
     const hasEmojiIcon = typeof iconEmoji === 'string' && iconEmoji.trim().length > 0;
+    const isPrimaryGeneratedDataUrl = typeof iconDataUrl === 'string' && iconDataUrl.startsWith('data:');
+    const isPrimarySvgPath = /\.svg$/i.test(iconPath || '');
+    const primaryTemplate =
+      typeof iconTemplate === 'boolean'
+        ? iconTemplate
+        : (isPrimaryGeneratedDataUrl ? true : !isPrimarySvgPath);
     const resolveTrayIcon = () => {
-      const primaryImg = createNativeImageFromMenuIcon(
-        { pathValue: iconPath, dataUrlValue: iconDataUrl, bitmapScale: iconBitmapScale },
-        18,
-      );
-      const usingPrimary = Boolean(primaryImg);
+      const primaryImg = createCachedMenuBarNativeImage({
+        cache: menuBarNativeImageCache,
+        nativeImage,
+        fs,
+        pathValue: iconPath,
+        dataUrlValue: iconDataUrl,
+        bitmapScale: iconBitmapScale,
+        size: 18,
+        template: primaryTemplate,
+        resizeQuality: 'best',
+      });
       // When the extension supplies an emoji as its tray icon (e.g. "🎉"), we render that
       // emoji as the tray title and leave the tray image empty. Falling back to the
       // extension's package icon here would produce two visuals side-by-side in one slot.
       const img =
         primaryImg ||
-        (hasEmojiIcon ? null : createNativeImageFromMenuIcon({ dataUrlValue: fallbackIconDataUrl }, 18));
+        (hasEmojiIcon
+          ? null
+          : createCachedMenuBarNativeImage({
+              cache: menuBarNativeImageCache,
+              nativeImage,
+              fs,
+              dataUrlValue: fallbackIconDataUrl,
+              size: 18,
+              template: false,
+              resizeQuality: 'best',
+            }));
       lastResolvedTrayIconOk = Boolean(img);
-      if (img) {
-        // Raycast icon tokens are serialized as data URLs and should be template images
-        // so macOS can adapt them to menu bar foreground contrast.
-        const isGeneratedDataUrl = typeof iconDataUrl === 'string' && iconDataUrl.startsWith('data:');
-        // Keep template rendering for bitmap assets (classic menubar style).
-        // For SVG asset paths, preserve source appearance (e.g., explicit light/dark icon variants).
-        const isSvg = /\.svg$/i.test(iconPath || '');
-        const shouldTemplate =
-          !usingPrimary
-            ? false
-            : (
-                typeof iconTemplate === 'boolean'
-                  ? iconTemplate
-                  : (isGeneratedDataUrl ? true : !isSvg)
-              );
-        try {
-          img.setTemplateImage(shouldTemplate);
-        } catch {}
-        return img;
-      }
+      if (img) return img;
       return nativeImage.createEmpty();
     };
 
@@ -19184,10 +19140,10 @@ if let tiff = image?.tiffRepresentation {
       const icon = resolveTrayIcon();
       tray = new Tray(icon);
       menuBarTrays.set(extId, tray);
+    } else {
+      // Refresh icon on accepted updates after creation (first payload can be incomplete).
+      tray.setImage(resolveTrayIcon());
     }
-
-    // Always refresh icon on update (first payload can be incomplete).
-    tray.setImage(resolveTrayIcon());
 
     // Update title: if there's a text title, show it; if only emoji icon, show that
     if (title) {
@@ -19225,31 +19181,19 @@ if let tiff = image?.tiffRepresentation {
       const iconDataUrl = typeof item?.iconDataUrl === 'string' ? item.iconDataUrl.trim() : '';
       const iconPath = typeof item?.iconPath === 'string' ? item.iconPath : '';
       const explicitTemplate = typeof item?.iconTemplate === 'boolean' ? item.iconTemplate : undefined;
-      try {
-        let img: any;
-        if (iconDataUrl.startsWith('data:')) {
-          img = nativeImage.createFromDataURL(iconDataUrl);
-        } else {
-          if (!iconPath) return undefined;
-          const fs = require('fs');
-          if (!fs.existsSync(iconPath)) return undefined;
-          img = nativeImage.createFromPath(iconPath);
-          if ((!img || img.isEmpty()) && /\.svg$/i.test(iconPath)) {
-            const svg = fs.readFileSync(iconPath, 'utf8');
-            const svgDataUrl = `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
-            img = nativeImage.createFromDataURL(svgDataUrl);
-          }
-        }
-        if (!img || img.isEmpty()) return undefined;
-        const shouldTemplate =
-          explicitTemplate ?? (iconDataUrl.startsWith('data:image/svg+xml') ? true : false);
-        const resized = img.resize({ width: 16, height: 16 });
-        try {
-          resized.setTemplateImage(shouldTemplate);
-        } catch {}
-        return resized;
-      } catch {}
-      return undefined;
+      const shouldTemplate =
+        explicitTemplate ?? (iconDataUrl.startsWith('data:image/svg+xml') ? true : false);
+      const image = createCachedMenuBarNativeImage({
+        cache: menuBarNativeImageCache,
+        nativeImage,
+        fs,
+        pathValue: iconPath,
+        dataUrlValue: iconDataUrl,
+        bitmapScale: item?.iconBitmapScale,
+        size: 16,
+        template: shouldTemplate,
+      });
+      return image || undefined;
     };
 
     const labelWithEmoji = (item: any) => {
@@ -19465,4 +19409,5 @@ app.on('will-quit', () => {
     tray.destroy();
   }
   menuBarTrays.clear();
+  menuBarNativeImageCache.clear();
 });

--- a/src/main/menubar-native-image-cache.ts
+++ b/src/main/menubar-native-image-cache.ts
@@ -1,0 +1,273 @@
+/**
+ * Main-process MenuBarExtra native image cache.
+ *
+ * Electron's NativeImage creation can decode and resize bitmap data every time
+ * a menu-bar payload is accepted. This helper keeps successful decoded/resized
+ * images keyed by visible icon inputs while preserving template-image state.
+ */
+
+export type MenuBarNativeImageLike = {
+  isEmpty?: () => boolean;
+  getSize?: () => { width: number; height: number };
+  resize?: (options: { width: number; height: number; quality?: string }) => MenuBarNativeImageLike;
+  setTemplateImage?: (isTemplate: boolean) => void;
+};
+
+export type MenuBarNativeImageFactory = {
+  createFromBuffer: (buffer: Buffer, options?: { scaleFactor?: number }) => MenuBarNativeImageLike;
+  createFromDataURL: (dataUrl: string) => MenuBarNativeImageLike;
+  createFromPath: (pathValue: string) => MenuBarNativeImageLike;
+};
+
+export type MenuBarFsLike = {
+  statSync: (pathValue: string) => {
+    size?: number;
+    mtimeMs?: number;
+    isFile?: () => boolean;
+  };
+  readFileSync: (pathValue: string, encoding: 'utf8') => string;
+};
+
+export type MenuBarNativeImageCache = {
+  getImage: (key: string) => MenuBarNativeImageLike | null;
+  setImage: (key: string, image: MenuBarNativeImageLike) => void;
+  getSvgDataUrl: (key: string) => string | null;
+  setSvgDataUrl: (key: string, dataUrl: string) => void;
+  clear: () => void;
+  readonly imageSize: number;
+  readonly svgDataUrlSize: number;
+};
+
+export type CreateCachedMenuBarNativeImageOptions = {
+  cache: MenuBarNativeImageCache;
+  nativeImage: MenuBarNativeImageFactory;
+  fs: MenuBarFsLike;
+  pathValue?: string;
+  dataUrlValue?: string;
+  bitmapScale?: number;
+  size: number;
+  template: boolean;
+  resizeQuality?: string;
+};
+
+const DEFAULT_MAX_ENTRIES = 256;
+
+class BoundedLruMap<T> {
+  private readonly maxEntries: number;
+  private readonly entries = new Map<string, T>();
+
+  constructor(maxEntries: number) {
+    this.maxEntries = Math.max(1, Math.floor(maxEntries));
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  get(key: string): T | null {
+    if (!this.entries.has(key)) return null;
+    const value = this.entries.get(key) as T;
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    return value;
+  }
+
+  set(key: string, value: T): void {
+    if (this.entries.has(key)) this.entries.delete(key);
+    this.entries.set(key, value);
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+class MenuBarNativeImageCacheImpl implements MenuBarNativeImageCache {
+  private readonly images: BoundedLruMap<MenuBarNativeImageLike>;
+  private readonly svgDataUrls: BoundedLruMap<string>;
+
+  constructor(maxEntries: number) {
+    this.images = new BoundedLruMap(maxEntries);
+    this.svgDataUrls = new BoundedLruMap(maxEntries);
+  }
+
+  get imageSize(): number {
+    return this.images.size;
+  }
+
+  get svgDataUrlSize(): number {
+    return this.svgDataUrls.size;
+  }
+
+  getImage(key: string): MenuBarNativeImageLike | null {
+    return this.images.get(key);
+  }
+
+  setImage(key: string, image: MenuBarNativeImageLike): void {
+    this.images.set(key, image);
+  }
+
+  getSvgDataUrl(key: string): string | null {
+    return this.svgDataUrls.get(key);
+  }
+
+  setSvgDataUrl(key: string, dataUrl: string): void {
+    this.svgDataUrls.set(key, dataUrl);
+  }
+
+  clear(): void {
+    this.images.clear();
+    this.svgDataUrls.clear();
+  }
+}
+
+export function createMenuBarNativeImageCache(maxEntries = DEFAULT_MAX_ENTRIES): MenuBarNativeImageCache {
+  return new MenuBarNativeImageCacheImpl(maxEntries);
+}
+
+export function normalizeMenuBarBitmapScale(bitmapScale: unknown): number {
+  const requestedScale = Number(bitmapScale);
+  return Number.isFinite(requestedScale) && requestedScale >= 1 ? requestedScale : 1;
+}
+
+export function createCachedMenuBarNativeImage(
+  options: CreateCachedMenuBarNativeImageOptions,
+): MenuBarNativeImageLike | null {
+  const {
+    cache,
+    nativeImage,
+    fs,
+    size,
+    template,
+    resizeQuality,
+  } = options;
+  const dataUrlValue = String(options.dataUrlValue || '').trim();
+  const pathValue = String(options.pathValue || '').trim();
+  const bitmapScale = normalizeMenuBarBitmapScale(options.bitmapScale);
+  const resizeKey = `size=${size}|scale=${bitmapScale}|template=${template ? 1 : 0}|quality=${resizeQuality || ''}`;
+
+  try {
+    if (dataUrlValue.startsWith('data:')) {
+      const key = `data:${dataUrlValue}|${resizeKey}`;
+      const cached = cache.getImage(key);
+      if (cached) return cached;
+
+      let image: MenuBarNativeImageLike | null = null;
+      const isRasterPng = dataUrlValue.startsWith('data:image/png');
+      if (isRasterPng && bitmapScale > 1) {
+        const commaIdx = dataUrlValue.indexOf(',');
+        const base64Body = commaIdx >= 0 ? dataUrlValue.slice(commaIdx + 1) : '';
+        const buffer = base64Body ? Buffer.from(base64Body, 'base64') : null;
+        if (buffer && buffer.length > 0) {
+          image = nativeImage.createFromBuffer(buffer, { scaleFactor: bitmapScale });
+        }
+      }
+      if (isEmptyNativeImage(image)) {
+        image = nativeImage.createFromDataURL(dataUrlValue);
+      }
+      const prepared = prepareNativeImageForMenu(image, size, bitmapScale, template, resizeQuality);
+      if (!prepared) return null;
+      cache.setImage(key, prepared);
+      return prepared;
+    }
+
+    if (!pathValue) return null;
+    const pathIdentity = getMenuBarPathIdentity(fs, pathValue);
+    if (!pathIdentity) return null;
+
+    const key = `path:${pathIdentity.cacheKey}|${resizeKey}`;
+    const cached = cache.getImage(key);
+    if (cached) return cached;
+
+    let image = nativeImage.createFromPath(pathValue);
+    if (isEmptyNativeImage(image) && pathIdentity.isSvg) {
+      const svgDataUrl = getCachedSvgDataUrl(cache, fs, pathValue, pathIdentity.cacheKey);
+      if (svgDataUrl) image = nativeImage.createFromDataURL(svgDataUrl);
+    }
+    const prepared = prepareNativeImageForMenu(image, size, bitmapScale, template, resizeQuality);
+    if (!prepared) return null;
+    cache.setImage(key, prepared);
+    return prepared;
+  } catch {
+    return null;
+  }
+}
+
+function getMenuBarPathIdentity(
+  fs: MenuBarFsLike,
+  pathValue: string,
+): { cacheKey: string; isSvg: boolean } | null {
+  try {
+    const stat = fs.statSync(pathValue);
+    if (typeof stat?.isFile === 'function' && !stat.isFile()) return null;
+    const size = Number.isFinite(Number(stat?.size)) ? Number(stat.size) : 0;
+    const mtimeMs = Number.isFinite(Number(stat?.mtimeMs)) ? Number(stat.mtimeMs) : 0;
+    return {
+      cacheKey: `${pathValue}|mtimeMs=${mtimeMs}|bytes=${size}`,
+      isSvg: /\.svg$/i.test(pathValue),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getCachedSvgDataUrl(
+  cache: MenuBarNativeImageCache,
+  fs: MenuBarFsLike,
+  pathValue: string,
+  pathIdentityKey: string,
+): string | null {
+  const cached = cache.getSvgDataUrl(pathIdentityKey);
+  if (cached) return cached;
+  try {
+    const svg = fs.readFileSync(pathValue, 'utf8');
+    const dataUrl = `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
+    cache.setSvgDataUrl(pathIdentityKey, dataUrl);
+    return dataUrl;
+  } catch {
+    return null;
+  }
+}
+
+function prepareNativeImageForMenu(
+  image: MenuBarNativeImageLike | null | undefined,
+  size: number,
+  bitmapScale: number,
+  template: boolean,
+  resizeQuality?: string,
+): MenuBarNativeImageLike | null {
+  if (isEmptyNativeImage(image)) return null;
+  let prepared = image as MenuBarNativeImageLike;
+
+  const currentSize = prepared.getSize?.() || { width: 0, height: 0 };
+  const shouldKeepRetinaRep =
+    bitmapScale > 1 && currentSize.width === size && currentSize.height === size;
+  if (!shouldKeepRetinaRep) {
+    if (typeof prepared.resize !== 'function') return null;
+    prepared = prepared.resize({
+      width: size,
+      height: size,
+      ...(resizeQuality ? { quality: resizeQuality } : {}),
+    });
+    if (isEmptyNativeImage(prepared)) return null;
+  }
+
+  try {
+    prepared.setTemplateImage?.(template);
+  } catch {}
+  return prepared;
+}
+
+function isEmptyNativeImage(image: MenuBarNativeImageLike | null | undefined): boolean {
+  if (!image) return true;
+  try {
+    return Boolean(image.isEmpty?.());
+  } catch {
+    return true;
+  }
+}


### PR DESCRIPTION
## What Changed

- Added a bounded main-process NativeImage cache for MenuBarExtra tray and menu item icons.
- Reused cached decode/resize results across accepted payload updates while keying by source, logical size, bitmap scale, resize quality, and template state.
- Preserved SVG fallback, retina PNG `iconBitmapScale`, template-image behavior, emoji title fallback, and menu item click routing.
- Avoided the initial double tray icon resolution when creating a new tray.
- Added focused mocked-native-image regression coverage with before/after counters.

## Why

Extensions with ticking menu-bar titles or item labels can still send accepted updates where icon sources are unchanged. Previously the main process rebuilt NativeImage objects and resized icons on every accepted payload, which could add visible menu-bar lag.

The new focused metric covers 20 repeated accepted updates with 1 tray icon and 36 item/submenu icons: native decode/read/resize operations drop from 1620 before caching to 81 after caching.

## Compatibility Impact

Behavior should stay compatible with current MenuBarExtra rendering. Path icons refresh when file size or mtime changes, SVG fallbacks are still used when native path decoding returns empty, template images are cached separately from non-template images, and the cache is bounded and cleared on quit.

## How Tested

- `node --no-warnings --test scripts/test-menubar-native-image-cache.mjs`
- `pnpm run build:main`
- Codex LSP diagnostics for `src/main/menubar-native-image-cache.ts`
- Codex LSP diagnostics for `src/main/main.ts`

## Stack Validation

Clean PR branch `codex/perf-menubar-native-image-cache-pr` was created from `origin/main` and contains only the menubar native image cache fix.