### PR TITLE
feat: add Window: Maximize (Stage Manager) command

### DIFF
--- a/src/main/commands.ts
+++ b/src/main/commands.ts
@@ -1394,6 +1394,12 @@ async function discoverAndBuildCommands(): Promise<CommandInfo[]> {
       category: 'system',
     },
     {
+      id: 'system-window-management-fill-stage',
+      title: 'Window: Maximize (Stage Manager)',
+      keywords: ['window', 'management', 'maximize', 'fill', 'stage manager', 'stage', 'strip', 'respect'],
+      category: 'system',
+    },
+    {
       id: 'system-window-management-maximize-width',
       title: 'Window: Maximize Width',
       keywords: ['window', 'management', 'maximize', 'width', 'horizontal', 'fill', 'stretch'],

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3307,6 +3307,7 @@ const WINDOW_MANAGEMENT_PRESET_COMMAND_IDS = new Set<string>([
   'system-window-management-center',
   'system-window-management-center-80',
   'system-window-management-fill',
+  'system-window-management-fill-stage',
   'system-window-management-maximize-width',
   'system-window-management-maximize-height',
   'system-window-management-top-left',
@@ -3372,6 +3373,7 @@ const WINDOW_MANAGEMENT_LAYOUT_COMMAND_IDS = new Set<string>([
   'system-window-management-center',
   'system-window-management-center-80',
   'system-window-management-fill',
+  'system-window-management-fill-stage',
   'system-window-management-maximize-width',
   'system-window-management-maximize-height',
   'system-window-management-top-left',
@@ -3939,6 +3941,18 @@ function computeWindowManagementLayoutBounds(
         width: area.width,
         height: area.height,
       };
+    case 'system-window-management-fill-stage': {
+      // Maximize while leaving the Stage Manager strip visible: reuse Almost
+      // Maximize's left inset, extend top/right/bottom to the work-area edges.
+      const inset = Math.round((area.width - Math.round(area.width * 0.9)) / 2);
+      const x = area.x + inset;
+      return {
+        x,
+        y: area.y,
+        width: Math.max(1, areaRight - x),
+        height: area.height,
+      };
+    }
     case 'system-window-management-maximize-width': {
       // Span the full work-area width, keep the current vertical position/height.
       if (!windowBounds) return null;

--- a/src/native/window-adjust.swift
+++ b/src/native/window-adjust.swift
@@ -10,6 +10,7 @@ private enum AdjustAction: String {
   case center = "center"
   case center80 = "center-80"
   case fill = "fill"
+  case fillStage = "fill-stage"
   case maximizeWidth = "maximize-width"
   case maximizeHeight = "maximize-height"
   case topLeft = "top-left"
@@ -566,6 +567,18 @@ private func adjustedFrame(_ base: WindowFrame, action: AdjustAction, forcedArea
         x: area.origin.x,
         y: area.origin.y,
         width: max(minWidth, round(area.width)),
+        height: max(minHeight, round(area.height))
+      )
+    }
+  case .fillStage:
+    if let area {
+      // Maximize while leaving the Stage Manager strip visible: reuse Almost
+      // Maximize's left inset, extend top/right/bottom to the work-area edges.
+      let inset = round((area.width - round(area.width * 0.9)) / 2)
+      next = WindowFrame(
+        x: area.origin.x + inset,
+        y: area.origin.y,
+        width: max(minWidth, round(area.width - inset)),
         height: max(minHeight, round(area.height))
       )
     }

--- a/src/renderer/src/WindowManagerPanel.tsx
+++ b/src/renderer/src/WindowManagerPanel.tsx
@@ -49,6 +49,7 @@ type PresetId =
   | 'center'
   | 'center-80'
   | 'fill'
+  | 'fill-stage'
   | 'maximize-width'
   | 'maximize-height'
   | 'auto-organize'
@@ -91,6 +92,7 @@ export const WINDOW_MANAGEMENT_PRESET_COMMANDS: WindowManagementPresetCommand[] 
   { commandId: 'system-window-management-center', presetId: 'center' },
   { commandId: 'system-window-management-center-80', presetId: 'center-80' },
   { commandId: 'system-window-management-fill', presetId: 'fill' },
+  { commandId: 'system-window-management-fill-stage', presetId: 'fill-stage' },
   { commandId: 'system-window-management-maximize-width', presetId: 'maximize-width' },
   { commandId: 'system-window-management-maximize-height', presetId: 'maximize-height' },
   { commandId: 'system-window-management-top-left', presetId: 'top-left' },
@@ -147,6 +149,7 @@ const PRESETS: Array<{ id: PresetId; label: string; subtitle: string }> = [
   { id: 'center', label: 'Center', subtitle: 'Current window' },
   { id: 'center-80', label: 'Almost Maximize', subtitle: 'Current window' },
   { id: 'fill', label: 'Maximize', subtitle: 'Current window' },
+  { id: 'fill-stage', label: 'Maximize (Stage Manager)', subtitle: 'Current window' },
   { id: 'maximize-width', label: 'Maximize Width', subtitle: 'Current window' },
   { id: 'maximize-height', label: 'Maximize Height', subtitle: 'Current window' },
   { id: 'top-left', label: 'Top Left', subtitle: 'Current window' },
@@ -308,6 +311,9 @@ function renderPresetIcon(id: PresetId): JSX.Element {
       break;
     case 'fill':
       cells.push({ x: 1, y: 1, w: 18, h: 12 });
+      break;
+    case 'fill-stage':
+      cells.push({ x: 1, y: 3, w: 2, h: 8 }, { x: 4, y: 1, w: 15, h: 12 });
       break;
     case 'maximize-width':
       cells.push({ x: 1, y: 4, w: 18, h: 6 });
@@ -1031,6 +1037,13 @@ function getPresetRegion(presetId: PresetId, area: ScreenArea): Rect | null {
   }
   if (presetId === 'fill') {
     return { x: area.left, y: area.top, width: area.width, height: area.height };
+  }
+  if (presetId === 'fill-stage') {
+    // Maximize while leaving the Stage Manager strip visible: reuse Almost
+    // Maximize's left inset (native path uses 90% width), extend the rest.
+    const inset = Math.round((area.width - Math.round(area.width * 0.9)) / 2);
+    const x = area.left + inset;
+    return { x, y: area.top, width: Math.max(1, area.left + area.width - x), height: area.height };
   }
   if (presetId === 'center') {
     const width = Math.max(1, Math.round(area.width * 0.6));

--- a/src/renderer/src/utils/command-helpers.tsx
+++ b/src/renderer/src/utils/command-helpers.tsx
@@ -546,6 +546,7 @@ type WindowManagementGlyphId =
   | 'center'
   | 'center-80'
   | 'fill'
+  | 'fill-stage'
   | 'maximize-width'
   | 'maximize-height'
   | 'top-left'
@@ -597,6 +598,7 @@ const WINDOW_MANAGEMENT_GLYPH_SUFFIXES = new Set<WindowManagementGlyphId>([
   'center',
   'center-80',
   'fill',
+  'fill-stage',
   'maximize-width',
   'maximize-height',
   'top-left',
@@ -779,6 +781,9 @@ function renderWindowManagementGlyph(glyphId: WindowManagementGlyphId): JSX.Elem
       break;
     case 'fill':
       cells.push({ x: 1, y: 1, w: 18, h: 12 });
+      break;
+    case 'fill-stage':
+      cells.push({ x: 1, y: 3, w: 2, h: 8 }, { x: 4, y: 1, w: 15, h: 12 });
       break;
     case 'maximize-width':
       cells.push({ x: 1, y: 4, w: 18, h: 6 });


### PR DESCRIPTION
## What

Adds a new window management command: **`Window: Maximize (Stage Manager)`**.

It maximizes the focused window while keeping macOS **Stage Manager's** staged-windows strip on the left visible:

- **left edge** — reuses *Almost Maximize*'s left inset (the work area is 90%-width centered there, so the inset is 5% of the work-area width)
- **top / right / bottom** — extend to the full work area, same as *Maximize*

## Why

Raycast's `Window: Maximize` implicitly changes its sizing depending on whether Stage Manager is enabled. Instead of overloading the existing `Maximize` behavior, this adds an explicit, separate command so users can choose either behavior deterministically.

## How

Window layout geometry lives in three places; all three implement the new preset identically (`fill-stage` / `system-window-management-fill-stage`):

| Path | File |
|---|---|
| Native helper (primary path for hotkeys/commands) | `src/native/window-adjust.swift` |
| Main-process fallback | `src/main/main.ts` |
| Window Management panel UI | `src/renderer/src/WindowManagerPanel.tsx` |

Plus:

- `src/main/commands.ts` — root command registration (searchable as "stage", "maximize", …)
- `src/renderer/src/utils/command-helpers.tsx` — launcher glyph (thin left strip + maximize rectangle), same glyph used for the panel tile

## Testing

- `tsc -p tsconfig.main.json` clean; renderer typecheck introduces no new errors
- `window-adjust.swift` compiles; binary accepts the `fill-stage` action
- Verified on-device via a signed DMG built from this branch: window maximizes with the Stage Manager strip remaining visible
